### PR TITLE
This is 2012, assume already have UTF8

### DIFF
--- a/src/PHPWord/Section.php
+++ b/src/PHPWord/Section.php
@@ -109,7 +109,7 @@ class PHPWord_Section {
 	 * @return PHPWord_Section_Text
 	 */
 	public function addText($text, $styleFont = null, $styleParagraph = null) {
-		$givenText = utf8_encode($text);
+		$givenText = $text;
 		$text = new PHPWord_Section_Text($givenText, $styleFont, $styleParagraph);
 		$this->_elementCollection[] = $text;
 		return $text;
@@ -125,11 +125,7 @@ class PHPWord_Section {
 	 * @return PHPWord_Section_Link
 	 */
 	public function addLink($linkSrc, $linkName = null, $styleFont = null, $styleParagraph = null) {
-		$linkSrc = utf8_encode($linkSrc);
-		if(!is_null($linkName)) {
-			$linkName = utf8_encode($linkName);
-		}
-		
+
 		$link = new PHPWord_Section_Link($linkSrc, $linkName, $styleFont, $styleParagraph);
 		$rID = PHPWord_Media::addSectionLinkElement($linkSrc);
 		$link->setRelationId($rID);
@@ -179,7 +175,6 @@ class PHPWord_Section {
 	 * @return PHPWord_Section_ListItem
 	 */
 	public function addListItem($text, $depth = 0, $styleFont = null, $styleList = null, $styleParagraph = null) {
-		$text = utf8_encode($text);
 		$listItem = new PHPWord_Section_ListItem($text, $depth, $styleFont, $styleList, $styleParagraph);
 		$this->_elementCollection[] = $listItem;
 		return $listItem;
@@ -287,7 +282,6 @@ class PHPWord_Section {
 	 * @return PHPWord_Section_Title
 	 */
 	public function addTitle($text, $depth = 1) {
-		$text = utf8_encode($text);
 		$styles = PHPWord_Style::getStyles();
 		if(array_key_exists('Heading_'.$depth, $styles)) {
 			$style = 'Heading'.$depth;

--- a/src/PHPWord/Section/Footer.php
+++ b/src/PHPWord/Section/Footer.php
@@ -72,7 +72,7 @@ class PHPWord_Section_Footer {
 	 * @return PHPWord_Section_Text
 	 */
 	public function addText($text, $styleFont = null, $styleParagraph = null) {
-		$givenText = utf8_encode($text);
+		$givenText = $text;
 		$text = new PHPWord_Section_Text($givenText, $styleFont, $styleParagraph);
 		$this->_elementCollection[] = $text;
 		return $text;
@@ -162,7 +162,6 @@ class PHPWord_Section_Footer {
 	 * @return PHPWord_Section_Footer_PreserveText
 	 */
 	public function addPreserveText($text, $styleFont = null, $styleParagraph = null) {
-		$text = utf8_encode($text);
 		$ptext = new PHPWord_Section_Footer_PreserveText($text, $styleFont, $styleParagraph);
 		$this->_elementCollection[] = $ptext;
 		return $ptext;

--- a/src/PHPWord/Section/Header.php
+++ b/src/PHPWord/Section/Header.php
@@ -72,7 +72,7 @@ class PHPWord_Section_Header {
 	 * @return PHPWord_Section_Text
 	 */
 	public function addText($text, $styleFont = null, $styleParagraph = null) {
-		$givenText = utf8_encode($text);
+		$givenText = $text;
 		$text = new PHPWord_Section_Text($givenText, $styleFont, $styleParagraph);
 		$this->_elementCollection[] = $text;
 		return $text;
@@ -162,7 +162,6 @@ class PHPWord_Section_Header {
 	 * @return PHPWord_Section_Footer_PreserveText
 	 */
 	public function addPreserveText($text, $styleFont = null, $styleParagraph = null) {
-		$text = utf8_encode($text);
 		$ptext = new PHPWord_Section_Footer_PreserveText($text, $styleFont, $styleParagraph);
 		$this->_elementCollection[] = $ptext;
 		return $ptext;

--- a/src/PHPWord/Section/Table/Cell.php
+++ b/src/PHPWord/Section/Table/Cell.php
@@ -108,7 +108,6 @@ class PHPWord_Section_Table_Cell {
 	 * @return PHPWord_Section_Text
 	 */
 	public function addText($text, $styleFont = null, $styleParagraph = null) {
-		$text = utf8_encode($text);
 		$text = new PHPWord_Section_Text($text, $styleFont, $styleParagraph);
 		$this->_elementCollection[] = $text;
 		return $text;
@@ -124,11 +123,7 @@ class PHPWord_Section_Table_Cell {
 	 */
 	public function addLink($linkSrc, $linkName = null, $style = null) {
 		if($this->_insideOf == 'section') {
-			$linkSrc = utf8_encode($linkSrc);
-			if(!is_null($linkName)) {
-				$linkName = utf8_encode($linkName);
-			}
-			
+
 			$link = new PHPWord_Section_Link($linkSrc, $linkName, $style);
 			$rID = PHPWord_Media::addSectionLinkElement($linkSrc);
 			$link->setRelationId($rID);
@@ -160,7 +155,6 @@ class PHPWord_Section_Table_Cell {
 	 * @return PHPWord_Section_ListItem
 	 */
 	public function addListItem($text, $depth = 0, $styleText = null, $styleList = null) {
-		$text = utf8_encode($text);
 		$listItem = new PHPWord_Section_ListItem($text, $depth, $styleText, $styleList);
 		$this->_elementCollection[] = $listItem;
 		return $listItem;
@@ -269,7 +263,6 @@ class PHPWord_Section_Table_Cell {
 	 */
 	public function addPreserveText($text, $styleFont = null, $styleParagraph = null) {
 		if($this->_insideOf == 'footer' || $this->_insideOf == 'header') {
-			$text = utf8_encode($text);
 			$ptext = new PHPWord_Section_Footer_PreserveText($text, $styleFont, $styleParagraph);
 			$this->_elementCollection[] = $ptext;
 			return $ptext;

--- a/src/PHPWord/Section/TextRun.php
+++ b/src/PHPWord/Section/TextRun.php
@@ -80,7 +80,7 @@ class PHPWord_Section_TextRun {
 	 * @return PHPWord_Section_Text
 	 */
 	public function addText($text = null, $styleFont = null) {
-		$givenText = utf8_encode($text);
+		$givenText = $text;
 		$text = new PHPWord_Section_Text($givenText, $styleFont);
 		$this->_elementCollection[] = $text;
 		return $text;
@@ -95,11 +95,7 @@ class PHPWord_Section_TextRun {
 	 * @return PHPWord_Section_Link
 	 */
 	public function addLink($linkSrc, $linkName = null, $styleFont = null) {
-		$linkSrc = utf8_encode($linkSrc);
-		if(!is_null($linkName)) {
-			$linkName = utf8_encode($linkName);
-		}
-		
+
 		$link = new PHPWord_Section_Link($linkSrc, $linkName, $styleFont);
 		$rID = PHPWord_Media::addSectionLinkElement($linkSrc);
 		$link->setRelationId($rID);

--- a/src/PHPWord/Template.php
+++ b/src/PHPWord/Template.php
@@ -85,12 +85,10 @@ class PHPWord_Template {
             $search = '${'.$search.'}';
         }
         
-        if(!is_array($replace)) {
-            $replace = utf8_encode($replace);
-        }
         
         $this->_documentXML = str_replace($search, $replace, $this->_documentXML);
     }
+    
     /**
      * Returns array of all variables in template
      */

--- a/src/PHPWord/Writer/Word2007/Base.php
+++ b/src/PHPWord/Writer/Word2007/Base.php
@@ -195,7 +195,7 @@ class PHPWord_Writer_Word2007_Base extends PHPWord_Writer_Word2007_WriterPart {
 
 					$objWriter->startElement('w:t');
 						$objWriter->writeAttribute('xml:space', 'preserve'); // needed because of drawing spaces before and after text
-						$objWriter->writeRaw($linkName);
+						$objWriter->writeRaw(htmlspecialchars($linkName));
 					$objWriter->endElement();
 				$objWriter->endElement();
 


### PR DESCRIPTION
There are conversion functions scattered around that assume text is
ISO-8859-1, and does conversion to UTF-8. PHPWord should assume text is
already in UTF-8, and let calling applications do charset conversions if
required because otherwise there is dataloss.

Fixes issue #9
