### PR TITLE
Advanced string replace in setValue in Update src/PHPWord/Template.php

### DIFF
--- a/src/PHPWord/Template.php
+++ b/src/PHPWord/Template.php
@@ -81,16 +81,27 @@ class PHPWord_Template {
      * @param mixed $replace
      */
     public function setValue($search, $replace) {
-        if(substr($search, 0, 2) !== '${' && substr($search, -1) !== '}') {
+        $pattern = '|\$\{([^\}]+)\}|U';
+        preg_match_all($pattern, $this->_documentXML, $matches);
+        $openedTagPattern = '/<[^>]+>/';
+        $closedTagPattern = '/<\/[^>]+>/';
+        foreach ($matches[0] as $value) {
+            $modificado = preg_replace($openedTagPattern, '', $value);
+            $modificado = preg_replace($closedTagPattern, '', $modificado);
+            $this->_documentXML = str_replace($value, $modificado, $this->_documentXML);
+        }
+
+        if (substr($search, 0, 1) !== '${' && substr($search, -1) !== '}') {
             $search = '${'.$search.'}';
         }
-        
-        if(!is_array($replace)) {
+
+        if (!is_array($replace)) {
             $replace = utf8_encode($replace);
         }
-        
+
         $this->_documentXML = str_replace($search, $replace, $this->_documentXML);
     }
+    
     /**
      * Returns array of all variables in template
      */


### PR DESCRIPTION
When started using Phpword it saved me a lot of time as i needed to replace a template 
in docx using php. I had a minor issue when started using the setValue method. I found 
that using Word, the program creates some tags that the str_replace couldn't detect.

I cracked a little bit the function, using some regular expressions in order to:
1. Find the regular expressions commencing with '${' and ending with '}' (in my case i 
      dropped the $ sign cause i needed to use the $ sign in my word file)
2. With only that string, find and eliminate all the opening tags
3. find and eliminate the closing tags in that string
   4. replace the old string (with garbage code) with the cleaned string
4. output the _documentXML
5. this is the piece of code I implemented if anyone is interested

Btw, great job with this tool it saved me a lot of time!

Consulate in the site: http://phpword.codeplex.com/workitem/49
