### PR TITLE
Added composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "phpoffice/phpword",
+    "description": "PHPWord - OpenXML - Read, Create and Write Spreadsheet documents in PHP - word processing",
+    "keywords": ["PHP", "Word", "OpenXML", "docx", "doc", "word"],
+    "homepage": "http://phpword.codeplex.com",
+    "type": "library",
+    "license": "LGPL",
+    "authors": [
+        {
+            "name": "Maarten Balliauw",
+            "homepage": "http://blog.maartenballiauw.be"
+        },
+        {
+            "name": "Mark Baker"
+        },
+        {
+            "name": "Franck Lefevre",
+            "homepage": "http://blog.rootslabs.net"
+        },
+        {
+            "name": "Erik Tilt"
+        }
+    ],
+    "require": {
+        "php": ">=5.2.0"
+    },
+    "recommend": {
+        "ext-zip": "*",
+        "ext-gd2": "*"
+    },
+
+    "autoload": {
+        "classmap": ["src/"]
+    }
+
+}
+


### PR DESCRIPTION
The other open pull request (https://github.com/PHPOffice/PHPWord/pull/24) required a php extension called "code", which to my knowledge doesn't exist, resulting in inability to install the extension. 

This is the same composer.json, without the "ext-code" requirement, verified to work. 
