### PR TITLE
Copy should throw an Exception

### DIFF
--- a/src/PHPWord/Template.php
+++ b/src/PHPWord/Template.php
@@ -66,7 +66,9 @@ class PHPWord_Template {
         $path = dirname($strFilename);
         $this->_tempFileName = $path.DIRECTORY_SEPARATOR.time().'.docx';
         
-        copy($strFilename, $this->_tempFileName); // Copy the source File to the temp File
+        if (!copy($strFilename, $this->_tempFileName)) { // Copy the source File to the temp File
+            throw new Exception("Could not copy the template from \"$strFilename\" to \"$this->_tempFileName\".");
+        }
 
         $this->_objZip = new ZipArchive();
         $this->_objZip->open($this->_tempFileName);


### PR DESCRIPTION
If copy fails, the script will continue execution and throw other confusing errors, like "Could not close zip file" because it's working with an XML object which is null.
