### PR TITLE
Support Multiple headers

### DIFF
--- a/Classes/PHPWord/Section.php
+++ b/Classes/PHPWord/Section.php
@@ -57,11 +57,11 @@ class PHPWord_Section {
 	private $_elementCollection = array();
 	
 	/**
-	 * Section Header
+	 * Section Headers
 	 * 
-	 * @var PHPWord_Section_Header
+	 * @var array
 	 */
-	private $_header = null;
+	private $_headers = array();
 	
 	/**
 	 * Section Footer
@@ -345,17 +345,33 @@ class PHPWord_Section {
 	 */
 	public function createHeader() {
 		$header = new PHPWord_Section_Header($this->_sectionCount);
-		$this->_header = $header;
+		$this->_headers[] = $header;
 		return $header;
 	}
 	
 	/**
-	 * Get Header
+	 * Get Headers
 	 * 
-	 * @return PHPWord_Section_Header
+	 * @return array
 	 */
-	public function getHeader() {
-		return $this->_header;
+	public function getHeaders() {
+		return $this->_headers;
+	}
+
+	/**
+	 * Is there a header for this section that is for the first page only?
+	 *
+	 * If any of the PHPWord_Section_Header instances have a type of
+	 * PHPWord_Section_Header::FIRST then this method returns true. False
+	 * otherwise.
+	 *
+	 * @return Boolean
+	 */
+	public function hasDifferentFirstPage() {
+		$value = array_filter($this->_headers, function(PHPWord_Section_Header &$header) {
+			return $header->getType() == PHPWord_Section_Header::FIRST;
+		});
+		return count($value) > 0;
 	}
 	
 	/**

--- a/Classes/PHPWord/Section/Header.php
+++ b/Classes/PHPWord/Section/Header.php
@@ -48,6 +48,35 @@ class PHPWord_Section_Header {
 	 * @var int
 	 */
 	private $_rId;
+
+	/**
+	 * Header type
+	 *
+	 * @var string
+	 * @link http://www.schemacentral.com/sc/ooxml/a-w_type-4.html Header or Footer Type
+	 */
+	private $_type = PHPWord_Section_Header::AUTO;
+
+	/**
+	 * Even Numbered Pages Only
+	 * @var string
+	 * @link http://www.schemacentral.com/sc/ooxml/a-w_type-4.html Header or Footer Type
+	 */
+	const EVEN  = 'even';
+
+	/**
+	 * Default Header or Footer
+	 * @var string
+	 * @link http://www.schemacentral.com/sc/ooxml/a-w_type-4.html Header or Footer Type
+	 */
+	const AUTO  = 'default'; // Did not use DEFAULT because it is a PHP keyword
+
+	/**
+	 * First Page Only
+	 * @var string
+	 * @link http://www.schemacentral.com/sc/ooxml/a-w_type-4.html Header or Footer Type
+	 */
+	const FIRST = 'first';
 	
 	/**
 	 * Header Element Collection
@@ -222,5 +251,34 @@ class PHPWord_Section_Header {
 	public function getHeaderCount() {
 		return $this->_headerCount;
 	}
+
+	/**
+	 * Get Header Type
+	 */
+	public function getType() {
+		return $this->_type;
+	}
+
+	/**
+	 * Reset back to default
+	 */
+	public function resetType() {
+		return $this->_type = PHPWord_Section_Header::AUTO;
+	}
+
+	/**
+	 * First page only header
+	 */
+	public function firstPage() {
+		return $this->_type = PHPWord_Section_Header::FIRST;
+	}
+
+	/**
+	 * Even numbered Pages only
+	 */
+	public function evenPage() {
+		return $this->_type = PHPWord_Section_Header::EVEN;
+	}
+
 }
 ?>

--- a/Classes/PHPWord/Writer/Word2007.php
+++ b/Classes/PHPWord/Writer/Word2007.php
@@ -114,12 +114,11 @@ class PHPWord_Writer_Word2007 implements PHPWord_Writer_IWriter {
 			$_sections = $this->_document->getSections();
 			
 			foreach($_sections as $section) {
-				$_header = $section->getHeader();
-				if(!is_null($_header)) {
+				$_headers = $section->getHeaders();
+				foreach ($_headers as $index => &$_header) {
 					$_cHdrs++;
 					$_header->setRelationId(++$rID);
-					$_headerCount = $_header->getHeaderCount();
-					$_headerFile = 'header'.$_headerCount.'.xml';
+					$_headerFile = 'header'.$_cHdrs.'.xml';
 					$sectionElements[] = array('target'=>$_headerFile, 'type'=>'header', 'rID'=>$rID);
 					$objZip->addFromString('word/'.$_headerFile, $this->getWriterPart('header')->writeHeader($_header));
 				}

--- a/Classes/PHPWord/Writer/Word2007/Document.php
+++ b/Classes/PHPWord/Writer/Word2007/Document.php
@@ -117,7 +117,7 @@ class PHPWord_Writer_Word2007_Document extends PHPWord_Writer_Word2007_Base {
 	
 	private function _writeEndSection(PHPWord_Shared_XMLWriter $objWriter = null, PHPWord_Section $section) {
 		$_settings = $section->getSettings();
-		$_header = $section->getHeader();
+		$_headers = $section->getHeaders();
 		$_footer = $section->getFooter();
 		$pgSzW = $_settings->getPageSizeW();
 		$pgSzH = $_settings->getPageSizeH();
@@ -132,11 +132,16 @@ class PHPWord_Writer_Word2007_Document extends PHPWord_Writer_Word2007_Base {
 		
 		$objWriter->startElement('w:sectPr');
 			
-			if(!is_null($_header)) {
+			foreach ($_headers as &$_header) {
 				$rId = $_header->getRelationId();
 				$objWriter->startElement('w:headerReference');
-					$objWriter->writeAttribute('w:type', 'default');
+					$objWriter->writeAttribute('w:type', $_header->getType());
 					$objWriter->writeAttribute('r:id', 'rId'.$rId);
+				$objWriter->endElement();
+			}
+			
+			if($section->hasDifferentFirstPage()) {
+				$objWriter->startElement('w:titlePg');
 				$objWriter->endElement();
 			}
 			

--- a/samples/old/HeaderFooter.php
+++ b/samples/old/HeaderFooter.php
@@ -7,12 +7,17 @@ $PHPWord = new PHPWord();
 // New portrait section
 $section = $PHPWord->createSection();
 
-// Add header
+// Add first page header
 $header = $section->createHeader();
+$header->firstPage();
 $table = $header->addTable();
 $table->addRow();
 $table->addCell(4500)->addText('This is the header.');
 $table->addCell(4500)->addImage('_earth.jpg', array('width'=>50, 'height'=>50, 'align'=>'right'));
+
+// Add header for all other pages
+$subsequent = $section->createHeader();
+$subsequent->addText("Subsequent pages in Section 1 will Have this!");
 
 // Add footer
 $footer = $section->createFooter();
@@ -21,6 +26,30 @@ $footer->addPreserveText('Page {PAGE} of {NUMPAGES}.', array('align'=>'center'))
 // Write some text
 $section->addTextBreak();
 $section->addText('Some text...');
+
+// Create a second page
+$section->addPageBreak();
+
+// Write some text
+$section->addTextBreak();
+$section->addText('Some text...');
+
+// Create a third page
+$section->addPageBreak();
+
+// Write some text
+$section->addTextBreak();
+$section->addText('Some text...');
+
+// New portrait section
+$section2 = $PHPWord->createSection();
+
+$sec2Header = $section2->createHeader();
+$sec2Header->addText("All pages in Section 2 will Have this!");
+
+// Write some text
+$section2->addTextBreak();
+$section2->addText('Some text...');
 
 // Save File
 $objWriter = PHPWord_IOFactory::createWriter($PHPWord, 'Word2007');


### PR DESCRIPTION
Sections can support multiple headers

Each section can now have a single header (previous behavior). It can now also support multiple headers. The spec defines three types of headers: `default`, `first`, and `even`. These code changes provide support for all three.

The HeaderFooter.php example has also been updated to illustrate how to use the new multiple headers for a section.

Used these pages as spec reference:

http://www.schemacentral.com/sc/ooxml/e-w_headerReference-1.html
http://www.schemacentral.com/sc/ooxml/a-w_type-4.html

Should provide the feature described here: https://phpword.codeplex.com/discussions/270211. Better late than never! :thumbsup:

(Orignally submitted in pull request #15)
