### PR TITLE
Fix bug in directory whitelist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,7 +15,7 @@
     </testsuites>
     <filter>
         <whitelist>
-            <directory suffix=".php">../Classes</directory>
+            <directory suffix=".php">./Classes</directory>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
Run `phpunit --coverage-html` to reproduce the error.
