### PR TITLE
Changed PHPWord namespace to PhpOffice\PhpWord

### DIFF
--- a/Classes/PHPWord/Autoloader.php
+++ b/Classes/PHPWord/Autoloader.php
@@ -36,7 +36,7 @@ if (!defined('PHPWORD_BASE_PATH')) {
  */
 class PHPWord_Autoloader
 {
-    const PREFIX = 'PHPWord';
+    const PREFIX = 'PhpOffice\PhpWord';
 
     /**
      * Register the autoloader

--- a/Classes/PHPWord/Exceptions/InvalidStyleException.php
+++ b/Classes/PHPWord/Exceptions/InvalidStyleException.php
@@ -1,5 +1,5 @@
 <?php
-namespace PHPWord\Exceptions;
+namespace PhpOffice\PhpWord\Exceptions;
 
 use InvalidArgumentException;
 

--- a/Classes/PHPWord/Style/Font.php
+++ b/Classes/PHPWord/Style/Font.php
@@ -25,7 +25,7 @@
  * @version    0.7.0
  */
 
-use PHPWord\Exceptions\InvalidStyleException;
+use PhpOffice\PhpWord\Exceptions\InvalidStyleException;
 
 /**
  * Class PHPWord_Style_Font
@@ -488,7 +488,7 @@ class PHPWord_Style_Font
      *
      * @param int|float|string $lineHeight
      * @return $this
-     * @throws \PHPWord\Exceptions\InvalidStyleException
+     * @throws InvalidStyleException
      */
     public function setLineHeight($lineHeight)
     {

--- a/Classes/PHPWord/Style/Paragraph.php
+++ b/Classes/PHPWord/Style/Paragraph.php
@@ -25,7 +25,7 @@
  * @version    0.7.0
  */
 
-use PHPWord\Exceptions\InvalidStyleException;
+use PhpOffice\PhpWord\Exceptions\InvalidStyleException;
 
 /**
  * PHPWord_Style_Paragraph
@@ -482,7 +482,7 @@ class PHPWord_Style_Paragraph
      *
      * @param int|float|string $lineHeight
      * @return $this
-     * @throws \PHPWord\Exceptions\InvalidStyleException
+     * @throws InvalidStyleException
      */
     public function setLineHeight($lineHeight)
     {

--- a/Tests/PHPWord/AutoloaderTest.php
+++ b/Tests/PHPWord/AutoloaderTest.php
@@ -25,8 +25,8 @@ class AutoloaderTest extends PHPUnit_Framework_TestCase
         $declared = get_declared_classes();
         $declaredCount = count($declared);
         Autoloader::autoload('Foo');
-        $this->assertEquals($declaredCount, count(get_declared_classes()), 'PHPWord\\Autoloader::autoload() is trying to load classes outside of the PHPWord namespace');
-        Autoloader::autoload('PHPWord\\Exceptions\\InvalidStyleException'); // TODO change this class to the main PHPWord class when it is namespaced
-        $this->assertTrue(in_array('PHPWord\\Exceptions\\InvalidStyleException', get_declared_classes()), 'PHPWord\\Autoloader::autoload() failed to autoload the PHPWord\\Exceptions\\InvalidStyleException class');
+        $this->assertEquals($declaredCount, count(get_declared_classes()), 'PhpOffice\\PhpWord\\Autoloader::autoload() is trying to load classes outside of the PhpOffice\\PhpWord namespace');
+        Autoloader::autoload('PhpOffice\\PhpWord\\Exceptions\\InvalidStyleException'); // TODO change this class to the main PHPWord class when it is namespaced
+        $this->assertTrue(in_array('PhpOffice\\PhpWord\\Exceptions\\InvalidStyleException', get_declared_classes()), 'PhpOffice\\PhpWord\\Autoloader::autoload() failed to autoload the PhpOffice\\PhpWord\\Exceptions\\InvalidStyleException class');
     }
 }


### PR DESCRIPTION
Changed the existing namespaces. Part of issue #77 .
