### PR TITLE
MS Word footnote fix

### DIFF
--- a/Classes/PHPWord/Section.php
+++ b/Classes/PHPWord/Section.php
@@ -422,9 +422,6 @@ class PHPWord_Section
      */
     public function getFooter()
     {
-        if (!($this->_footer instanceOf PHPWord_Section_Footer)) {
-            $this->_footer = new PHPWord_Section_Footer($this->_sectionCount);
-        }
         return $this->_footer;
     }
 

--- a/Classes/PHPWord/Writer/Word2007.php
+++ b/Classes/PHPWord/Writer/Word2007.php
@@ -128,6 +128,7 @@ class PHPWord_Writer_Word2007 implements PHPWord_Writer_IWriter
             $rID = PHPWord_Media::countSectionMediaElements() + 6;
             $_sections = $this->_document->getSections();
 
+            $footers = array();
             foreach ($_sections as $section) {
                 $_headers = $section->getHeaders();
                 foreach ($_headers as $index => &$_header) {
@@ -139,12 +140,14 @@ class PHPWord_Writer_Word2007 implements PHPWord_Writer_IWriter
                 }
 
                 $_footer = $section->getFooter();
-                $_cFtrs++;
-                $_footer->setRelationId(++$rID);
-                $_footerCount = $_footer->getFooterCount();
-                $_footerFile = 'footer' . $_footerCount . '.xml';
-                $sectionElements[] = array('target' => $_footerFile, 'type' => 'footer', 'rID' => $rID);
-                $objZip->addFromString('word/' . $_footerFile, $this->getWriterPart('footer')->writeFooter($_footer));
+                $footers[++$_cFtrs] = $_footer;
+                if (!is_null($_footer)) {
+                    $_footer->setRelationId(++$rID);
+                    $_footerCount = $_footer->getFooterCount();
+                    $_footerFile = 'footer' . $_footerCount . '.xml';
+                    $sectionElements[] = array('target' => $_footerFile, 'type' => 'footer', 'rID' => $rID);
+                    $objZip->addFromString('word/' . $_footerFile, $this->getWriterPart('footer')->writeFooter($_footer));
+                }
             }
 
             if (PHPWord_Footnote::countFootnoteElements() > 0) {
@@ -159,7 +162,15 @@ class PHPWord_Writer_Word2007 implements PHPWord_Writer_IWriter
 
             // build docx file
             // Write dynamic files
-            $objZip->addFromString('[Content_Types].xml', $this->getWriterPart('contenttypes')->writeContentTypes($this->_imageTypes, $this->_objectTypes, $_cHdrs, $_cFtrs));
+            $objZip->addFromString(
+                '[Content_Types].xml',
+                $this->getWriterPart('contenttypes')->writeContentTypes(
+                    $this->_imageTypes,
+                    $this->_objectTypes,
+                    $_cHdrs,
+                    $footers
+                )
+            );
             $objZip->addFromString('_rels/.rels', $this->getWriterPart('rels')->writeRelationships($this->_document));
             $objZip->addFromString('docProps/app.xml', $this->getWriterPart('docprops')->writeDocPropsApp($this->_document));
             $objZip->addFromString('docProps/core.xml', $this->getWriterPart('docprops')->writeDocPropsCore($this->_document));

--- a/Classes/PHPWord/Writer/Word2007/ContentTypes.php
+++ b/Classes/PHPWord/Writer/Word2007/ContentTypes.php
@@ -31,7 +31,7 @@
 class PHPWord_Writer_Word2007_ContentTypes extends PHPWord_Writer_Word2007_WriterPart
 {
 
-    public function writeContentTypes($_imageTypes, $_objectTypes, $_cHdrs, $_cFtrs)
+    public function writeContentTypes($_imageTypes, $_objectTypes, $_cHdrs, $footers)
     {
         // Create XML writer
         $objWriter = null;
@@ -153,12 +153,14 @@ class PHPWord_Writer_Word2007_ContentTypes extends PHPWord_Writer_Word2007_Write
             );
         }
 
-        for ($i = 1; $i <= $_cFtrs; $i++) {
-            $this->_writeOverrideContentType(
-                $objWriter,
-                '/word/footer' . $i . '.xml',
-                'application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml'
-            );
+        for ($i = 1; $i <= count($footers); $i++) {
+            if (!is_null($footers[$i])) {
+                $this->_writeOverrideContentType(
+                    $objWriter,
+                    '/word/footer' . $i . '.xml',
+                    'application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml'
+                );
+            }
         }
 
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -52,6 +52,7 @@ Changes in branch for release 0.7.1 :
 - Feature:  (ivanlanin)       GH-99             - General: Basic support for TextRun on ODT and RTF
 - Feature:  (ivanlanin)                         - Reader: Initial effort for Word2007
 - Feature:  (ivanlanin)                         - MemoryImage: Allow remote image when allow_url_open = on
+- Bugfix:   (ivanlanin)                         - Footnote: Corrupt DOCX reported by MS Word when sections > 1 and not every sections have footnote
 - QA:       (Progi1984)                         - UnitTests
 
 Changes in branch for release 0.7.0 :


### PR DESCRIPTION
MS Word report corrupted DOCX when there's more than 1 section and not every sections have footnotes. OO is fine.

Bug source: [Content-Types].xml entry is different with document.xml.rels
