### PR TITLE
Added tblGrid element for Libre/Open Office table sizing

### DIFF
--- a/src/PhpWord/Writer/Word2007/Base.php
+++ b/src/PhpWord/Writer/Word2007/Base.php
@@ -571,6 +571,30 @@ class Base extends WriterPart
 
         if ($_cRows > 0) {
             $xmlWriter->startElement('w:tbl');
+            
+            $cellWidths = array();
+            for($i=0; $i<$_cRows; $i++)
+            {
+                $row = $_rows[$i];
+                $cells = $row->getCells();
+                if(count($cells) <= count($cellWidths))
+                    continue;
+                
+                $cellWidths = array();
+                foreach ($cells as $cell)
+                    $cellWidths[] = $cell->getWidth();
+            }
+            
+            $xmlWriter->startElement('w:tblGrid');
+            foreach($cellWidths as $width)
+            {
+                $xmlWriter->startElement('w:gridCol');
+                $xmlWriter->writeAttribute('w:w', $width);
+                $xmlWriter->writeAttribute('w:type', 'dxa');
+                $xmlWriter->endElement();
+            }
+            $xmlWriter->endElement();
+            
             $tblStyle = $table->getStyle();
             $tblWidth = $table->getWidth();
             if ($tblStyle instanceof PhpOffice\PhpWord\Style\Table) {


### PR DESCRIPTION
added tblGrid element to the Office2007 Writer. The tables' columns of the docx generated files are sized properly.
