### PR TITLE
Get image dimensions without EXIF extension

### DIFF
--- a/src/PhpWord/Section/Image.php
+++ b/src/PhpWord/Section/Image.php
@@ -132,7 +132,12 @@ class Image
                 throw new InvalidImageException;
             }
             $imgData = getimagesize($source);
-            $this->imageType = exif_imagetype($source);
+            if (function_exists('exif_imagetype')) {
+                $this->imageType = exif_imagetype($source);
+            } else {
+                $tmp = getimagesize($source);
+                $this->imageType = $tmp[2];
+            }
             if (!in_array($this->imageType, $supportedTypes)) {
                 throw new UnsupportedImageTypeException;
             }

--- a/src/PhpWord/Writer/Word2007.php
+++ b/src/PhpWord/Writer/Word2007.php
@@ -270,7 +270,12 @@ class Word2007 implements IWriter
         if (stripos(strrev($src), strrev('.php')) === 0) {
             $extension = 'php';
         } else {
-            $imageType = exif_imagetype($src);
+            if (function_exists('exif_imagetype')) {
+                $imageType = exif_imagetype($src);
+            } else {
+                $tmp = getimagesize($src);
+                $imageType = $tmp[2];
+            }
             if ($imageType === \IMAGETYPE_JPEG) {
                 $extension = 'jpg';
             } elseif ($imageType === \IMAGETYPE_GIF) {


### PR DESCRIPTION
Use `getimagesize()` when `exif_imagetype()` doesn't exist.
