### PR TITLE
Keep image aspect ratio if only 1 dimension styled

### DIFF
--- a/src/PhpWord/Element/Image.php
+++ b/src/PhpWord/Element/Image.php
@@ -131,9 +131,17 @@ class Image extends AbstractElement
         $this->source = $source;
         $this->isWatermark = $isWatermark;
         $this->style = $this->setStyle(new ImageStyle(), $style, true);
-        if ($this->style->getWidth() == null && $this->style->getHeight() == null) {
-            $this->style->setWidth($imgData[0]);
-            $this->style->setHeight($imgData[1]);
+        $styleWidth = $this->style->getWidth();
+        $styleHeight = $this->style->getHeight();
+        if (!($styleWidth && $styleHeight)) {
+            if ($styleWidth == null && $styleHeight == null) {
+                $this->style->setWidth($imgData[0]);
+                $this->style->setHeight($imgData[1]);
+            } else if ($styleWidth) {
+                $this->style->setHeight($imgData[1] * ($styleWidth / $imgData[0]));
+            } else {
+                $this->style->setWidth($imgData[0] * ($styleHeight / $imgData[1]));
+            }
         }
         $this->setImageFunctions();
     }


### PR DESCRIPTION
If only one of image width or height is specified, then scale missing dimension to maintain the aspect ratio.

I suspect that for most use-cases users would prefer to maintain the aspect ratio of images rather than distort them if a width or height style is specified but not both.  This small patch sets the missing dimension to maintain the image's aspect ratio.
