### PR TITLE
Image positioning typo corrected and additional samples

### DIFF
--- a/samples/Sample_13_Images.php
+++ b/samples/Sample_13_Images.php
@@ -31,6 +31,37 @@ foreach ($wrappingStyles as $wrappingStyle) {
     $section->addText($text);
 }
 
+//Absolute positioning
+$section->addTextBreak(3);
+$section->addText('Absolute positioning: see top right corner of page');
+$section->addImage(
+    'resources/_mars.jpg',
+    array(
+        'width' => \PhpOffice\PhpWord\Shared\Drawing::centimetersToPixels(3),
+        'height' => \PhpOffice\PhpWord\Shared\Drawing::centimetersToPixels(3),
+        'positioning' => \PhpOffice\PhpWord\Style\Image::POSITION_ABSOLUTE,
+        'marginLeft' => \PhpOffice\PhpWord\Shared\Drawing::centimetersToPixels(15.5),
+        'marginTop' => \PhpOffice\PhpWord\Shared\Drawing::centimetersToPixels(1.55)
+    )
+);
+
+//Relative positioning
+$section->addTextBreak(3);
+$section->addText('Relative positioning: Horizontal position center relative to column,');
+$section->addText('Vertical position top relative to line');
+$section->addImage(
+    'resources/_mars.jpg',
+    array(
+        'width' => \PhpOffice\PhpWord\Shared\Drawing::centimetersToPixels(3),
+        'height' => \PhpOffice\PhpWord\Shared\Drawing::centimetersToPixels(3),
+        'positioning' => \PhpOffice\PhpWord\Style\Image::POSITION_RELATIVE,
+        'posHorizontal' => \PhpOffice\PhpWord\Style\Image::POSITION_HORIZONTAL_CENTER,
+        'posHorizontalRel' => \PhpOffice\PhpWord\Style\Image::POSITION_RELATIVE_TO_COLUMN,
+        'posVertical' => \PhpOffice\PhpWord\Style\Image::POSITION_VERTICAL_TOP,
+        'posVerticalRel' => \PhpOffice\PhpWord\Style\Image::POSITION_RELATIVE_TO_LINE
+    )
+);
+
 // Save file
 echo write($phpWord, basename(__FILE__, '.php'), $writers);
 if (!CLI) {

--- a/src/PhpWord/Style/Image.php
+++ b/src/PhpWord/Style/Image.php
@@ -31,7 +31,7 @@ class Image extends AbstractStyle
      * @const string
      */
     const POSITION_HORIZONTAL_LEFT = 'left';
-    const POSITION_HORIZONTAL_CENTER = 'centered';
+    const POSITION_HORIZONTAL_CENTER = 'center';
     const POSITION_HORIZONTAL_RIGHT = 'right';
 
     /**


### PR DESCRIPTION
Corrected typo to 'const POSITION_HORIZONTAL_CENTER = 'center';' and added examples to Sample_13

You guys had me confused by changing some of my original code. I lost track. However, I now understand that you have further improved it and put parts in a style writer.
Thank you very much :-)
