### PR TITLE
Fix second header bug

### DIFF
--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -355,7 +355,7 @@ abstract class AbstractContainer extends AbstractElement
         $docPart = $isCellTextrun ? $this->getDocPart() : $this->container;
         $docPartId = $isCellTextrun ? $this->getDocPartId() : $this->sectionId;
         $inHeaderFooter = ($docPart == 'header' || $docPart == 'footer');
-
+        $docPartId = $inHeaderFooter ? $this->getDocPartId() : $docPartId;
         return $inHeaderFooter ? $docPart . $docPartId : $docPart;
     }
 


### PR DESCRIPTION
Fixed a bug, that when a second header was added to a section, all images added to the second header were assigned to the first header, resulting in at least a corrupted DOCX.

(I thought that I had committed this earlier today, but apparently due to my inexperience with GitHub, this was not finalized)
