### PR TITLE
List item change to depend on TextRun

### DIFF
--- a/samples/Sample_14_ListItem.php
+++ b/samples/Sample_14_ListItem.php
@@ -25,34 +25,42 @@ $predefinedMultilevel = array('listType' => \PhpOffice\PhpWord\Style\ListItem::T
 // Lists
 
 $section->addText('Multilevel list.');
-$section->addListItem('List Item I', 0, null, 'multilevel');
-$section->addListItem('List Item I.a', 1, null, 'multilevel');
-$section->addListItem('List Item I.b', 1, null, 'multilevel');
-$section->addListItem('List Item II', 0, null, 'multilevel');
-$section->addListItem('List Item II.a', 1, null, 'multilevel');
-$section->addListItem('List Item III', 0, null, 'multilevel');
+$section->addListItem(0, null, 'multilevel')->addText('List Item I');
+$section->addListItem(1, null, 'multilevel')->addText('List Item I.a');
+$section->addListItem(1, null, 'multilevel')->addText('List Item I.b');
+$section->addListItem(0, null, 'multilevel')->addText('List Item II');
+$section->addListItem(1, null, 'multilevel')->addText('List Item II.a');
+$section->addListItem(0, null, 'multilevel')->addText('List Item III');
 $section->addTextBreak(2);
 
 $section->addText('Basic simple bulleted list.');
-$section->addListItem('List Item 1');
-$section->addListItem('List Item 2');
-$section->addListItem('List Item 3');
+$section->addListItem()->addText('List Item 1');
+$section->addListItem()->addText('List Item 2');
+$section->addListItem()->addText('List Item 3');
 $section->addTextBreak(2);
 
 $section->addText('Continue from multilevel list above.');
-$section->addListItem('List Item IV', 0, null, 'multilevel');
-$section->addListItem('List Item IV.a', 1, null, 'multilevel');
+$section->addListItem(0, null, 'multilevel')->addText('List Item IV');
+$section->addListItem(1, null, 'multilevel')->addText('List Item IV.a');
 $section->addTextBreak(2);
 
 $section->addText('Multilevel predefined list.');
-$section->addListItem('List Item 1', 0, 'myOwnStyle', $predefinedMultilevel, 'P-Style');
-$section->addListItem('List Item 2', 0, 'myOwnStyle', $predefinedMultilevel, 'P-Style');
-$section->addListItem('List Item 3', 1, 'myOwnStyle', $predefinedMultilevel, 'P-Style');
-$section->addListItem('List Item 4', 1, 'myOwnStyle', $predefinedMultilevel, 'P-Style');
-$section->addListItem('List Item 5', 2, 'myOwnStyle', $predefinedMultilevel, 'P-Style');
-$section->addListItem('List Item 6', 1, 'myOwnStyle', $predefinedMultilevel, 'P-Style');
-$section->addListItem('List Item 7', 0, 'myOwnStyle', $predefinedMultilevel, 'P-Style');
+$section->addListItem(0, 'myOwnStyle', $predefinedMultilevel, 'P-Style')->addText('List Item 1');
+$section->addListItem(0, 'myOwnStyle', $predefinedMultilevel, 'P-Style')->addText('List Item 2');
+$section->addListItem(1, 'myOwnStyle', $predefinedMultilevel, 'P-Style')->addText('List Item 3');
+$section->addListItem(1, 'myOwnStyle', $predefinedMultilevel, 'P-Style')->addText('List Item 4');
+$section->addListItem(2, 'myOwnStyle', $predefinedMultilevel, 'P-Style')->addText('List Item 5');
+$section->addListItem(1, 'myOwnStyle', $predefinedMultilevel, 'P-Style')->addText('List Item 6');
+$section->addListItem(0, 'myOwnStyle', $predefinedMultilevel, 'P-Style')->addText('List Item 7');
 $section->addTextBreak(2);
+
+$section->addText('Listitems with inline formatting');
+$listItemObject = $section->addListItem();
+$listItemObject->addText('Testing');
+$listItemObject->addText(' Strong', array('bold'=>true));
+$listItemObject = $section->addListItem();
+$listItemObject->addText('Testing 2');
+$listItemObject->addText(' Italic and stron', array('bold'=>true, 'italic'=>true));
 
 // Save file
 echo write($phpWord, basename(__FILE__, '.php'), $writers);

--- a/src/PhpWord/Element/ListItem.php
+++ b/src/PhpWord/Element/ListItem.php
@@ -19,11 +19,12 @@ namespace PhpOffice\PhpWord\Element;
 
 use PhpOffice\PhpWord\Shared\String;
 use PhpOffice\PhpWord\Style\ListItem as ListItemStyle;
+use PhpOffice\PhpWord\Style\Paragraph;
 
 /**
  * List item element
  */
-class ListItem extends AbstractElement
+class ListItem extends TextRun
 {
     /**
      * ListItem Style
@@ -33,32 +34,23 @@ class ListItem extends AbstractElement
     private $style;
 
     /**
-     * Textrun
-     *
-     * @var Text
-     */
-    private $textObject;
-
-    /**
      * ListItem Depth
      *
      * @var int
      */
     private $depth;
 
-
     /**
      * Create a new ListItem
      *
-     * @param string $text
      * @param int $depth
      * @param mixed $fontStyle
      * @param array|string|null $listStyle
      * @param mixed $paragraphStyle
      */
-    public function __construct($text, $depth = 0, $fontStyle = null, $listStyle = null, $paragraphStyle = null)
+    public function __construct($depth = 0, $fontStyle = null, $listStyle = null, $paragraphStyle = null)
     {
-        $this->textObject = new Text(String::toUTF8($text), $fontStyle, $paragraphStyle);
+        $this->container = 'listitem';
         $this->depth = $depth;
 
         // Version >= 0.10.0 will pass numbering style name. Older version will use old method
@@ -67,6 +59,7 @@ class ListItem extends AbstractElement
         } else {
             $this->style = $this->setStyle(new ListItemStyle(), $listStyle, true);
         }
+        $this->paragraphStyle = $this->setStyle(new Paragraph(), $paragraphStyle);
     }
 
     /**

--- a/src/PhpWord/Element/TextRun.php
+++ b/src/PhpWord/Element/TextRun.php
@@ -29,7 +29,7 @@ class TextRun extends AbstractContainer
      *
      * @var string|\PhpOffice\PhpWord\Style\Paragraph
      */
-    private $paragraphStyle;
+    protected $paragraphStyle;
 
     /**
      * Create new instance

--- a/src/PhpWord/Writer/Word2007/Element/Container.php
+++ b/src/PhpWord/Writer/Word2007/Element/Container.php
@@ -41,7 +41,7 @@ class Container extends AbstractElement
         $xmlWriter = $this->getXmlWriter();
         $container = $this->getElement();
         $containerClass = substr(get_class($container), strrpos(get_class($container), '\\') + 1);
-        $withoutP = in_array($containerClass, array('TextRun', 'Footnote', 'Endnote')) ? true : false;
+        $withoutP = in_array($containerClass, array('TextRun', 'Footnote', 'Endnote', 'ListItem')) ? true : false;
 
         // Loop through subelements
         $subelements = $container->getElements();

--- a/src/PhpWord/Writer/Word2007/Element/ListItem.php
+++ b/src/PhpWord/Writer/Word2007/Element/ListItem.php
@@ -34,15 +34,12 @@ class ListItem extends AbstractElement
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
 
-        $textObject = $element->getTextObject();
-
-        $styleWriter = new ParagraphStyleWriter($xmlWriter, $textObject->getParagraphStyle());
-        $styleWriter->setWithoutPPR(true);
-        $styleWriter->setIsInline(true);
-
         $xmlWriter->startElement('w:p');
 
         $xmlWriter->startElement('w:pPr');
+        $paragraphStyle = $element->getParagraphStyle();
+        $styleWriter = new ParagraphStyleWriter($xmlWriter, $paragraphStyle);
+        $styleWriter->setIsInline(true);
         $styleWriter->write();
 
         $xmlWriter->startElement('w:numPr');
@@ -56,8 +53,8 @@ class ListItem extends AbstractElement
 
         $xmlWriter->endElement(); // w:pPr
 
-        $elementWriter = new Text($xmlWriter, $textObject, true);
-        $elementWriter->write();
+        $containerWriter = new Container($xmlWriter, $element);
+        $containerWriter->write();
 
         $xmlWriter->endElement(); // w:p
     }


### PR DESCRIPTION
Following the issue #230 I have changed the inheritance of ListItem. It now inherits from TextRun, such that it behaves as a container. It is now possible to provide inline formatting of a ListItem.

@ivanlanin: I already appologize for not having my branch full in sync. I am still struggling with Eclipse, Egit and GitHub. I am able to start with a fully synced branch, but when changes are merged in the upstream branch, while I am coding, I am getting out of sync.
Still searching the web for a good tutorial :/ 
