### PR TITLE
Update composer requirements for php-zip

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,13 +33,13 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "ext-xml": "*",
-        "ext-zip": "*"
+        "ext-xml": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"
     },
     "suggest": {
+        "ext-zip": "Used to write DOCX and ODT",
         "ext-gd2": "Required to add images",
         "ext-xmlwriter": "Required to write DOCX and ODT",
         "ext-xsl": "Required to apply XSL style sheet to template part",


### PR DESCRIPTION
With PCLZip support added php-zip isn't a requirement any more.

See #243
