### PR TITLE
Fix rare PclZip/realpath/PHP version problem

### DIFF
--- a/src/PhpWord/Shared/ZipArchive.php
+++ b/src/PhpWord/Shared/ZipArchive.php
@@ -218,7 +218,10 @@ class ZipArchive
     {
         /** @var \PclZip $zip Type hint */
         $zip = $this->zip;
-        $filename = realpath($filename);
+        $test_filename = realpath($filename);
+        if($test_filename !== false) {
+            $filename = $test_filename;
+        }
         $filenameParts = pathinfo($filename);
         $localnameParts = pathinfo($localname);
 


### PR DESCRIPTION
In PHP 5.4.4 `realpath()` handles absolute paths correctly, but in PHP 5.3.8 returns false.

Note: PHP 5.4.4 and PHP 5.3.8 on Windows.

``` php
// PHP 5.4.4 - pass - returns original path
// PHP 5.3.8 - fail - returns false
$tempfile = tempnam(sys_get_temp_dir(), "PHPWORD");

echo realpath($tempfile);
```
