### PR TITLE
Added shading to the paragraph style for full width shading

### DIFF
--- a/src/PhpWord/Style/Paragraph.php
+++ b/src/PhpWord/Style/Paragraph.php
@@ -153,6 +153,13 @@ class Paragraph extends AbstractStyle
     private $tabs = array();
 
     /**
+     * Shading
+     *
+     * @var \PhpOffice\PhpWord\Style\Shading
+     */
+    private $shading;
+
+    /**
      * Create new instance
      */
     public function __construct()
@@ -209,6 +216,7 @@ class Paragraph extends AbstractStyle
                 'level'         => $this->getNumLevel(),
             ),
             'tabs'              => $this->getTabs(),
+            'shading'           => $this->getShading(),
         );
 
         return $styles;
@@ -693,5 +701,28 @@ class Paragraph extends AbstractStyle
     public function getPageBreakBefore()
     {
         return $this->hasPageBreakBefore();
+    }
+
+    /**
+     * Get shading
+     *
+     * @return \PhpOffice\PhpWord\Style\Shading
+     */
+    public function getShading()
+    {
+        return $this->shading;
+    }
+
+    /**
+     * Set shading
+     *
+     * @param mixed $value
+     * @return self
+     */
+    public function setShading($value = null)
+    {
+        $this->setObjectVal($value, 'Shading', $this->shading);
+
+        return $this;
     }
 }

--- a/src/PhpWord/Writer/Word2007/Style/Paragraph.php
+++ b/src/PhpWord/Writer/Word2007/Style/Paragraph.php
@@ -99,6 +99,13 @@ class Paragraph extends AbstractStyle
         $this->writeChildStyle($xmlWriter, 'Indentation', $styles['indentation']);
         $this->writeChildStyle($xmlWriter, 'Spacing', $styles['spacing']);
 
+        // Background-Color
+        $shading = $style->getShading();
+        if (!is_null($shading)) {
+            $styleWriter = new Shading($xmlWriter, $shading);
+            $styleWriter->write();
+        }
+
         // Tabs
         $this->writeTabs($xmlWriter, $styles['tabs']);
 


### PR DESCRIPTION
In Word 2007 you can set shading on a paragraph level to display full width background colors (A client of mine used this when creating a template document for us to recreate in PHP Word). 

It's the exact same code as what's in the font style and font style writer.
