### PR TITLE
Autoloader Options

### DIFF
--- a/src/PhpWord/Autoloader.php
+++ b/src/PhpWord/Autoloader.php
@@ -30,9 +30,9 @@ class Autoloader
      *
      * @return void
      */
-    public static function register()
+    public static function register($throw = true, $prepend = false)
     {
-        spl_autoload_register(array(new self, 'autoload'));
+        spl_autoload_register(array(new self, 'autoload'), $throw, $prepend);
     }
 
     /**


### PR DESCRIPTION
Add the ability to set the autoloader options.

This allows you to add the autoloader to the top of the stack instead of the bottom which improves compatibility with older autoloaders like the Zend 1.0 autoloader.
