### PR TITLE
addHTML fixes for PHP 5.3

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -42,9 +42,14 @@ class Html
          * which could be applied when such an element occurs in the parseNode function.
          */
 
-        // Preprocess: remove all line ends, decode HTML entity, and add body tag for HTML fragments
+        // Preprocess: remove all line ends, decode HTML entity,
+        // fix ampersand and angle brackets and add body tag for HTML fragments
         $html = str_replace(array("\n", "\r"), '', $html);
-        $html = html_entity_decode($html);
+        $html = str_replace(array('&lt;', '&gt;', '&amp;'), array('_lt_', '_gt_', '_amp_'), $html);
+        $html = html_entity_decode($html, ENT_QUOTES, 'UTF-8');
+        $html = str_replace('&', '&amp;', $html);
+        $html = str_replace(array('_lt_', '_gt_', '_amp_'), array('&lt;', '&gt;', '&amp;'), $html);
+
         if ($fullHTML === false) {
             $html = '<body>' . $html . '</body>';
         }

--- a/tests/PhpWord/Tests/Shared/HtmlTest.php
+++ b/tests/PhpWord/Tests/Shared/HtmlTest.php
@@ -60,6 +60,12 @@ class HtmlTest extends \PHPUnit_Framework_TestCase
         $content .= '<table><tr><th>Header</th><td>Content</td></tr></table>';
         $content .= '<ul><li>Bullet</li><ul><li>Bullet</li></ul></ul>';
         $content .= '<ol><li>Bullet</li></ol>';
+        $content .= "'Single Quoted Text'";
+        $content .= '"Double Quoted Text"';
+        $content .= '& Ampersand';
+        $content .= '&lt;&gt;&ldquo;&lsquo;&rsquo;&laquo;&raquo;&lsaquo;&rsaquo;';
+        $content .= '&amp;&bull;&deg;&hellip;&trade;&copy;&reg;&mdash;';
+        $content .= '&ndash;&nbsp;&emsp;&ensp;&sup2;&sup3;&frac14;&frac12;&frac34;';
         Html::addHtml($section, $content);
     }
 }


### PR DESCRIPTION
I found 2 bugs with the addHTML function. One when running under PHP 5.3 the default character encoding is ISO-8859-1 (This was changed to UTF-8 in PHP 5.4) which causes loadXML to hork because of it converts things like & nbsp ; to non-valid UTF-8 characters. The second is when you try to use an ampersand in the html you are trying to convert to docx. 
