### PR TITLE
For absolute positioning vPos and hPos need to be set to POS_ABSOLUTE

### DIFF
--- a/src/PhpWord/Style/Frame.php
+++ b/src/PhpWord/Style/Frame.php
@@ -362,7 +362,7 @@ class Frame extends AbstractStyle
      */
     public function setHPos($value)
     {
-        $enum = array(self::POS_LEFT, self::POS_CENTER, self::POS_RIGHT, self::POS_INSIDE, self::POS_OUTSIDE);
+        $enum = array(self::POS_LEFT, self::POS_CENTER, self::POS_RIGHT, self::POS_INSIDE, self::POS_OUTSIDE, self::POS_ABSOLUTE);
         $this->hPos = $this->setEnumVal($value, $enum, $this->hPos);
 
         return $this;
@@ -386,7 +386,7 @@ class Frame extends AbstractStyle
      */
     public function setVPos($value)
     {
-        $enum = array(self::POS_TOP, self::POS_CENTER, self::POS_BOTTOM, self::POS_INSIDE, self::POS_OUTSIDE);
+        $enum = array(self::POS_TOP, self::POS_CENTER, self::POS_BOTTOM, self::POS_INSIDE, self::POS_OUTSIDE, self::POS_ABSOLUTE);
         $this->vPos = $this->setEnumVal($value, $enum, $this->vPos);
 
         return $this;


### PR DESCRIPTION
When a frame is being positioned absolute, then at least Word 2007 requires that within the docx file the 'mso-position-horizontal' and 'mso-position-vertical' style values need to be set to absolute
