### PR TITLE
Bugfix: not all borders are written when specific borders specified

### DIFF
--- a/src/PhpWord/Writer/Word2007/Style/MarginBorder.php
+++ b/src/PhpWord/Writer/Word2007/Style/MarginBorder.php
@@ -55,10 +55,9 @@ class MarginBorder extends AbstractStyle
         $xmlWriter = $this->getXmlWriter();
 
         $sides = array('top', 'left', 'right', 'bottom', 'insideH', 'insideV');
-        $sizeCount = count($this->sizes) - 1;
 
-        for ($i = 0; $i < $sizeCount; $i++) {
-            if ($this->sizes[$i] !== null) {
+        foreach ($this->sizes as $i => $size) {
+            if ($size !== null) {
                 $color = null;
                 if (isset($this->colors[$i])) {
                     $color = $this->colors[$i];


### PR DESCRIPTION
testcode:

``` php
    $cell = $row->addCell(400, array(
      'borderRightColor'=>'efefef',
      'borderRightSize'=>40,
      'borderBottomColor'=>'efefef',
      'borderBottomSize'=>40,
    ));
```

displays only rightBorder but not the bottomBorder.

Sorry for no unit test. Would you prefer the XMLWriter to be injected and then the xml output tested or mocking the XMLWriter and testing the behaviour with expectations? (difficult with PHPUnit only, I would suggest using mockery)
Unfortuately I cannot write the unit test right now, but still hope this bug will be fixed
