### PR TITLE
bugfix: specific borders were not written correctly in word2007

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This release added form fields (textinput, checkbox, and dropdown), drawing shap
 - Page breaks on titles and tables - @ivanlanin GH-274
 - Table inside vertical border does not rendered properly - @ivanlanin GH-280
 - `add<elementName>` of container should be case insensitive, e.g. `addToc` should be accepted, not only `addTOC` - @ivanlanin GH-294
+- Fix specific borders (and margins) were not written correctly in word2007 writer
 
 ### Deprecated
 

--- a/src/PhpWord/Writer/Word2007/Style/MarginBorder.php
+++ b/src/PhpWord/Writer/Word2007/Style/MarginBorder.php
@@ -59,8 +59,8 @@ class MarginBorder extends AbstractStyle
         $sides = array('top', 'left', 'right', 'bottom', 'insideH', 'insideV');
         $sizeCount = count($this->sizes);
 
-        for ($i = 0; $i < $sizeCount; $i++) {
-            if ($this->sizes[$i] !== null) {
+        foreach ($this->sizes as $i => $size) {
+            if ($size !== null) {
                 $color = null;
                 if (isset($this->colors[$i])) {
                     $color = $this->colors[$i];


### PR DESCRIPTION
testcode:

``` php
    $cell = $row->addCell(400, array(
      'borderRightColor'=>'efefef',
      'borderRightSize'=>40,
      'borderBottomColor'=>'efefef',
      'borderBottomSize'=>40,
    ));
```

displays only rightBorder but not the bottomBorder.

Sorry for no unit test. Would you prefer the XMLWriter to be injected and then the xml output tested or mocking the XMLWriter and testing the behaviour with expectations? (difficult with PHPUnit only, I would suggest using mockery)
Unfortuately I cannot write the unit test right now, but still hope this bug will be fixed
