### PR TITLE
READ_EQUAL must return FALSE if expected not found

### DIFF
--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -483,8 +483,12 @@ abstract class AbstractPart
             $style = true;
         } elseif ($method == self::READ_FALSE) {
             $style = false;
-        } elseif ($method == self::READ_EQUAL && $attributeValue == $expected) {
-            $style = true;
+        } elseif ($method == self::READ_EQUAL ){
+            if( $attributeValue == $expected) {
+                $style = true;
+            }else{
+                $style = false;
+            }
         }
 
         return $style;


### PR DESCRIPTION
In the previous version of the code self:READ_EQUAL would return the value found in the style if the expected value was not found. That this meant was that invalid NON-boolean values would be set for superScript or subScript when a match would not be found.
