### PR TITLE
Fix off-by-one array access when enumerating border sizes.

### DIFF
--- a/src/PhpWord/Writer/Word2007/Style/MarginBorder.php
+++ b/src/PhpWord/Writer/Word2007/Style/MarginBorder.php
@@ -55,7 +55,7 @@ class MarginBorder extends AbstractStyle
         $xmlWriter = $this->getXmlWriter();
 
         $sides = array('top', 'left', 'right', 'bottom', 'insideH', 'insideV');
-        $sizeCount = count($this->sizes) - 1;
+        $sizeCount = count($this->sizes);
 
         for ($i = 0; $i < $sizeCount; $i++) {
             if ($this->sizes[$i] !== null) {


### PR DESCRIPTION
The old behaviour prevented a single 'borderBottomSize' to be written to the output DOCX.

I walked through the unit tests to see if I were able to extend some border tests, only to find them missing. I'm not quite sure what the exact testing style is supposed to be, so if you could give me some directions that'd be great. Alternatively, you could write the test for this bug yourself?
