### PR TITLE
Set the right method name for addShape() for AbstractContainer

### DIFF
--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -41,7 +41,7 @@ namespace PhpOffice\PhpWord\Element;
  * @method TextBox addTextBox(mixed $style = null)
  * @method Field addField(string $type = null, array $properties = array(), array $options = array())
  * @method Line addLine(mixed $lineStyle = null)
- * @method Shape addObject(string $type, mixed $style = null)
+ * @method Shape addShape(string $type, mixed $style = null)
  * @method Chart addChart(string $type, array $categories, array $values, array $style = null)
  * @method FormField addFormField(string $type, mixed $fStyle = null, mixed $pStyle = null)
  * @method SDT addSDT(string $type)


### PR DESCRIPTION
Probably a bad copy/paste from addObject().
