### PR TITLE
Update Head.php

### DIFF
--- a/src/PhpWord/Writer/HTML/Part/Head.php
+++ b/src/PhpWord/Writer/HTML/Part/Head.php
@@ -97,6 +97,14 @@ class Head extends AbstractPart
                 'border' => '0',
                 'border-top' => '1px solid #CCC',
             ),
+            'table' => array(
+                'border' => '1px solid black',
+                'border-spacing' => '0px',
+                'width' => '100%',
+            ),
+            'td' => array(
+                'border' => '1px solid black',
+            ),
         );
         foreach ($defaultStyles as $selector => $style) {
             $styleWriter = new GenericStyleWriter($style);


### PR DESCRIPTION
The generated HTML and PDF tables are missing the border lines. Sample_07_TemplateCloneRow.docx shows the lines around the table and the table cells. However the generated HTML and PDF file are missing those lines. 
And the generated files show the width of the table as very small. The table should use the full width of the page.
