### PR TITLE
Remove newlines from the HTML table cells 

### DIFF
--- a/src/PhpWord/Writer/HTML/Element/Container.php
+++ b/src/PhpWord/Writer/HTML/Element/Container.php
@@ -45,7 +45,13 @@ class Container extends AbstractElement
             return '';
         }
         $containerClass = substr(get_class($container), strrpos(get_class($container), '\\') + 1);
-        $withoutP = in_array($containerClass, array('TextRun', 'Footnote', 'Endnote')) ? true : false;
+        $withoutP = false;
+        if (
+            $this->withoutP ||
+            in_array($containerClass, array('TextRun', 'Footnote', 'Endnote'))
+        ) {
+            $withoutP = true;
+        }
         $content = '';
 
         $elements = $container->getElements();

--- a/src/PhpWord/Writer/HTML/Element/Table.php
+++ b/src/PhpWord/Writer/HTML/Element/Table.php
@@ -47,7 +47,7 @@ class Table extends AbstractElement
                 $tblHeader = $rowStyle->isTblHeader();
                 $content .= '<tr>' . PHP_EOL;
                 foreach ($row->getCells() as $cell) {
-                    $writer = new Container($this->parentWriter, $cell);
+                    $writer = new Container($this->parentWriter, $cell, true);
                     $cellTag = $tblHeader ? 'th' : 'td';
                     $content .= "<{$cellTag}>" . PHP_EOL;
                     $content .= $writer->write();


### PR DESCRIPTION
I use the example which creates the file Sample_07_TemplateCloneRow.docx. However in HTML and PDF you see the newlines in the table cells.

``` html
<tr>
<td>
<p></p>
<p><span style="font-family: 'Calibri';">Value 1</span></p>
<p><span style="font-family: 'Calibri';">:</span></p>
</td>
<td>
<p><span style="font-family: 'Calibri'; font-weight: bold;">Sun</span></p>
</td>
</tr>
```

This patch will remove these `<p>` s inside of the `<td>` tags. Then the table cells in the docx will look the same as in the generated HTML and PDF files.
