### PR TITLE
Allow setting background-color on a paragraph style in ODText

### DIFF
--- a/src/PhpWord/Style/Paragraph.php
+++ b/src/PhpWord/Style/Paragraph.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
@@ -14,7 +15,6 @@
  * @copyright   2010-2014 PHPWord contributors
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
-
 namespace PhpOffice\PhpWord\Style;
 
 use PhpOffice\PhpWord\Exception\InvalidStyleException;
@@ -49,6 +49,7 @@ use PhpOffice\PhpWord\Shared\String;
  */
 class Paragraph extends AbstractStyle
 {
+
     /**
      * @const int One line height equals 240 twip
      */
@@ -153,6 +154,13 @@ class Paragraph extends AbstractStyle
     private $tabs = array();
 
     /**
+     * Shading
+     *
+     * @var \PhpOffice\PhpWord\Style\Shading
+     */
+    private $shading;
+
+    /**
      * Create new instance
      */
     public function __construct()
@@ -192,23 +200,23 @@ class Paragraph extends AbstractStyle
     public function getStyleValues()
     {
         $styles = array(
-            'name'              => $this->getStyleName(),
-            'basedOn'           => $this->getBasedOn(),
-            'next'              => $this->getNext(),
-            'alignment'         => $this->getAlign(),
-            'indentation'       => $this->getIndentation(),
-            'spacing'           => $this->getSpace(),
-            'pagination'        => array(
-                'widowControl'  => $this->hasWidowControl(),
-                'keepNext'      => $this->isKeepNext(),
-                'keepLines'     => $this->isKeepLines(),
-                'pageBreak'     => $this->hasPageBreakBefore(),
+            'name' => $this->getStyleName(),
+            'basedOn' => $this->getBasedOn(),
+            'next' => $this->getNext(),
+            'alignment' => $this->getAlign(),
+            'indentation' => $this->getIndentation(),
+            'spacing' => $this->getSpace(),
+            'pagination' => array(
+                'widowControl' => $this->hasWidowControl(),
+                'keepNext' => $this->isKeepNext(),
+                'keepLines' => $this->isKeepLines(),
+                'pageBreak' => $this->hasPageBreakBefore(),
             ),
-            'numbering'         => array(
-                'style'         => $this->getNumStyle(),
-                'level'         => $this->getNumLevel(),
+            'numbering' => array(
+                'style' => $this->getNumStyle(),
+                'level' => $this->getNumLevel(),
             ),
-            'tabs'              => $this->getTabs(),
+            'tabs' => $this->getTabs(),
         );
 
         return $styles;
@@ -694,4 +702,53 @@ class Paragraph extends AbstractStyle
     {
         return $this->hasPageBreakBefore();
     }
+
+    /**
+     * Get background
+     *
+     * @return string
+     */
+    public function getBgColor()
+    {
+        if ($this->shading !== null) {
+            return $this->shading->getFill();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Set background
+     *
+     * @param string $value
+     * @return self
+     */
+    public function setBgColor($value = null)
+    {
+        return $this->setShading(array('fill' => $value));
+    }
+
+    /**
+     * Get shading
+     *
+     * @return \PhpOffice\PhpWord\Style\Shading
+     */
+    public function getShading()
+    {
+        return $this->shading;
+    }
+
+    /**
+     * Set shading
+     *
+     * @param mixed $value
+     * @return self
+     */
+    public function setShading($value = null)
+    {
+        $this->setObjectVal($value, 'Shading', $this->shading);
+
+        return $this;
+    }
+
 }

--- a/src/PhpWord/Writer/ODText/Style/Paragraph.php
+++ b/src/PhpWord/Writer/ODText/Style/Paragraph.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
@@ -14,7 +15,6 @@
  * @copyright   2010-2014 PHPWord contributors
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
-
 namespace PhpOffice\PhpWord\Writer\ODText\Style;
 
 /**
@@ -24,6 +24,7 @@ namespace PhpOffice\PhpWord\Writer\ODText\Style;
  */
 class Paragraph extends AbstractStyle
 {
+
     /**
      * Write style
      */
@@ -53,9 +54,13 @@ class Paragraph extends AbstractStyle
             $xmlWriter->writeAttribute('fo:margin-top', $marginTop . 'cm');
             $xmlWriter->writeAttribute('fo:margin-bottom', $marginBottom . 'cm');
             $xmlWriter->writeAttribute('fo:text-align', $style->getAlign());
+            if ($shading = $style->getShading()) {
+                $xmlWriter->writeAttribute('fo:background-color', '#' . $shading->getFill());
+            }
         }
         $xmlWriter->endElement(); //style:paragraph-properties
 
         $xmlWriter->endElement(); //style:style
     }
+
 }


### PR DESCRIPTION
With this patch, "bgColor" definitions in paragraph styles are correctly written to .odt documents.
