### PR TITLE
Add column styles to set cell width in ODText

### DIFF
--- a/src/PhpWord/Style/Column.php
+++ b/src/PhpWord/Style/Column.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @link        https://github.com/PHPOffice/PHPWord
+ * @copyright   2010-2014 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+namespace PhpOffice\PhpWord\Style;
+
+/**
+ * Table column style
+ */
+class Column extends AbstractStyle
+{
+
+    /**
+     * Width
+     *
+     * @var string
+     */
+    private $width;
+
+    /**
+     * Get width
+     *
+     * @return string Width
+     */
+    public function getWidth()
+    {
+        return $this->width;
+    }
+
+    /**
+     * Set width
+     *
+     * @param string $value
+     * @return self
+     */
+    public function setWidth($value)
+    {
+        $this->width = $value;
+
+        return $this;
+    }
+
+}

--- a/src/PhpWord/Writer/ODText/Element/Table.php
+++ b/src/PhpWord/Writer/ODText/Element/Table.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
@@ -14,7 +15,6 @@
  * @copyright   2010-2014 PHPWord contributors
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
-
 namespace PhpOffice\PhpWord\Writer\ODText\Element;
 
 /**
@@ -24,6 +24,7 @@ namespace PhpOffice\PhpWord\Writer\ODText\Element;
  */
 class Table extends AbstractElement
 {
+
     /**
      * Write element
      */
@@ -43,10 +44,11 @@ class Table extends AbstractElement
             $xmlWriter->writeAttribute('table:name', $element->getElementId());
             $xmlWriter->writeAttribute('table:style', $element->getElementId());
 
-            $xmlWriter->startElement('table:table-column');
-            $xmlWriter->writeAttribute('table:number-columns-repeated', $colCount);
-            $xmlWriter->endElement(); // table:table-column
-
+            for ($i = 0; $i < $colCount; $i++) {
+                $xmlWriter->startElement('table:table-column');
+                $xmlWriter->writeAttribute('table:style-name', $element->getElementId() . '.' . $i);
+                $xmlWriter->endElement();
+            }
             foreach ($rows as $row) {
                 $xmlWriter->startElement('table:table-row');
                 /** @var $row \PhpOffice\PhpWord\Element\Row Type hint */
@@ -64,4 +66,5 @@ class Table extends AbstractElement
             $xmlWriter->endElement(); // table:table
         }
     }
+
 }

--- a/src/PhpWord/Writer/ODText/Style/Column.php
+++ b/src/PhpWord/Writer/ODText/Style/Column.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @link        https://github.com/PHPOffice/PHPWord
+ * @copyright   2010-2014 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+namespace PhpOffice\PhpWord\Writer\ODText\Style;
+
+/**
+ * Table column style writer
+ *
+ */
+class Column extends AbstractStyle
+{
+
+    /**
+     * Write style
+     */
+    public function write()
+    {
+        /** @var \PhpOffice\PhpWord\Style\Column $style Type hint */
+        $style = $this->getStyle();
+        if (!$style instanceof \PhpOffice\PhpWord\Style\Column) {
+            return;
+        }
+        $xmlWriter = $this->getXmlWriter();
+
+        $xmlWriter->startElement('style:style');
+        $xmlWriter->writeAttribute('style:name', $style->getStyleName());
+        $xmlWriter->writeAttribute('style:family', 'table-column');
+        $xmlWriter->startElement('style:table-column-properties');
+        if ($width = $style->getWidth()) {
+            $xmlWriter->writeAttribute('style:column-width', number_format($width * 0.0017638889, 2, '.', '') . 'cm');
+        }
+        $xmlWriter->endElement(); // style:table-column-properties
+        $xmlWriter->endElement(); // style:style
+    }
+
+}


### PR DESCRIPTION
This patch introduces the column width styling for ODT described in issue #411.

This is a new pull request, this time against the develop branch and only including the column-style related changes.
