### PR TITLE
Update Table.php: Always close th as th

### DIFF
--- a/src/PhpWord/Writer/HTML/Element/Table.php
+++ b/src/PhpWord/Writer/HTML/Element/Table.php
@@ -51,7 +51,7 @@ class Table extends AbstractElement
                     $cellTag = $tblHeader ? 'th' : 'td';
                     $content .= "<{$cellTag}>" . PHP_EOL;
                     $content .= $writer->write();
-                    $content .= '</td>' . PHP_EOL;
+                    $content .= "</{$cellTag}>" . PHP_EOL;
                 }
                 $content .= '</tr>' . PHP_EOL;
             }


### PR DESCRIPTION
You must not open a `<th>` and close it as a `</td>`.
read http://www.w3schools.com/tags/tag_th.asp
