### PR TITLE
Issue #468 Error suppression in AbstractContainer update for error listeners

### DIFF
--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -98,10 +98,24 @@ abstract class AbstractContainer extends AbstractElement
             // Special case for TextBreak
             // @todo Remove the `$count` parameter in 1.0.0 to make this element similiar to other elements?
             if ($element == 'TextBreak') {
-                @list($count, $fontStyle, $paragraphStyle) = $args; // Suppress error
-                if ($count === null) {
+                if (isset($args[0])) {
+                    $count = $args[0];
+                } else {
                     $count = 1;
                 }
+
+                if (isset($args[1])) {
+                    $fontStyle = $args[1];
+                } else {
+                    $fontStyle = null;
+                }
+
+                if (isset($args[2])) {
+                    $paragraphStyle = $args[2];
+                } else {
+                    $paragraphStyle = null;
+                }
+
                 for ($i = 1; $i <= $count; $i++) {
                     $this->addElement($element, $fontStyle, $paragraphStyle);
                 }


### PR DESCRIPTION
This pull request addresses #468 so that people who have custom handlers for php errors and warnings will no longer get triggered when using the addTextBreak on sections in certain scenarios where they don't pass all the arguments.  The error suppression stops the error from being shown but it is still passed to the handlers creating unwanted alerts.

I've moved it to a couple of conditionals so that no warnings are created.
