### PR TITLE
Modified for adding compatible objects

### DIFF
--- a/src/PhpWord/Element/Object.php
+++ b/src/PhpWord/Element/Object.php
@@ -69,7 +69,7 @@ class Object extends AbstractElement
      */
     public function __construct($source, $style = null)
     {
-        $supportedTypes = array('xls', 'doc', 'ppt', 'xlsx', 'docx', 'pptx');
+        $supportedTypes = array('xlsx', 'docx', 'pptx');
         $pathInfo = pathinfo($source);
 
         if (file_exists($source) && in_array($pathInfo['extension'], $supportedTypes)) {

--- a/src/PhpWord/Media.php
+++ b/src/PhpWord/Media.php
@@ -83,7 +83,7 @@ class Media
 
                 // Objects
                 case 'object':
-                    $target = "{$container}_oleObject{$mediaTypeCount}.bin";
+                    $target = "{$container}_oleObject{$mediaTypeCount}.".pathinfo($source)['extension']."";
                     break;
 
                 // Links

--- a/src/PhpWord/Writer/Word2007.php
+++ b/src/PhpWord/Writer/Word2007.php
@@ -300,6 +300,7 @@ class Word2007 extends AbstractWriter implements WriterInterface
     {
         foreach ($media as $medium) {
             $mediumType = $medium['type'];
+            $mediumExtension = pathinfo($medium['source'])['extension'];
             if ($mediumType == 'image') {
                 $extension = $medium['imageExtension'];
                 if (!isset($this->contentTypes['default'][$extension])) {

--- a/src/PhpWord/Writer/Word2007.php
+++ b/src/PhpWord/Writer/Word2007.php
@@ -306,9 +306,26 @@ class Word2007 extends AbstractWriter implements WriterInterface
                     $this->contentTypes['default'][$extension] = $medium['imageType'];
                 }
             } elseif ($mediumType == 'object') {
-                if (!isset($this->contentTypes['default']['bin'])) {
-                    $this->contentTypes['default']['bin'] = 'application/vnd.openxmlformats-officedocument.oleObject';
-                }
+                switch($mediumExtension)
+            	{
+            	  case "docx":
+                    if (!isset($this->contentTypes['default']['docx'])) {
+                          $this->contentTypes['default']['docx'] = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+                  	}
+                    	break;
+                    
+                  case "pptx":
+                    if (!isset($this->contentTypes['default']['pptx'])) {
+                    	  $this->contentTypes['default']['pptx'] = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+                    	}
+                    	break;
+                    	
+                  case "xlsx":
+                    if (!isset($this->contentTypes['default']['xlsx'])) {
+                    	  $this->contentTypes['default']['xlsx'] = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+                    	}
+                    	break;
+            	}
             }
         }
     }

--- a/src/PhpWord/Writer/Word2007.php
+++ b/src/PhpWord/Writer/Word2007.php
@@ -307,26 +307,25 @@ class Word2007 extends AbstractWriter implements WriterInterface
                     $this->contentTypes['default'][$extension] = $medium['imageType'];
                 }
             } elseif ($mediumType == 'object') {
-                switch($mediumExtension)
-            	{
-            	  case "docx":
-                    if (!isset($this->contentTypes['default']['docx'])) {
-                          $this->contentTypes['default']['docx'] = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-                  	}
-                    	break;
+                switch ($mediumExtension) {
+                    case "docx":
+                        if (!isset($this->contentTypes['default']['docx'])) {
+                            $this->contentTypes['default']['docx'] = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+                        }
+                        break;
                     
-                  case "pptx":
-                    if (!isset($this->contentTypes['default']['pptx'])) {
-                    	  $this->contentTypes['default']['pptx'] = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
-                    	}
-                    	break;
-                    	
-                  case "xlsx":
-                    if (!isset($this->contentTypes['default']['xlsx'])) {
-                    	  $this->contentTypes['default']['xlsx'] = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
-                    	}
-                    	break;
-            	}
+                    case "pptx":
+                        if (!isset($this->contentTypes['default']['pptx'])) {
+                            $this->contentTypes['default']['pptx'] = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+                        }
+                        break;
+                    
+                    case "xlsx":
+                        if (!isset($this->contentTypes['default']['xlsx'])) {
+                            $this->contentTypes['default']['xlsx'] = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+                        }
+                        break;
+                }
             }
         }
     }

--- a/src/PhpWord/Writer/Word2007.php
+++ b/src/PhpWord/Writer/Word2007.php
@@ -300,7 +300,8 @@ class Word2007 extends AbstractWriter implements WriterInterface
     {
         foreach ($media as $medium) {
             $mediumType = $medium['type'];
-            $mediumExtension = pathinfo($medium['source'])['extension'];
+            $pathSource = pathinfo($medium['source']);
+            $mediumExtension = $pathSource['extension'];
             if ($mediumType == 'image') {
                 $extension = $medium['imageExtension'];
                 if (!isset($this->contentTypes['default'][$extension])) {

--- a/src/PhpWord/Writer/Word2007/Part/Rels.php
+++ b/src/PhpWord/Writer/Word2007/Part/Rels.php
@@ -85,7 +85,7 @@ class Rels extends AbstractPart
     private function writeMediaRel(XMLWriter $xmlWriter, $relId, $mediaRel)
     {
         $typePrefix = 'officeDocument/2006/relationships/';
-        $typeMapping = array('image' => 'image', 'object' => 'oleObject', 'link' => 'hyperlink');
+        $typeMapping = array('image' => 'image', 'object' => 'package', 'link' => 'hyperlink');
         $targetMapping = array('image' => 'media/', 'object' => 'embeddings/');
 
         $mediaType = $mediaRel['type'];


### PR DESCRIPTION
Issue - OLEobject creation not done properly and hopefully we cannot do. so we can embed object as package.

Because of xls, doc, and ppt types are not packages they are Removed.

Now we can add object of type xlsx,docx and pptx through addObject.
