### PR TITLE
Adding condition for document template saving using libreoffice

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -204,7 +204,8 @@ class TemplateProcessor
                 // If tmpXmlRow doesn't contain continue, this row is no longer part of the spanned row.
                 $tmpXmlRow = $this->getSlice($extraRowStart, $extraRowEnd);
                 if (!preg_match('#<w:vMerge/>#', $tmpXmlRow) &&
-                    !preg_match('#<w:vMerge w:val="continue" />#', $tmpXmlRow)) {
+                    !preg_match('#<w:vMerge w:val="continue" />#', $tmpXmlRow) &&
+                    !preg_match('#<w:vMerge w:val="continue"/>#', $tmpXmlRow)) {
                     break;
                 }
                 // This row was a spanned row, update $rowEnd and search for the next row.


### PR DESCRIPTION
When  I save document template with libreoffice (in .docx format) the cloneRow with nested table doesn't work.
The problem is that the regular expression, that used for search if row is no longer part of the spanned row, was wrong: 
<w:vMerge w:val="continue" /> became <w:vMerge w:val="continue"/> without space at the closure tag.
Sorry for my English.
