### PR TITLE
#503

### DIFF
--- a/src/PhpWord/Shared/OLERead.php
+++ b/src/PhpWord/Shared/OLERead.php
@@ -55,7 +55,7 @@ class OLERead
     public $wrkData                         = null;
     public $wrkObjectPool                   = null;
     public $summaryInformation              = null;
-    public $docSummaryInfos                 = null;
+    public $documentSummaryInformation      = null;
 
 
     /**
@@ -281,7 +281,7 @@ class OLERead
 
             // Additional Document Summary information
             if ($name == chr(5) . 'DocumentSummaryInformation') {
-                $this->docSummaryInfos = count($this->props) - 1;
+                $this->documentSummaryInformation = count($this->props) - 1;
             }
 
             $offset += self::PROPERTY_STORAGE_BLOCK_SIZE;


### PR DESCRIPTION
Replaced docSummaryInfos with documentSummaryInformation in OLERead class, used by MsDoc reader.
I chose documentSummaryInformation because it's more explicit and present in more places.
