### PR TITLE
Added the ability to enable gridlines and axislabels on charts

### DIFF
--- a/samples/Sample_32_Chart.php
+++ b/samples/Sample_32_Chart.php
@@ -22,11 +22,16 @@ $categories = array('A', 'B', 'C', 'D', 'E');
 $series1 = array(1, 3, 2, 5, 4);
 $series2 = array(3, 1, 7, 2, 6);
 $series3 = array(8, 3, 2, 5, 4);
+$showGridLines = false;
+$showAxisLabels = false;
 
 foreach ($chartTypes as $chartType) {
     $section->addTitle(ucfirst($chartType), 2);
     $chart = $section->addChart($chartType, $categories, $series1);
     $chart->getStyle()->setWidth(Converter::inchToEmu(2.5))->setHeight(Converter::inchToEmu(2));
+    $chart->getStyle()->setShowGridX($showGridLines);
+    $chart->getStyle()->setShowGridY($showGridLines);
+    $chart->getStyle()->setShowAxisLabels($showAxisLabels);
     if (in_array($chartType, $twoSeries)) {
         $chart->addSeries($categories, $series2);
     }
@@ -43,7 +48,8 @@ $section = $phpWord->addSection(array('colsNum' => 2, 'breakType' => 'continuous
 
 $chartTypes = array('pie', 'bar', 'column', 'line', 'area');
 $multiSeries = array('bar', 'column', 'line', 'area');
-$style = array('width' => Converter::cmToEmu(5), 'height' => Converter::cmToEmu(4), '3d' => true);
+$style = array('width' => Converter::cmToEmu(5), 'height' => Converter::cmToEmu(4), '3d' => true, 
+                'showAxisLabels' => $showAxisLabels, 'showGridX' => $showGridLines, 'showGridY' => $showGridLines);
 foreach ($chartTypes as $chartType) {
     $section->addTitle(ucfirst($chartType), 2);
     $chart = $section->addChart($chartType, $categories, $series1, $style);

--- a/src/PhpWord/Style/Chart.php
+++ b/src/PhpWord/Style/Chart.php
@@ -47,6 +47,27 @@ class Chart extends AbstractStyle
     private $is3d = false;
 
     /**
+     * Show labels for axis
+     *
+     * @var bool
+     */
+    private $showAxisLabels = false;
+
+    /**
+     * Show Gridlines for Y-Axis
+     *
+     * @var bool
+     */
+    private $gridY = false;
+
+    /**
+     * Show Gridlines for X-Axis
+     *
+     * @var bool
+     */
+    private $gridX = false;
+
+    /**
      * Create a new instance
      *
      * @param array $style
@@ -121,6 +142,75 @@ class Chart extends AbstractStyle
     public function set3d($value = true)
     {
         $this->is3d = $this->setBoolVal($value, $this->is3d);
+
+        return $this;
+    }
+
+    /**
+     * Show labels for axis
+     *
+     * @return bool
+     */
+    public function showAxisLabels()
+    {
+        return $this->showAxisLabels;
+    }
+
+    /**
+     * Set show Gridlines for Y-Axis
+     *
+     * @param bool $value
+     * @return self
+     */
+    public function setShowAxisLabels($value = true)
+    {
+        $this->showAxisLabels = $this->setBoolVal($value, $this->showAxisLabels);
+
+        return $this;
+    }
+
+    /**
+     * Show Gridlines for Y-Axis
+     *
+     * @return bool
+     */
+    public function showGridY()
+    {
+        return $this->gridY;
+    }
+
+    /**
+     * Set show Gridlines for Y-Axis
+     *
+     * @param bool $value
+     * @return self
+     */
+    public function setShowGridY($value = true)
+    {
+        $this->gridY = $this->setBoolVal($value, $this->gridY);
+
+        return $this;
+    }
+
+    /**
+     * Show Gridlines for X-Axis
+     *
+     * @return bool
+     */
+    public function showGridX()
+    {
+        return $this->gridX;
+    }
+
+    /**
+     * Set show Gridlines for X-Axis
+     *
+     * @param bool $value
+     * @return self
+     */
+    public function setShowGridX($value = true)
+    {
+        $this->gridX = $this->setBoolVal($value, $this->gridX);
 
         return $this;
     }

--- a/src/PhpWord/Writer/Word2007/Part/Chart.php
+++ b/src/PhpWord/Writer/Word2007/Part/Chart.php
@@ -282,10 +282,9 @@ class Chart extends AbstractPart
             $xmlWriter->writeElementBlock('c:delete', 'val', 0);
             $xmlWriter->writeElementBlock('c:majorTickMark', 'val', 'none');
             $xmlWriter->writeElementBlock('c:minorTickMark', 'val', 'none');
-            if($style->showAxisLabels()) {
+            if ($style->showAxisLabels()) {
                 $xmlWriter->writeElementBlock('c:tickLblPos', 'val', 'nextTo');
-            }
-            else {
+            } else {
                 $xmlWriter->writeElementBlock('c:tickLblPos', 'val', 'none');
             }
             $xmlWriter->writeElementBlock('c:crosses', 'val', 'autoZero');

--- a/src/PhpWord/Writer/Word2007/Part/Chart.php
+++ b/src/PhpWord/Writer/Word2007/Part/Chart.php
@@ -264,6 +264,7 @@ class Chart extends AbstractPart
      */
     private function writeAxis(XMLWriter $xmlWriter, $type)
     {
+        $style = $this->element->getStyle();
         $types = array(
             'cat' => array('c:catAx', 1, 'b', 2),
             'val' => array('c:valAx', 2, 'l', 1),
@@ -273,7 +274,7 @@ class Chart extends AbstractPart
         $xmlWriter->startElement($axisType);
 
         $xmlWriter->writeElementBlock('c:axId', 'val', $axisId);
-        $xmlWriter->writeElementBlock('c:axPos', 'val', $axisPos);
+        $xmlWriter->writeElementBlock('c:axPos', 'val', $axisPos);        
         $xmlWriter->writeElementBlock('c:crossAx', 'val', $axisCross);
         $xmlWriter->writeElementBlock('c:auto', 'val', 1);
 
@@ -281,10 +282,12 @@ class Chart extends AbstractPart
             $xmlWriter->writeElementBlock('c:delete', 'val', 0);
             $xmlWriter->writeElementBlock('c:majorTickMark', 'val', 'none');
             $xmlWriter->writeElementBlock('c:minorTickMark', 'val', 'none');
-            $xmlWriter->writeElementBlock('c:tickLblPos', 'val', 'none'); // nextTo
+            if($style->showAxisLabels())
+                $xmlWriter->writeElementBlock('c:tickLblPos', 'val', 'nextTo');
+            else $xmlWriter->writeElementBlock('c:tickLblPos', 'val', 'none');
             $xmlWriter->writeElementBlock('c:crosses', 'val', 'autoZero');
         }
-        if (isset($this->options['radar'])) {
+        if (isset($this->options['radar']) || ($type == "cat" && $style->showGridX()) || ($type == "val" && $style->showGridY())) {
             $xmlWriter->writeElement('c:majorGridlines');
         }
 

--- a/src/PhpWord/Writer/Word2007/Part/Chart.php
+++ b/src/PhpWord/Writer/Word2007/Part/Chart.php
@@ -274,7 +274,7 @@ class Chart extends AbstractPart
         $xmlWriter->startElement($axisType);
 
         $xmlWriter->writeElementBlock('c:axId', 'val', $axisId);
-        $xmlWriter->writeElementBlock('c:axPos', 'val', $axisPos);        
+        $xmlWriter->writeElementBlock('c:axPos', 'val', $axisPos);
         $xmlWriter->writeElementBlock('c:crossAx', 'val', $axisCross);
         $xmlWriter->writeElementBlock('c:auto', 'val', 1);
 
@@ -282,9 +282,12 @@ class Chart extends AbstractPart
             $xmlWriter->writeElementBlock('c:delete', 'val', 0);
             $xmlWriter->writeElementBlock('c:majorTickMark', 'val', 'none');
             $xmlWriter->writeElementBlock('c:minorTickMark', 'val', 'none');
-            if($style->showAxisLabels())
+            if($style->showAxisLabels()) {
                 $xmlWriter->writeElementBlock('c:tickLblPos', 'val', 'nextTo');
-            else $xmlWriter->writeElementBlock('c:tickLblPos', 'val', 'none');
+            }
+            else {
+                $xmlWriter->writeElementBlock('c:tickLblPos', 'val', 'none');
+            }
             $xmlWriter->writeElementBlock('c:crosses', 'val', 'autoZero');
         }
         if (isset($this->options['radar']) || ($type == "cat" && $style->showGridX()) || ($type == "val" && $style->showGridY())) {


### PR DESCRIPTION
Added options 'showAxisLabels', 'showGridX', 'showGridY' to charts style element.
Added appropriet set and get methods.
Those options can be testet in Sample_32_Charts.php, but they are set to false for now.
Default output of that sample is not changed.
