### PR TITLE
Fix for Incorrect Constant Names in \Style\Font.php #574

### DIFF
--- a/src/PhpWord/Style/Font.php
+++ b/src/PhpWord/Style/Font.php
@@ -33,8 +33,10 @@ class Font extends AbstractStyle
     const UNDERLINE_DASHLONG = 'dashLong';
     const UNDERLINE_DASHLONGHEAVY = 'dashLongHeavy';
     const UNDERLINE_DOUBLE = 'dbl';
-    const UNDERLINE_DOTHASH = 'dotDash';
-    const UNDERLINE_DOTHASHHEAVY = 'dotDashHeavy';
+    const UNDERLINE_DOTHASH = 'dotDash';  // Incorrect spelling retained for backwards compatibility
+    const UNDERLINE_DOTHASHHEAVY = 'dotDashHeavy';  // Incorrect spelling retained for backwards compatibility
+    const UNDERLINE_DOTDASH = 'dotDash';  // Correct spelling
+    const UNDERLINE_DOTDASHHEAVY = 'dotDashHeavy';  // Correct spelling
     const UNDERLINE_DOTDOTDASH = 'dotDotDash';
     const UNDERLINE_DOTDOTDASHHEAVY = 'dotDotDashHeavy';
     const UNDERLINE_DOTTED = 'dotted';


### PR DESCRIPTION
Correct the spelling of the "dotDash" and "dotDashHeavy" constants, leaving the old versions behind for backwards compatibility.