### PR TITLE
Fix FormField Constructor Ignoring Styles

### DIFF
--- a/src/PhpWord/Element/FormField.php
+++ b/src/PhpWord/Element/FormField.php
@@ -75,6 +75,8 @@ class FormField extends Text
     public function __construct($type, $fontStyle = null, $paragraphStyle = null)
     {
         $this->setType($type);
+        $paragraphStyle = $this->setParagraphStyle($paragraphStyle);
+        $this->setFontStyle($fontStyle, $paragraphStyle);
     }
 
     /**


### PR DESCRIPTION
I noticed that the font and paragraph styles I supplied when adding a
new FormField were ignored. It seems that the FormField class extends
the Text class and overwrote the constructor, but the code to set the
paragraph and font styles was mistakenly omitted. I just copied and
pasted what was in the Text class constructor, and now it works like a
charm!
