### PR TITLE
#587 Add getAlignment() setAlignment to Frame and Table

### DIFF
--- a/src/PhpWord/Style/Frame.php
+++ b/src/PhpWord/Style/Frame.php
@@ -183,13 +183,34 @@ class Frame extends AbstractStyle
     }
 
     /**
-     * Get alignment
+     * Get alignment (For backwards compatiblity)
      *
      * @return string
      */
     public function getAlign()
     {
+        return $this->getAlignment();
+    }
+
+    /**
+     * Get alignment
+     *
+     * @return string
+     */
+    public function getAlignment()
+    {
         return $this->alignment->getValue();
+    }
+
+    /**
+     * Set alignment (For backwards compatiblity)
+     *
+     * @param string $value
+     * @return self
+     */
+    public function setAlign($value = null)
+    {
+        return $this->setAlignment($value);
     }
 
     /**
@@ -198,7 +219,7 @@ class Frame extends AbstractStyle
      * @param string $value
      * @return self
      */
-    public function setAlign($value = null)
+    public function setAlignment($value = null)
     {
         $this->alignment->setValue($value);
 

--- a/src/PhpWord/Style/Table.php
+++ b/src/PhpWord/Style/Table.php
@@ -494,13 +494,34 @@ class Table extends Border
     }
 
     /**
-     * Get alignment
+     * Get alignment (For backwards compatiblity)
      *
      * @return string
      */
     public function getAlign()
     {
+        return $this->getAlignment();
+    }
+
+    /**
+     * Get alignment
+     *
+     * @return string
+     */
+    public function getAlignment()
+    {
         return $this->alignment->getValue();
+    }
+
+    /**
+     * Set alignment (For backwards compatiblity)
+     *
+     * @param string $value
+     * @return self
+     */
+    public function setAlign($value = null)
+    {
+        return $this->setAlignment($value);
     }
 
     /**
@@ -509,7 +530,7 @@ class Table extends Border
      * @param string $value
      * @return self
      */
-    public function setAlign($value = null)
+    public function setAlignment($value = null)
     {
         $this->alignment->setValue($value);
 


### PR DESCRIPTION
Add getAlignment() and setAlignment methods to the Frame and Table
elements, so that the method names are consistent with the attribute
names.  Preserve the old methods for backwards compatibility.  (Issue #587)