### PR TITLE
#349 Documentation Updates: Table with Percentage and Alignment

### DIFF
--- a/docs/elements.rst
+++ b/docs/elements.rst
@@ -299,7 +299,7 @@ Table, row, and cell styles
 
 Table styles:
 
--  ``width`` Table width in percent
+-  ``width`` Table width in fiftieths (1/50) of a percent
 -  ``alignment`` Table alignment, *left*, *right*, *center*, *both*, *justify*
 -  ``bgColor`` Background color, e.g. '9966CC'
 -  ``border(Top|Right|Bottom|Left)Size`` Border size in twips

--- a/docs/elements.rst
+++ b/docs/elements.rst
@@ -300,6 +300,7 @@ Table, row, and cell styles
 Table styles:
 
 -  ``width`` Table width in percent
+-  ``alignment`` Table alignment, *left*, *right*, *center*, *both*, *justify*
 -  ``bgColor`` Background color, e.g. '9966CC'
 -  ``border(Top|Right|Bottom|Left)Size`` Border size in twips
 -  ``border(Top|Right|Bottom|Left)Color`` Border color, e.g. '9966CC'


### PR DESCRIPTION
Note that table with percentage is actually specified in 1/50ths of a percentage (issue #349), and add note about table alignment as well.
