### PR TITLE
Fix Dateformat typo, fix hours casing, add Month-Day-Year formats

### DIFF
--- a/src/PhpWord/Element/Field.php
+++ b/src/PhpWord/Element/Field.php
@@ -47,9 +47,23 @@ class Field extends AbstractElement
         ),
         'DATE'=>array(
             'properties'=> array(
-               'dateformat' =>array('d-M-yyyy', 'dddd d MMMM yyyy', 'd MMMM yyyy', 'd-M-yy', 'yyyy-MM-dd',
-                    'd-MMM-yy', 'd/M/yyyy', 'd MMM. yy', 'd/M/yy', 'MMM-yy', 'd-M-yyy H:mm', 'd-M-yyyy H:mm:ss',
-                    'h:mm am/pm', 'h:mm:ss am/pm', 'HH:mm', 'HH:mm:ss')
+               'dateformat' =>array(
+                    /* Generic formats */
+                    'yyyy-MM-dd', 'yyyy-MM', 'MMM-yy', 'MMM-yyyy', 'h:mm am/pm', 'h:mm:ss am/pm', 'HH:mm', 'HH:mm:ss', 
+                    
+                    /* Day-Month-Year formats */
+                    'dddd d MMMM yyyy', 'd MMMM yyyy', 'd-MMM-yy', 'd MMM. yy', 
+                    'd-M-yy', 'd-M-yy H:mm', 'd-M-yy H:mm:ss', 'd-M-yy H:mm am/pm', 'd-M-yy H:mm:ss am/pm', 'd-M-yy HH:mm', 'd-M-yy HH:mm:ss', 
+                    'd/M/yy', 'd/M/yy H:mm', 'd/M/yy H:mm:ss', 'd/M/yy H:mm am/pm', 'd/M/yy H:mm:ss am/pm', 'd/M/yy HH:mm', 'd/M/yy HH:mm:ss',
+                    'd-M-yyyy', 'd-M-yyyy H:mm', 'd-M-yyyy H:mm:ss', 'd-M-yyyy H:mm am/pm', 'd-M-yyyy H:mm:ss am/pm', 'd-M-yyyy HH:mm', 'd-M-yyyy HH:mm:ss', 
+                    'd/M/yyyy', 'd/M/yyyy H:mm', 'd/M/yyyy H:mm:ss', 'd/M/yyyy H:mm am/pm', 'd/M/yyyy H:mm:ss am/pm', 'd/M/yyyy HH:mm', 'd/M/yyyy HH:mm:ss',
+                    
+                    /* Month-Day-Year formats */
+                    'dddd, MMMM d yyyy', 'MMMM d yyyy', 'MMM-d-yy', 'MMM. d yy', 
+                    'M-d-yy', 'M-d-yy H:mm', 'M-d-yy H:mm:ss', 'M-d-yy H:mm am/pm', 'M-d-yy H:mm:ss am/pm', 'M-d-yy HH:mm', 'M-d-yy HH:mm:ss', 
+                    'M/d/yy', 'M/d/yy H:mm', 'M/d/yy H:mm:ss', 'M/d/yy H:mm am/pm', 'M/d/yy H:mm:ss am/pm', 'M/d/yy HH:mm', 'M/d/yy HH:mm:ss',
+                    'M-d-yyyy', 'M-d-yyyy H:mm', 'M-d-yyyy H:mm:ss', 'M-d-yyyy H:mm am/pm', 'M-d-yyyy H:mm:ss am/pm', 'M-d-yyyy HH:mm', 'M-d-yyyy HH:mm:ss', 
+                    'M/d/yyyy', 'M/d/yyyy H:mm', 'M/d/yyyy H:mm:ss', 'M/d/yyyy H:mm am/pm', 'M/d/yyyy H:mm:ss am/pm', 'M/d/yyyy HH:mm', 'M/d/yyyy HH:mm:ss')
             ),
             'options'=>array('PreserveFormat', 'LunarCalendar', 'SakaEraCalendar', 'LastUsedFormat')
         )

--- a/src/PhpWord/Element/Field.php
+++ b/src/PhpWord/Element/Field.php
@@ -53,17 +53,17 @@ class Field extends AbstractElement
                     
                     /* Day-Month-Year formats */
                     'dddd d MMMM yyyy', 'd MMMM yyyy', 'd-MMM-yy', 'd MMM. yy', 
-                    'd-M-yy', 'd-M-yy H:mm', 'd-M-yy H:mm:ss', 'd-M-yy H:mm am/pm', 'd-M-yy H:mm:ss am/pm', 'd-M-yy HH:mm', 'd-M-yy HH:mm:ss', 
-                    'd/M/yy', 'd/M/yy H:mm', 'd/M/yy H:mm:ss', 'd/M/yy H:mm am/pm', 'd/M/yy H:mm:ss am/pm', 'd/M/yy HH:mm', 'd/M/yy HH:mm:ss',
-                    'd-M-yyyy', 'd-M-yyyy H:mm', 'd-M-yyyy H:mm:ss', 'd-M-yyyy H:mm am/pm', 'd-M-yyyy H:mm:ss am/pm', 'd-M-yyyy HH:mm', 'd-M-yyyy HH:mm:ss', 
-                    'd/M/yyyy', 'd/M/yyyy H:mm', 'd/M/yyyy H:mm:ss', 'd/M/yyyy H:mm am/pm', 'd/M/yyyy H:mm:ss am/pm', 'd/M/yyyy HH:mm', 'd/M/yyyy HH:mm:ss',
+                    'd-M-yy', 'd-M-yy h:mm', 'd-M-yy h:mm:ss', 'd-M-yy h:mm am/pm', 'd-M-yy h:mm:ss am/pm', 'd-M-yy HH:mm', 'd-M-yy HH:mm:ss', 
+                    'd/M/yy', 'd/M/yy h:mm', 'd/M/yy h:mm:ss', 'd/M/yy h:mm am/pm', 'd/M/yy h:mm:ss am/pm', 'd/M/yy HH:mm', 'd/M/yy HH:mm:ss',
+                    'd-M-yyyy', 'd-M-yyyy h:mm', 'd-M-yyyy h:mm:ss', 'd-M-yyyy h:mm am/pm', 'd-M-yyyy h:mm:ss am/pm', 'd-M-yyyy HH:mm', 'd-M-yyyy HH:mm:ss', 
+                    'd/M/yyyy', 'd/M/yyyy h:mm', 'd/M/yyyy h:mm:ss', 'd/M/yyyy h:mm am/pm', 'd/M/yyyy h:mm:ss am/pm', 'd/M/yyyy HH:mm', 'd/M/yyyy HH:mm:ss',
                     
                     /* Month-Day-Year formats */
                     'dddd, MMMM d yyyy', 'MMMM d yyyy', 'MMM-d-yy', 'MMM. d yy', 
-                    'M-d-yy', 'M-d-yy H:mm', 'M-d-yy H:mm:ss', 'M-d-yy H:mm am/pm', 'M-d-yy H:mm:ss am/pm', 'M-d-yy HH:mm', 'M-d-yy HH:mm:ss', 
-                    'M/d/yy', 'M/d/yy H:mm', 'M/d/yy H:mm:ss', 'M/d/yy H:mm am/pm', 'M/d/yy H:mm:ss am/pm', 'M/d/yy HH:mm', 'M/d/yy HH:mm:ss',
-                    'M-d-yyyy', 'M-d-yyyy H:mm', 'M-d-yyyy H:mm:ss', 'M-d-yyyy H:mm am/pm', 'M-d-yyyy H:mm:ss am/pm', 'M-d-yyyy HH:mm', 'M-d-yyyy HH:mm:ss', 
-                    'M/d/yyyy', 'M/d/yyyy H:mm', 'M/d/yyyy H:mm:ss', 'M/d/yyyy H:mm am/pm', 'M/d/yyyy H:mm:ss am/pm', 'M/d/yyyy HH:mm', 'M/d/yyyy HH:mm:ss')
+                    'M-d-yy', 'M-d-yy h:mm', 'M-d-yy h:mm:ss', 'M-d-yy h:mm am/pm', 'M-d-yy h:mm:ss am/pm', 'M-d-yy HH:mm', 'M-d-yy HH:mm:ss', 
+                    'M/d/yy', 'M/d/yy h:mm', 'M/d/yy h:mm:ss', 'M/d/yy h:mm am/pm', 'M/d/yy h:mm:ss am/pm', 'M/d/yy HH:mm', 'M/d/yy HH:mm:ss',
+                    'M-d-yyyy', 'M-d-yyyy h:mm', 'M-d-yyyy h:mm:ss', 'M-d-yyyy h:mm am/pm', 'M-d-yyyy h:mm:ss am/pm', 'M-d-yyyy HH:mm', 'M-d-yyyy HH:mm:ss', 
+                    'M/d/yyyy', 'M/d/yyyy h:mm', 'M/d/yyyy h:mm:ss', 'M/d/yyyy h:mm am/pm', 'M/d/yyyy h:mm:ss am/pm', 'M/d/yyyy HH:mm', 'M/d/yyyy HH:mm:ss')
             ),
             'options'=>array('PreserveFormat', 'LunarCalendar', 'SakaEraCalendar', 'LastUsedFormat')
         )


### PR DESCRIPTION
- Fixed a typo: d-M-yyy -> d-M-yyyy
- Fixed the casing on the hours to be correct for two formats. (Hours can be either "HH" or "h", but "H" is invalid.)
- Expanded the list of valid date formats, mostly to add support for Month-Day-Year formats, but also added several new Day-Month-Year formats as well.

Here's the output from my Word document when I tested each of the formats below.  (Output is arranged in the order in which the array elements are specified):

```
8/6/2015
2015-08-06
2015-08
Aug-15
Aug-2015
1:19 PM
1:19:40 PM
13:19
13:19:40
Thursday 6 August 2015
6 August 2015
6-Aug-15
6 Aug. 15
6-8-15
6-8-15 1:19
6-8-15 1:19:40
6-8-15 1:19 PM
6-8-15 1:19:40 PM
6-8-15 13:19
6-8-15 13:19:40
6/8/15
6/8/15 1:19
6/8/15 1:19:40
6/8/15 1:19 PM
6/8/15 1:19:40 PM
6/8/15 13:19
6/8/15 13:19:40
6-8-2015
6-8-2015 1:19
6-8-2015 1:19:40
6-8-2015 1:19 PM
6-8-2015 1:19:40 PM
6-8-2015 13:19
6-8-2015 13:19:40
6/8/2015
6/8/2015 1:19
6/8/2015 1:19:40
6/8/2015 1:19 PM
6/8/2015 1:19:40 PM
6/8/2015 13:19
6/8/2015 13:19:40
Thursday, August 6 2015
August 6 2015
Aug-6-15
Aug. 6 15
8-6-15
8-6-15 1:19
8-6-15 1:19:40
8-6-15 1:19 PM
8-6-15 1:19:40 PM
8-6-15 13:19
8-6-15 13:19:40
8/6/15
8/6/15 1:19
8/6/15 1:19:40
8/6/15 1:19 PM
8/6/15 1:19:40 PM
8/6/15 13:19
8/6/15 13:19:40
8-6-2015
8-6-2015 1:19
8-6-2015 1:19:40
8-6-2015 1:19 PM
8-6-2015 1:19:40 PM
8-6-2015 13:19
8-6-2015 13:19:40
8/6/2015
8/6/2015 1:19
8/6/2015 1:19:40
8/6/2015 1:19 PM
8/6/2015 1:19:40 PM
8/6/2015 13:19
8/6/2015 13:19:40
```
