### PR TITLE
Fix Empty Dropdown Entry

### DIFF
--- a/src/PhpWord/Writer/Word2007/Element/FormField.php
+++ b/src/PhpWord/Writer/Word2007/Element/FormField.php
@@ -165,6 +165,9 @@ class FormField extends Text
         $xmlWriter->writeElementBlock('w:result', 'w:val', $value);
         $xmlWriter->writeElementBlock('w:default', 'w:val', $default);
         foreach ($entries as $entry) {
+            if ($entry == null || $entry == '') {
+                $entry = str_repeat(' ', self::FILLER_LENGTH);
+            }
             $xmlWriter->writeElementBlock('w:listEntry', 'w:val', $entry);
         }
         $xmlWriter->endElement();


### PR DESCRIPTION
Pad any empty dropdown entries we find so that xmlWriter doesn't
generate an error.  Fix for issue #583.
