### PR TITLE
Word 2007 Reader: Added support for ListItemRun

### DIFF
--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -140,14 +140,25 @@ abstract class AbstractPart
 
         // List item
         } elseif ($xmlReader->elementExists('w:pPr/w:numPr', $domNode)) {
-            $textContent = '';
+
             $numId = $xmlReader->getAttribute('w:val', $domNode, 'w:pPr/w:numPr/w:numId');
             $levelId = $xmlReader->getAttribute('w:val', $domNode, 'w:pPr/w:numPr/w:ilvl');
-            $nodes = $xmlReader->getElements('w:r', $domNode);
+            $nodes = $xmlReader->getElements('*', $domNode);
+
+            $listItemRun = $parent->addListItemRun($levelId, "PHPWordList{$numId}", $paragraphStyle);
+
             foreach ($nodes as $node) {
-                $textContent .= $xmlReader->getValue('w:t', $node);
+                $this->readRun(
+                    $xmlReader,
+                    $node,
+                    $listItemRun,
+                    $docPart,
+                    $paragraphStyle
+                );
             }
-            $parent->addListItem($textContent, $levelId, null, "PHPWordList{$numId}", $paragraphStyle);
+
+
+
 
         // Heading
         } elseif (!empty($headingMatches)) {


### PR DESCRIPTION
Some data is lost while reading lists with Word2007 parser.
Lists items are parsed as ListItem elements, this class is not meant to be a container, therefore if a list item contains a link or an image it will be ignored.

This fix wraps all child elements of a list item inside a ListItemRun, a more suitable class which is a container and that will allow us to hold, text, links, images, etc. inside as elements.
