### PR TITLE
Do Not Force Table Cells to Have Widths

### DIFF
--- a/src/PhpWord/Writer/Word2007/Style/Cell.php
+++ b/src/PhpWord/Writer/Word2007/Style/Cell.php
@@ -47,10 +47,12 @@ class Cell extends AbstractStyle
         $xmlWriter->startElement('w:tcPr');
 
         // Width
-        $xmlWriter->startElement('w:tcW');
-        $xmlWriter->writeAttribute('w:w', $this->width);
-        $xmlWriter->writeAttribute('w:type', 'dxa');
-        $xmlWriter->endElement(); // w:tcW
+        if ($this->width != null) {
+          $xmlWriter->startElement('w:tcW');
+          $xmlWriter->writeAttribute('w:w', $this->width);
+          $xmlWriter->writeAttribute('w:type', 'dxa');
+          $xmlWriter->endElement(); // w:tcW
+        }
 
         // Text direction
         $textDir = $style->getTextDirection();


### PR DESCRIPTION
Previously, all table cells had widths which resulted in Word
interpreting the cell as having a preferred width of zero, which
squished the cell contents.  This change does not write out the width
attribute when the width is zero, which then allows the cell's width to
truly be dynamic based on the contents of the cell.
