### PR TITLE
v0.13.* doesn't appear to exist yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Example:
 ```json
 {
     "require": {
-       "phpoffice/phpword": "v0.13.*"
+       "phpoffice/phpword": "v0.12.*"
     }
 }
 ```


### PR DESCRIPTION
"phpoffice/phpword": "v0.13.*" throws an error when trying to install with composer.

"The requested package phpoffice/phpword could not be found in any version, there may be a typo in the package name."