### PR TITLE
Bugfix #548: variables edited in word get messed with invisible XML

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -136,6 +136,43 @@ class TemplateProcessor
     }
 
     /**
+     * Clean all template parts of hidden XML within variables/placeholders.
+     *
+     * @return void
+     */
+    public function fixBrokenVariables()
+    {
+        $this->tempDocumentMainPart = $this->fixBrokenVariablesForPart($this->tempDocumentMainPart);
+
+        foreach ($this->tempDocumentHeaders as &$headerXML) {
+            $headerXML = $this->fixBrokenVariablesForPart($headerXML);
+        }
+
+        foreach ($this->tempDocumentFooters as &$footerXML) {
+            $headerXML = $this->fixBrokenVariablesForPart($footerXML);
+        }
+    }
+
+    /**
+     * Fix dirty hidden XML within variables in document part.
+     *
+     * @param string $documentPartXML said document part
+     *
+     * @return string
+     */
+    protected function fixBrokenVariablesForPart(string $documentPartXML)
+    {
+        return
+            preg_replace_callback(
+                '|\$([^{]*)(\{.*})|U',
+                function ($match) {
+                    return '$'.strip_tags($match[2]);
+                },
+                $documentPartXML
+            );
+    }
+
+    /**
      * @param mixed $macro
      * @param mixed $replace
      * @param integer $limit

--- a/tests/PhpWord/TemplateProcessorTest.php
+++ b/tests/PhpWord/TemplateProcessorTest.php
@@ -142,6 +142,30 @@ final class TemplateProcessorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers ::fixBrokenVariablesForPart
+     * @test
+     */
+    public function testFixBrokenVariablesForPart()
+    {
+        // accessing protected method via closure binding
+        $template = new TemplateProcessor();
+        $closure = function ($arg) {
+            return $this->fixBrokenVariablesForPart($arg);
+        };
+        $method = $closure->bindTo($template, $template);
+
+        // example XML found in actual word document
+        $actualDirtyXml = ''
+        .'<w:szCs w:val="18"/>${</w:rPr>sps_telephone}<w:t>'
+        .'$</w:t></w:r><w:r w:rsidR="00 C3064E" w:rsidRPr="00C3064E"><w:rPr><w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial"/><w:noProof/><w:sz w:val="20"/><w:szCs w:val="18"/></w:rPr><w:t>'
+        .'{sps</w:t></w:r><w:r w:rsidR="00243 BDA"><w:rPr><w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial"/><w:noProof/><w:sz w:val="20"/><w:szCs w:val="18"/></w:rPr><w:t>'
+        .'_</w:t></w:r><w:r w:rsidR="00C3064E" w:rsidRPr="00C3064E"><w:rPr><w:rFonts w:ascii="Arial" w:hAnsi="Arial" w:cs="Arial"/><w:noProof/><w:sz w:val="20"/><w:szCs w:val="18"/></w:rPr><w:t>nom}'.'${sps_mail}';
+
+        $expectedCleanXml = '<w:szCs w:val="18"/>${sps_telephone}<w:t>${sps_nom}${sps_mail}';
+        $this->assertEquals($method($actualDirtyXml), $expectedCleanXml);
+    }
+
+    /**
      * @civers ::setValue
      * @covers ::cloneRow
      * @covers ::saveAs


### PR DESCRIPTION
Hi,

So in our experience with Word templates, whenever someone edits a variable name without rewriting it entirely (the whole "${variable}"), it becomes a mess with invisible XML, preventing the variable to be replaced with intended content later.

I wrote this to clean Word templates variables before calling ``setValue()``. It should simply be used this way :
```php
$template = new TemplateProcessor(...);
$template->fixBrokenVariables();
$template->setValue(...);
// etc.
```
I was not sure wether I should include that in the constructor (a document *should* be clean by default I guess), but since it could be too much on a lot of documents maybe (?), I made a separate function so you can call it when you need it.

What do you think, @kaystrobach ?

(I'm new to Github, tell me if I did something wrong.)