### PR TITLE
10% performance gain in TemplateProcessor::setValue() for limited replacement

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -411,9 +411,13 @@ class TemplateProcessor
         if (self::MAXIMUM_REPLACEMENTS_DEFAULT === $limit) {
             return str_replace($search, $replace, $documentPartXML);
         } else {
-            $regExpDelim = '/';
-            $escapedSearch = preg_quote($search, $regExpDelim);
-            return preg_replace("{$regExpDelim}{$escapedSearch}{$regExpDelim}u", $replace, $documentPartXML, $limit);
+            $searchOccurencePosition = strpos($documentPartXML, $search);
+            while ($limit > 0 && $searchOccurencePosition !== false) {
+                $documentPartXML = substr($documentPartXML, 0, $searchOccurencePosition).$replace.substr($documentPartXML, $searchOccurencePosition + strlen($search));
+                $searchOccurencePosition = strpos($documentPartXML, $search, $searchOccurencePosition);
+                $limit--;
+            }
+            return $documentPartXML;
         }
     }
 


### PR DESCRIPTION
Hi

This code has a better performance compared to preg_replace. Unfortunately, it is less readable because not all internal string manipulation functions can handle UTF-8. 

Here are some screenshots of XDebug's profiler before my change

![image](https://cloud.githubusercontent.com/assets/14139801/12647680/a1f6534a-c5d6-11e5-89d7-e3d5bd01a70d.png)

and after

![image](https://cloud.githubusercontent.com/assets/14139801/12647690/b173cc26-c5d6-11e5-83b2-fdb41ae7b9fa.png)

Thanks for this great library.