### PR TITLE
Resolves certain HTML tags rendering no output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Place announcement text here.
 - Improved error message for the case when `autoload.php` is not found. - @RomanSyroeshko #371
 - Renamed the `align` option of `NumberingLevel`, `Frame`, `Table`, and `Paragraph` styles into `alignment`. - @RomanSyroeshko
 - Improved performance of `TemplateProcessor::setValue()`. - @kazitanvirahsan #614, #617
+- Fixed some HTML tags not rendering any output (p, header & table) - #257, #324 - @twmobius and @garethellis 
 
 ### Deprecated
 - `getAlign` and `setAlign` methods of `NumberingLevel`, `Frame`, `Table`, and `Paragraph` styles.

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -177,9 +177,7 @@ class Html
             $cNodes = $node->childNodes;
             if (count($cNodes) > 0) {
                 foreach ($cNodes as $cNode) {
-                    if ($element instanceof AbstractContainer) {
-                        self::parseNode($cNode, $element, $styles, $data);
-                    }
+                    self::parseNode($cNode, $element, $styles, $data);
                 }
             }
         }
@@ -232,11 +230,9 @@ class Html
     {
         $styles['font'] = self::parseInlineStyle($node, $styles['font']);
 
-        // Commented as source of bug #257. `method_exists` doesn't seems to work properly in this case.
-        // @todo Find better error checking for this one
-        // if (method_exists($element, 'addText')) {
+        if( is_callable(array($element, 'addText')) ) {
             $element->addText($node->nodeValue, $styles['font'], $styles['paragraph']);
-        // }
+        }
 
         return null;
     }

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -230,7 +230,7 @@ class Html
     {
         $styles['font'] = self::parseInlineStyle($node, $styles['font']);
 
-        if( is_callable(array($element, 'addText')) ) {
+        if (is_callable(array($element, 'addText'))) {
             $element->addText($node->nodeValue, $styles['font'], $styles['paragraph']);
         }
 

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -177,7 +177,9 @@ class Html
             $cNodes = $node->childNodes;
             if (count($cNodes) > 0) {
                 foreach ($cNodes as $cNode) {
-                    self::parseNode($cNode, $element, $styles, $data);
+                    if ($element instanceof AbstractContainer) {
+                        self::parseNode($cNode, $element, $styles, $data);
+                    }
                 }
             }
         }
@@ -230,9 +232,11 @@ class Html
     {
         $styles['font'] = self::parseInlineStyle($node, $styles['font']);
 
-        if (is_callable(array($element, 'addText'))) {
+        // Commented as source of bug #257. `method_exists` doesn't seems to work properly in this case.
+        // @todo Find better error checking for this one
+        // if (method_exists($element, 'addText')) {
             $element->addText($node->nodeValue, $styles['font'], $styles['paragraph']);
-        }
+        // }
 
         return null;
     }


### PR DESCRIPTION
This is a continuation of PR #416 which appears to have been abandoned by @twmobius. The commits herein are just the same commits that he submitted, but I have addressed the concerns raised by @Progi1984 in [this comment](https://github.com/PHPOffice/PHPWord/pull/416#issuecomment-66249254).

This PR should resolve #257 and #324.
