### PR TITLE
Add TextRun as container for CheckBox

### DIFF
--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -207,7 +207,7 @@ abstract class AbstractContainer extends AbstractElement
             'ListItem'      => array('Section', 'Header', 'Footer', 'Cell', 'TextBox'),
             'ListItemRun'   => array('Section', 'Header', 'Footer', 'Cell', 'TextBox'),
             'Table'         => array('Section', 'Header', 'Footer', 'Cell', 'TextBox'),
-            'CheckBox'      => array('Section', 'Header', 'Footer', 'Cell'),
+            'CheckBox'      => array('Section', 'Header', 'Footer', 'Cell', 'TextRun'),
             'TextBox'       => array('Section', 'Header', 'Footer', 'Cell'),
             'Footnote'      => array('Section', 'TextRun', 'Cell'),
             'Endnote'       => array('Section', 'TextRun', 'Cell'),


### PR DESCRIPTION
This fixes exception if you want to put checkbox inside textrun which is inside a table cell. See code above.

``` php
$table = $section->addTable();
$table->addRow();
$cell = $table->addCell(2000);
$textRun = $cell->addTextRun();
$textRun->addCheckBox('test', ' yes');
$textRun->addCheckBox('test', ' no');
```
