### PR TITLE
Add missing Style getters & setters for Element classes.

### DIFF
--- a/src/PhpWord/Element/Link.php
+++ b/src/PhpWord/Element/Link.php
@@ -80,8 +80,7 @@ class Link extends AbstractElement
     {
         $this->source = String::toUTF8($source);
         $this->text = is_null($text) ? $this->source : String::toUTF8($text);
-        $this->fontStyle = $this->setNewStyle(new Font('text'), $fontStyle);
-        $this->paragraphStyle = $this->setNewStyle(new Paragraph(), $paragraphStyle);
+        $this->setFontStyle($fontStyle, $paragraphStyle);
         $this->internal = $internal;
         return $this;
     }
@@ -107,6 +106,21 @@ class Link extends AbstractElement
     }
 
     /**
+     * Set Text style
+     *
+     * @param string|array|\PhpOffice\PhpWord\Style\Font $style
+     * @param string|array|\PhpOffice\PhpWord\Style\Paragraph $paragraphStyle
+     * @return string|\PhpOffice\PhpWord\Style\Font
+     */
+    public function setFontStyle($style = null, $paragraphStyle = null)
+    {
+        $this->fontStyle = $this->setNewStyle(new Font('text'), $style);
+        $this->paragraphStyle = $this->setNewStyle(new Paragraph(), $paragraphStyle);
+
+        return $this->fontStyle;
+    }
+
+    /**
      * Get Text style
      *
      * @return string|\PhpOffice\PhpWord\Style\Font
@@ -114,6 +128,19 @@ class Link extends AbstractElement
     public function getFontStyle()
     {
         return $this->fontStyle;
+    }
+
+    /**
+     * Set Paragraph style
+     *
+     * @param string|array|\PhpOffice\PhpWord\Style\Paragraph $style
+     * @return string|\PhpOffice\PhpWord\Style\Paragraph
+     */
+    public function setParagraphStyle($style = null)
+    {
+        $this->paragraphStyle = $this->setNewStyle(new Paragraph(), $style);
+
+        return $this->paragraphStyle;
     }
 
     /**

--- a/src/PhpWord/Element/ListItem.php
+++ b/src/PhpWord/Element/ListItem.php
@@ -130,7 +130,7 @@ class ListItem extends AbstractElement
      */
     public function getParagraphStyle()
     {
-        return $this->getParagraphStyle();
+        return $this->getTextObject()->getParagraphStyle();
     }
 
     /**

--- a/src/PhpWord/Element/ListItem.php
+++ b/src/PhpWord/Element/ListItem.php
@@ -52,20 +52,32 @@ class ListItem extends AbstractElement
      * @param string $text
      * @param int $depth
      * @param mixed $fontStyle
-     * @param array|string|null $listStyle
+     * @param mixed $listStyle
      * @param mixed $paragraphStyle
      */
     public function __construct($text, $depth = 0, $fontStyle = null, $listStyle = null, $paragraphStyle = null)
     {
+        $this->setStyle($listStyle);
         $this->textObject = new Text(String::toUTF8($text), $fontStyle, $paragraphStyle);
         $this->depth = $depth;
+    }
 
+    /**
+     * Set style
+     *
+     * @param string|array|\PhpOffice\PhpWord\Style\ListItem $style
+     * @return string|\PhpOffice\PhpWord\Style\ListItem
+     */
+    public function setStyle($style)
+    {
         // Version >= 0.10.0 will pass numbering style name. Older version will use old method
-        if (!is_null($listStyle) && is_string($listStyle)) {
-            $this->style = new ListItemStyle($listStyle);
+        if (!is_null($style) && is_string($style)) {
+            $this->style = new ListItemStyle($style);
         } else {
-            $this->style = $this->setNewStyle(new ListItemStyle(), $listStyle, true);
+            $this->style = $this->setNewStyle(new ListItemStyle(), $style, true);
         }
+
+        return $this->style;
     }
 
     /**
@@ -76,6 +88,49 @@ class ListItem extends AbstractElement
     public function getStyle()
     {
         return $this->style;
+    }
+
+    /**
+     * Set Text style
+     *
+     * @param string|array|\PhpOffice\PhpWord\Style\Font $style
+     * @param string|array|\PhpOffice\PhpWord\Style\Paragraph $paragraphStyle
+     * @return string|\PhpOffice\PhpWord\Style\Font
+     */
+    public function setFontStyle($style = null, $paragraphStyle = null)
+    {
+        return $this->getTextObject()->setFontStyle($style, $paragraphStyle);
+    }
+
+    /**
+     * Get Text style
+     *
+     * @return string|\PhpOffice\PhpWord\Style\Font
+     */
+    public function getFontStyle()
+    {
+        return $this->getTextObject()->getFontStyle();
+    }
+
+    /**
+     * Set Paragraph style
+     *
+     * @param string|array|\PhpOffice\PhpWord\Style\Paragraph $style
+     * @return string|\PhpOffice\PhpWord\Style\Paragraph
+     */
+    public function setParagraphStyle($style = null)
+    {
+        $this->getTextObject()->setParagraphStyle($style);
+    }
+
+    /**
+     * Get Paragraph style
+     *
+     * @return string|\PhpOffice\PhpWord\Style\Paragraph
+     */
+    public function getParagraphStyle()
+    {
+        return $this->getParagraphStyle();
     }
 
     /**

--- a/src/PhpWord/Element/TextRun.php
+++ b/src/PhpWord/Element/TextRun.php
@@ -43,7 +43,20 @@ class TextRun extends AbstractContainer
      */
     public function __construct($paragraphStyle = null)
     {
-        $this->paragraphStyle = $this->setNewStyle(new Paragraph(), $paragraphStyle);
+        $this->setParagraphStyle($paragraphStyle);
+    }
+
+    /**
+     * Set Paragraph style
+     *
+     * @param string|array|\PhpOffice\PhpWord\Style\Paragraph $style
+     * @return string|\PhpOffice\PhpWord\Style\Paragraph
+     */
+    public function setParagraphStyle($style = null)
+    {
+        $this->paragraphStyle = $this->setNewStyle(new Paragraph(), $style);
+
+        return $this->paragraphStyle;
     }
 
     /**


### PR DESCRIPTION
In my project, I extended PHPWord's functionality to create universal "paragraph" objects (AKA elements that accept paragraph styles). I needed to do this so that I could add styles (namely `keepNext`) to the last paragraph of set of paragraphs. When doing this, I noticed that a lot of elements that accepted paragraph styles on creation didn't have getter/setter functions for further updating these styles. See the errors thrown by my IDE below:

![screenshot from 2016-04-07 17 56 38](https://cloud.githubusercontent.com/assets/3789442/14369611/3ca7127a-fcec-11e5-9bb2-92d91300a2c7.png)

My project currently only uses `Element\Text`, `Element\TextRun`, `Element\Link`, and `Element\ListItem`. Because of this, the following PR only has commits to make sure these 4 classes have the relevant getter/setter functions for all styles. I am trying to get a big update to production ASAP, so this is all I can do for right now (i.e. `Element\CheckBox` is missing still).

Let me know if you want to wait on this until I finish the rest of the classes, since I'd be more than happy too. Also, I tried to follow your method style from `Element\Text` even though there were some things I wanted to tweak (didn't want to go refactor crazy on my first PR).

Thanks for the great library, hope this helps!
