### PR TITLE
Save PNG alpha information when using remote images.

### DIFF
--- a/src/PhpWord/Element/Image.php
+++ b/src/PhpWord/Element/Image.php
@@ -335,6 +335,10 @@ class Image extends AbstractElement
         // Read image binary data and convert to hex/base64 string
         if ($this->sourceType == self::SOURCE_GD) {
             $imageResource = call_user_func($this->imageCreateFunc, $actualSource);
+            if ($this->imageType === 'image/png') {
+                // PNG images need to preserve alpha channel information
+                imagesavealpha($imageResource, true);
+            }
             ob_start();
             call_user_func($this->imageFunc, $imageResource);
             $imageBinary = ob_get_contents();

--- a/src/PhpWord/Writer/AbstractWriter.php
+++ b/src/PhpWord/Writer/AbstractWriter.php
@@ -360,6 +360,10 @@ abstract class AbstractWriter implements WriterInterface
             // Retrive GD image content or get local media
             if (isset($element['isMemImage']) && $element['isMemImage']) {
                 $image = call_user_func($element['createFunction'], $element['source']);
+                if ($element['imageType'] === 'image/png') {
+                    // PNG images need to preserve alpha channel information
+                    imagesavealpha($image, true);
+                }
                 ob_start();
                 call_user_func($element['imageFunction'], $image);
                 $imageContents = ob_get_contents();


### PR DESCRIPTION
PNG images downloaded from remote sources can be either blurry or, worse, very glitched. This is because [`imagesavealpha($image, true)`](http://php.net/manual/en/function.imagesavealpha.php) is not run automatically when PNG images are downloaded, created, and saved locally for file creation.

RE: #667 
