### PR TITLE
v0.13.* -> v0.12.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Example:
 ```json
 {
     "require": {
-       "phpoffice/phpword": "v0.13.*"
+       "phpoffice/phpword": "v0.12.*"
     }
 }
 ```


### PR DESCRIPTION
There is no `v0.13.x` release yet. I suppose this is a mistake in readme.

See more: https://github.com/PHPOffice/PHPWord/issues/786
