### PR TITLE
Update Html.php

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -58,7 +58,7 @@ class Html
         // Load DOM
         $dom = new \DOMDocument();
         $dom->preserveWhiteSpace = true;
-        $dom->loadXML($html);
+        $dom->loadXML($html,LIBXML_NOCDATA);
         $node = $dom->getElementsByTagName('body');
 
         self::parseNode($node->item(0), $element);


### PR DESCRIPTION
LIBXML_NOCDATA options for loadXML to support the addition of <![CDATA[_lt_]]> tags as the &lt; etc. do not work as such in the master branch. See issue https://github.com/PHPOffice/PHPWord/issues/791