### PR TITLE
Add info about Invalid image

### DIFF
--- a/src/PhpWord/Element/Image.php
+++ b/src/PhpWord/Element/Image.php
@@ -383,7 +383,7 @@ class Image extends AbstractElement
             $imageData = @getimagesize($source);
         }
         if (!is_array($imageData)) {
-            throw new InvalidImageException();
+            throw new InvalidImageException(sprintf('Invalid image: %s', $source));
         }
         list($actualWidth, $actualHeight, $imageType) = $imageData;
 


### PR DESCRIPTION
if there are many images in document are used and one of them throws `InvalidImageException` it is very difficult to detect which one without any message here...