### PR TITLE
Add Style import

### DIFF
--- a/src/PhpWord/Reader/MsDoc.php
+++ b/src/PhpWord/Reader/MsDoc.php
@@ -20,6 +20,7 @@ namespace PhpOffice\PhpWord\Reader;
 use PhpOffice\Common\Drawing;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Shared\OLERead;
+use PhpOffice\PhpWord\Style;
 
 /**
  * Reader for Word97


### PR DESCRIPTION
Add the Style import to MsDoc.php so Style is correctly referenced later on in the [switch statement](https://github.com/PHPOffice/PHPWord/blob/master/src/PhpWord/Reader/MsDoc.php#L1673) located here.
