### PR TITLE
use missing namespace for PhpOffice\PhpWord\Style

### DIFF
--- a/src/PhpWord/Reader/MsDoc.php
+++ b/src/PhpWord/Reader/MsDoc.php
@@ -20,6 +20,7 @@ namespace PhpOffice\PhpWord\Reader;
 use PhpOffice\Common\Drawing;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Shared\OLERead;
+use PhpOffice\PhpWord\Style;
 
 /**
  * Reader for Word97


### PR DESCRIPTION
the PhpOffice\PhpWord\Style\Font class wasn't found inside the namespace of the file

simply added use PhpOffice\PhpWord\Style to fix the issue
