### PR TITLE
Fixes PHPOffice/PHPWord#927

### DIFF
--- a/src/PhpWord/Writer/Word2007/Part/Settings.php
+++ b/src/PhpWord/Writer/Word2007/Part/Settings.php
@@ -106,7 +106,7 @@ class Settings extends AbstractPart
             'w:themeFontLang' => array('@attributes' => array('w:val' => 'en-US')),
             'w:decimalSymbol' => array('@attributes' => array('w:val' => '.')),
             'w:listSeparator' => array('@attributes' => array('w:val' => ';')),
-            'w:compat' => '',
+            'w:compat' => array(),
             'm:mathPr' => array(
                 'm:mathFont' => array('@attributes' => array('m:val' => 'Cambria Math')),
                 'm:brkBin' => array('@attributes' => array('m:val' => 'before')),

--- a/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
@@ -64,5 +64,6 @@ class SettingsTest extends \PHPUnit_Framework_TestCase
 
         $path = '/w:settings/w:compat/w:compatSetting';
         $this->assertTrue($doc->elementExists($path, $file));
+        $this->assertEquals($phpWord->getCompatibility()->getOoxmlVersion(), 15);
     }
 }


### PR DESCRIPTION
The test works because the warning is only raised once `$phpWord->getCompatibility()->getOoxmlVersion()` is no longer null. 
