### PR TITLE
support for Image creation from string image data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ Maintenance release. This release is focused primarily on `TemplateProcessor`.
 
 
 
-0.12.0 (3 January 2015)
+v0.12.0 (3 January 2015)
 -----------------------
 This release added form fields (textinput, checkbox, and dropdown), drawing shapes (arc, curve, line, polyline, rect, oval), and basic 2D chart (pie, doughnut, bar, line, area, scatter, radar) elements along with some new styles. Basic MsDoc reader is introduced.
 
@@ -125,7 +125,7 @@ This release added form fields (textinput, checkbox, and dropdown), drawing shap
 
 
 
-0.11.1 (2 June 2014)
+v0.11.1 (2 June 2014)
 --------------------
 This is an immediate bugfix release for HTML reader.
 
@@ -133,7 +133,7 @@ This is an immediate bugfix release for HTML reader.
 
 
 
-0.11.0 (1 June 2014)
+v0.11.0 (1 June 2014)
 --------------------
 This release marked the change of PHPWord license from LGPL 2.1 to LGPL 3. Four new elements were added: TextBox, ListItemRun, Field, and Line. Relative and absolute positioning for images and textboxes were added. Writer classes were refactored into parts, elements, and styles. ODT and RTF features were enhanced. Ability to add elements to PHPWord object via HTML were implemented. RTF and HTML reader were initiated.
 
@@ -197,7 +197,7 @@ This release marked the change of PHPWord license from LGPL 2.1 to LGPL 3. Four 
 
 
 
-0.10.1 (21 May 2014)
+v0.10.1 (21 May 2014)
 --------------------
 This is a bugfix release for `php-zip` requirement in Composer.
 
@@ -205,7 +205,7 @@ This is a bugfix release for `php-zip` requirement in Composer.
 
 
 
-0.10.0 (4 May 2014)
+v0.10.0 (4 May 2014)
 -------------------
 This release marked heavy refactorings on internal code structure with the creation of some abstract classes to reduce code duplication. `Element` subnamespace is introduced in this release to replace `Section`. Word2007 reader capability is greatly enhanced. Endnote is introduced. List numbering is now customizable. Basic HTML and PDF writing support is enabled. Basic ODText reader is introduced.
 
@@ -289,7 +289,7 @@ This release marked heavy refactorings on internal code structure with the creat
 
 
 
-0.9.1 (27 Mar 2014)
+v0.9.1 (27 Mar 2014)
 -------------------
 This is a bugfix release for PSR-4 compatibility.
 
@@ -297,7 +297,7 @@ This is a bugfix release for PSR-4 compatibility.
 
 
 
-0.9.0 (26 Mar 2014)
+v0.9.0 (26 Mar 2014)
 -------------------
 This release marked the transformation to namespaces (PHP 5.3+).
 
@@ -319,7 +319,7 @@ This release marked the transformation to namespaces (PHP 5.3+).
 
 
 
-0.8.1 (17 Mar 2014)
+v0.8.1 (17 Mar 2014)
 -------------------
 This is a bugfix release for image detection functionality.
 
@@ -327,7 +327,7 @@ This is a bugfix release for image detection functionality.
 
 
 
-0.8.0 (15 Mar 2014)
+v0.8.0 (15 Mar 2014)
 -------------------
 This release merged a lot of improvements from the community. Unit tests introduced in this release and has reached 90% code coverage.
 
@@ -375,7 +375,7 @@ This release merged a lot of improvements from the community. Unit tests introdu
 
 
 
-0.7.0 (28 Jan 2014)
+v0.7.0 (28 Jan 2014)
 -------------------
 This is the first release after a long development hiatus in [CodePlex](https://phpword.codeplex.com/). This release initialized ODT and RTF Writer, along with some other new features for the existing Word2007 Writer, e.g. tab, multiple header, rowspan and colspan. [Composer](https://packagist.org/packages/phpoffice/phpword) and [Travis](https://travis-ci.org/PHPOffice/PHPWord) were added.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 v0.13.0 (31 July 2016)
 -------------------
-This release brings several improvements in `TemplateProcessor`,
-automatic output escaping feature for OOXML, ODF, HTML, and RTF (turned off, by default). It also
-introduces constants for horizontal alignment options, and resolves some issues with PHP 7.
+This release brings several improvements in `TemplateProcessor`, automatic output escaping feature for OOXML, ODF, HTML, and RTF (turned off, by default).
+It also introduces constants for horizontal alignment options, and resolves some issues with PHP 7.
 Manual installation feature has been dropped since the release. Please, use [Composer](https://getcomposer.org/) to install PHPWord.
 
 ### Added

--- a/samples/Sample_27_Field.php
+++ b/samples/Sample_27_Field.php
@@ -14,10 +14,18 @@ $section->addText('Date field:');
 $section->addField('DATE', array('dateformat' => 'dddd d MMMM yyyy H:mm:ss'), array('PreserveFormat'));
 
 $section->addText('Page field:');
-$section->addField('PAGE', array('format' => 'ArabicDash'));
+$section->addField('PAGE', array('format' => 'Arabic'));
 
 $section->addText('Number of pages field:');
-$section->addField('NUMPAGES', array('format' => 'Arabic', 'numformat' => '0,00'), array('PreserveFormat'));
+$section->addField('NUMPAGES', array('numformat' => '0,00', 'format' => 'Arabic'), array('PreserveFormat'));
+
+$textrun = $section->addTextRun();
+$textrun->addText('An index field is ');
+$textrun->addField('XE', array(), array('Bold'), 'FieldValue');
+$textrun->addText('here:');
+
+$section->addText('The actual index:');
+$section->addField('INDEX', array(), array('PreserveFormat'));
 
 $textrun = $section->addTextRun(array('alignment' => \PhpOffice\PhpWord\SimpleType\Jc::CENTER));
 $textrun->addText('This is the date of lunar calendar ');

--- a/src/PhpWord/Element/Field.php
+++ b/src/PhpWord/Element/Field.php
@@ -40,7 +40,8 @@ class Field extends AbstractElement
         ),
         'NUMPAGES'=>array(
            'properties'=>array(
-               'format' => array('Arabic', 'ArabicDash', 'alphabetic', 'ALPHABETIC', 'roman', 'ROMAN'),
+               'format' => array('Arabic', 'ArabicDash', 'CardText', 'DollarText', 'Ordinal', 'OrdText',
+                   'alphabetic', 'ALPHABETIC', 'roman', 'ROMAN', 'Caps', 'FirstCap', 'Lower', 'Upper'),
                'numformat' => array('0', '0,00', '#.##0', '#.##0,00', '€ #.##0,00(€ #.##0,00)', '0%', '0,00%')
            ),
            'options'=>array('PreserveFormat')
@@ -52,6 +53,14 @@ class Field extends AbstractElement
                     'h:mm am/pm', 'h:mm:ss am/pm', 'HH:mm', 'HH:mm:ss')
             ),
             'options'=>array('PreserveFormat', 'LunarCalendar', 'SakaEraCalendar', 'LastUsedFormat')
+        ),
+        'XE'=>array(
+            'properties' => array(),
+            'options' => array('Bold', 'Italic')
+        ),
+        'INDEX'=>array(
+            'properties' => array(),
+            'options'=>array('PreserveFormat')
         )
     );
 
@@ -61,6 +70,13 @@ class Field extends AbstractElement
      * @var string
      */
     protected $type;
+
+    /**
+     * Field text
+     *
+     * @var string
+     */
+    protected $text;
 
     /**
      * Field properties
@@ -83,11 +99,12 @@ class Field extends AbstractElement
      * @param array $properties
      * @param array $options
      */
-    public function __construct($type = null, $properties = array(), $options = array())
+    public function __construct($type = null, $properties = array(), $options = array(), $text = null)
     {
         $this->setType($type);
         $this->setProperties($properties);
         $this->setOptions($options);
+        $this->setText($text);
     }
 
     /**
@@ -183,5 +200,36 @@ class Field extends AbstractElement
     public function getOptions()
     {
         return $this->options;
+    }
+
+    /**
+     * Set Field text
+     *
+     * @param string $text
+     *
+     * @return string
+     * 
+     * @throws \InvalidArgumentException
+     */
+    public function setText($text)
+    {
+        if (isset($text)) {
+            if (is_string($text)) {
+                $this->text = $text;
+            } else {
+                throw new \InvalidArgumentException("Invalid text");
+            }
+        }
+        return $this->text;
+    }
+
+    /**
+     * Get Field text
+     *
+     * @return string
+     */
+    public function getText()
+    {
+        return $this->text;
     }
 }

--- a/src/PhpWord/Element/Image.php
+++ b/src/PhpWord/Element/Image.php
@@ -35,6 +35,7 @@ class Image extends AbstractElement
     const SOURCE_LOCAL = 'local'; // Local images
     const SOURCE_GD = 'gd'; // Generated using GD
     const SOURCE_ARCHIVE = 'archive'; // Image in archives zip://$archive#$image
+    const SOURCE_STRING = 'string'; // Image from string
 
     /**
      * Image source
@@ -379,6 +380,8 @@ class Image extends AbstractElement
         // Check image data
         if ($this->sourceType == self::SOURCE_ARCHIVE) {
             $imageData = $this->getArchiveImageSize($source);
+        } else if ($this->sourceType == self::SOURCE_STRING) {
+            $imageData = $this->getStringImageSize($source);
         } else {
             $imageData = @getimagesize($source);
         }
@@ -416,9 +419,15 @@ class Image extends AbstractElement
         } elseif (strpos($source, 'zip://') !== false) {
             $this->memoryImage = false;
             $this->sourceType = self::SOURCE_ARCHIVE;
+        } elseif (filter_var($source, FILTER_VALIDATE_URL) !== false) {
+            $this->memoryImage = true;
+            $this->sourceType = self::SOURCE_GD;
+        } elseif (@file_exists($source)) {
+            $this->memoryImage = false;
+            $this->sourceType = self::SOURCE_LOCAL;
         } else {
-            $this->memoryImage = (filter_var($source, FILTER_VALIDATE_URL) !== false);
-            $this->sourceType = $this->memoryImage ? self::SOURCE_GD : self::SOURCE_LOCAL;
+            $this->memoryImage = true;
+            $this->sourceType = self::SOURCE_STRING;
         }
     }
 
@@ -458,6 +467,24 @@ class Image extends AbstractElement
         }
 
         return $imageData;
+    }
+
+    /**
+     * get image size from string
+     * 
+     * @param string $source
+     * 
+     * @codeCoverageIgnore this method is just a replacement for getimagesizefromstring which exists only as of PHP 5.4
+     */
+    private function getStringImageSize($source)
+    {
+        if (!function_exists('getimagesizefromstring')) {
+            $uri = 'data://application/octet-stream;base64,'  . base64_encode($source);
+            return @getimagesize($uri);
+        } else {
+            return @getimagesizefromstring($source);
+        }
+        return false;
     }
 
     /**

--- a/src/PhpWord/Style/Font.php
+++ b/src/PhpWord/Style/Font.php
@@ -725,7 +725,7 @@ class Font extends AbstractStyle
     }
 
     /**
-     * Set shading
+     * Set Paragraph
      *
      * @param mixed $value
      * @return self

--- a/src/PhpWord/Writer/Word2007/Element/Field.php
+++ b/src/PhpWord/Writer/Word2007/Element/Field.php
@@ -38,12 +38,17 @@ class Field extends Text
         }
 
         $instruction = ' ' . $element->getType() . ' ';
+        if ($element->getText() != null) {
+            $instruction .= '"' . $element->getText() . '" ';
+        }
         $properties  = $element->getProperties();
         foreach ($properties as $propkey => $propval) {
             switch ($propkey) {
                 case 'format':
-                case 'numformat':
                     $instruction .= '\* ' . $propval . ' ';
+                    break;
+                case 'numformat':
+                    $instruction .= '\# ' . $propval . ' ';
                     break;
                 case 'dateformat':
                     $instruction .= '\@ "' . $propval . '" ';
@@ -66,22 +71,49 @@ class Field extends Text
                 case 'LastUsedFormat':
                     $instruction .= '\l ';
                     break;
+                case 'Bold':
+                    $instruction .= '\b ';
+                    break;
+                case 'Italic':
+                    $instruction .= '\i ';
+                    break;
             }
         }
 
         $this->startElementP();
 
-        $xmlWriter->startElement('w:fldSimple');
-        $xmlWriter->writeAttribute('w:instr', $instruction);
+        $xmlWriter->startElement('w:r');
+        $xmlWriter->startElement('w:fldChar');
+        $xmlWriter->writeAttribute('w:fldCharType', 'begin');
+        $xmlWriter->endElement(); // w:fldChar
+        $xmlWriter->endElement(); // w:r
+
+        $xmlWriter->startElement('w:r');
+        $xmlWriter->startElement('w:instrText');
+        $xmlWriter->writeAttribute('xml:space', 'preserve');
+        $xmlWriter->text($instruction);
+        $xmlWriter->endElement(); // w:instrText
+        $xmlWriter->endElement(); // w:r
+
+        $xmlWriter->startElement('w:r');
+        $xmlWriter->startElement('w:fldChar');
+        $xmlWriter->writeAttribute('w:fldCharType', 'separate');
+        $xmlWriter->endElement(); // w:fldChar
+        $xmlWriter->endElement(); // w:r
+
         $xmlWriter->startElement('w:r');
         $xmlWriter->startElement('w:rPr');
         $xmlWriter->startElement('w:noProof');
         $xmlWriter->endElement(); // w:noProof
         $xmlWriter->endElement(); // w:rPr
-
         $xmlWriter->writeElement('w:t', '1');
         $xmlWriter->endElement(); // w:r
-        $xmlWriter->endElement(); // w:fldSimple
+        
+        $xmlWriter->startElement('w:r');
+        $xmlWriter->startElement('w:fldChar');
+        $xmlWriter->writeAttribute('w:fldCharType', 'end');
+        $xmlWriter->endElement(); // w:fldChar
+        $xmlWriter->endElement(); // w:r
 
         $this->endElementP(); // w:p
     }

--- a/src/PhpWord/Writer/Word2007/Part/Styles.php
+++ b/src/PhpWord/Writer/Word2007/Part/Styles.php
@@ -170,6 +170,9 @@ class Styles extends AbstractPart
             $xmlWriter->startElement('w:link');
             $xmlWriter->writeAttribute('w:val', $styleLink);
             $xmlWriter->endElement();
+        } else if (!is_null($paragraphStyle)) {
+        	// if type is 'paragraph' it should have a styleId
+            $xmlWriter->writeAttribute('w:styleId', $styleName);
         }
 
         // Style name
@@ -178,7 +181,9 @@ class Styles extends AbstractPart
         $xmlWriter->endElement();
 
         // Parent style
-        $xmlWriter->writeElementIf(!is_null($paragraphStyle), 'w:basedOn', 'w:val', 'Normal');
+        if (!is_null($paragraphStyle)) {
+             $xmlWriter->writeElementBlock('w:basedOn', 'w:val', $paragraphStyle->getStyleName());
+        }
 
         // w:pPr
         if (!is_null($paragraphStyle)) {

--- a/src/PhpWord/Writer/Word2007/Part/Styles.php
+++ b/src/PhpWord/Writer/Word2007/Part/Styles.php
@@ -171,7 +171,7 @@ class Styles extends AbstractPart
             $xmlWriter->writeAttribute('w:val', $styleLink);
             $xmlWriter->endElement();
         } else if (!is_null($paragraphStyle)) {
-        	// if type is 'paragraph' it should have a styleId
+            // if type is 'paragraph' it should have a styleId
             $xmlWriter->writeAttribute('w:styleId', $styleName);
         }
 

--- a/tests/PhpWord/Element/FieldTest.php
+++ b/tests/PhpWord/Element/FieldTest.php
@@ -71,6 +71,20 @@ class FieldTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * New instance with type and properties and options and text
+     */
+    public function testConstructWithTypePropertiesOptionsText()
+    {
+        $oField = new Field('XE', array(), array('Bold'), 'FieldValue');
+
+        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Field', $oField);
+        $this->assertEquals('XE', $oField->getType());
+        $this->assertEquals(array(), $oField->getProperties());
+        $this->assertEquals(array('Bold'), $oField->getOptions());
+        $this->assertEquals('FieldValue', $oField->getText());
+    }
+
+    /**
      * Test setType exception
      *
      * @expectedException \InvalidArgumentException

--- a/tests/PhpWord/Element/ImageTest.php
+++ b/tests/PhpWord/Element/ImageTest.php
@@ -156,4 +156,57 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $image = new Image("zip://{$archiveFile}#{$imageFile}");
         $this->assertEquals('image/jpeg', $image->getImageType());
     }
+
+    /**
+     * Test getting image as string
+     */
+    public function testImageAsStringFromFile()
+    {
+        $image = new Image(__DIR__ . '/../_files/images/earth.jpg');
+
+        $this->assertNotNull($image->getImageStringData());
+        $this->assertNotNull($image->getImageStringData(true));
+    }
+
+    /**
+     * Test getting image from zip as string
+     */
+    public function testImageAsStringFromZip()
+    {
+        $archiveFile = __DIR__ . '/../_files/documents/reader.docx';
+        $imageFile = 'word/media/image1.jpeg';
+        $image = new Image("zip://{$archiveFile}#{$imageFile}");
+
+        $this->assertNotNull($image->getImageStringData());
+        $this->assertNotNull($image->getImageStringData(true));
+    }
+
+    /**
+     * Test construct from string
+     */
+    public function testConstructFromString()
+    {
+        $source = file_get_contents(__DIR__ . '/../_files/images/earth.jpg');
+
+        $image = new Image($source);
+        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $image);
+        $this->assertEquals($source, $image->getSource());
+        $this->assertEquals(md5($source), $image->getMediaId());
+        $this->assertEquals('image/jpeg', $image->getImageType());
+        $this->assertEquals('jpg', $image->getImageExtension());
+        $this->assertEquals('imagecreatefromjpeg', $image->getImageCreateFunction());
+        $this->assertEquals('imagejpeg', $image->getImageFunction());
+        $this->assertTrue($image->isMemImage());
+    }
+
+    /**
+     * Test invalid string image
+     *
+     * @expectedException \PhpOffice\PhpWord\Exception\InvalidImageException
+     */
+    public function testInvalidImageString()
+    {
+        $object = new Image('this_is-a_non_valid_image');
+        $object->getSource();
+    }
 }

--- a/tests/PhpWord/Writer/Word2007/Part/StylesTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/StylesTest.php
@@ -18,7 +18,10 @@ namespace PhpOffice\PhpWord\Writer\Word2007\Part;
 
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\SimpleType\Jc;
+use PhpOffice\PhpWord\Style\Font;
+use PhpOffice\PhpWord\Style\Paragraph;
 use PhpOffice\PhpWord\TestHelperDOCX;
+use PhpOffice\PhpWord\Writer\Word2007;
 
 /**
  * Test class for PhpOffice\PhpWord\Writer\Word2007\Part\Styles
@@ -73,5 +76,42 @@ class StylesTest extends \PHPUnit_Framework_TestCase
         $path = '/w:styles/w:style[@w:styleId="New Style"]/w:next';
         $element = $doc->getElement($path, $file);
         $this->assertEquals('Normal', $element->getAttribute('w:val'));
+    }
+
+    public function testFontStyleBasedOn()
+    {
+        $phpWord = new PhpWord();
+
+        $baseParagraphStyle = new Paragraph();
+        $baseParagraphStyle->setAlignment(Jc::CENTER);
+        $baseParagraphStyle = $phpWord->addParagraphStyle('BaseStyle', $baseParagraphStyle);
+         
+        $childFont = new Font();
+        $childFont->setParagraph($baseParagraphStyle);
+        $childFont->setSize(16);
+        $childFont = $phpWord->addFontStyle('ChildFontStyle', $childFont);
+         
+        $otherFont = new Font();
+        $otherFont->setSize(20);
+        $otherFont = $phpWord->addFontStyle('OtherFontStyle', $otherFont);
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $file = 'word/styles.xml';
+
+        // Normal style generated?
+        $path = '/w:styles/w:style[@w:styleId="BaseStyle"]/w:name';
+        $element = $doc->getElement($path, $file);
+        $this->assertEquals('BaseStyle', $element->getAttribute('w:val'));
+
+        // Font style with paragraph should have it's base style set to that paragraphs style name
+        $path = '/w:styles/w:style[w:name/@w:val="ChildFontStyle"]/w:basedOn';
+        $element = $doc->getElement($path, $file);
+        $this->assertEquals('BaseStyle', $element->getAttribute('w:val'));
+
+        // Font style without paragraph should not have a base style set
+        $path = '/w:styles/w:style[w:name/@w:val="OtherFontStyle"]/w:basedOn';
+        $element = $doc->getElement($path, $file);
+        $this->assertNull($element);
     }
 }


### PR DESCRIPTION
This change allows us to create an PhpOffice\PhpWord\Element\Image from a string representing the image data.
```php
        $source = file_get_contents(__DIR__ . '/../_files/images/earth.jpg');
        $image = new Image($source);
```
Of course in real life `$source` would come from a DB for instance.

Thanks to this you do not have to write the image data to file before passing it to the constructor.
This solves issue #921