### PR TITLE
Add metadata for w:trackRevisions setting

### DIFF
--- a/src/PhpWord/Metadata/Revisions.php
+++ b/src/PhpWord/Metadata/Revisions.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @link        https://github.com/PHPOffice/PHPWord
+ * @copyright   2010-2016 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Metadata;
+
+/**
+ * Revisions class
+ *
+ * @since 0.12.0 // TODO: modify the version
+ * @link http://www.datypic.com/sc/ooxml/t-w_CT_DocProtect.html // TODO: find link
+ */
+class Revisions
+{
+    /**
+     * Tracking revisions
+     *
+     * @var boolean
+     * @link http://www.datypic.com/sc/ooxml/a-w_edit-1.html // TODO: find docs
+     */
+    private $enabled = false;
+
+    /**
+     * Whether track revisions is enabled
+     *
+     * @return boolean
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * Enable track revisions
+     *
+     * @param bool $value
+     * @return self
+     */
+    public function setEnabled($value)
+    {
+        $this->enabled = $value;
+
+        return $this;
+    }
+}

--- a/src/PhpWord/PhpWord.php
+++ b/src/PhpWord/PhpWord.php
@@ -91,7 +91,7 @@ class PhpWord
         }
 
         // Metadata
-        $metadata = array('DocInfo', 'Protection', 'Compatibility');
+        $metadata = array('DocInfo', 'Protection', 'Compatibility', 'Revisions');
         foreach ($metadata as $meta) {
             $class = 'PhpOffice\\PhpWord\\Metadata\\' . $meta;
             $this->metadata[$meta] = new $class();
@@ -174,6 +174,16 @@ class PhpWord
     public function getProtection()
     {
         return $this->metadata['Protection'];
+    }
+
+    /**
+     * Get revisions
+     *
+     * @return \PhpOffice\PhpWord\Metadata\Revisions
+     */
+    public function getRevisions()
+    {
+        return $this->metadata['Revisions'];
     }
 
     /**

--- a/src/PhpWord/Writer/Word2007/Part/Settings.php
+++ b/src/PhpWord/Writer/Word2007/Part/Settings.php
@@ -141,6 +141,7 @@ class Settings extends AbstractPart
         // Other settings
         $this->getProtection();
         $this->getCompatibility();
+        $this->getRevisions();
     }
 
     /**
@@ -158,6 +159,19 @@ class Settings extends AbstractPart
                     'w:edit' => $protection->getEditing(),
                 )
             );
+        }
+    }
+
+    /**
+     * Get track revisions settings
+     *
+     * @return void
+     */
+    private function getRevisions()
+    {
+        $revisions = $this->getParentWriter()->getPhpWord()->getRevisions();
+        if ($revisions->isEnabled()) {
+            $this->settings['w:trackRevisions'] = array();
         }
     }
 

--- a/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
@@ -66,4 +66,20 @@ class SettingsTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($doc->elementExists($path, $file));
         $this->assertEquals($phpWord->getCompatibility()->getOoxmlVersion(), 15);
     }
+
+    /**
+     * Test revisions
+     */
+    public function testRevisions()
+    {
+        $phpWord = new PhpWord();
+        $phpWord->getRevisions()->setEnabled(true);
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $file = 'word/settings.xml';
+
+        $path = '/w:settings/w:trackRevisions';
+        $this->assertTrue($doc->elementExists($path, $file));
+    }
 }


### PR DESCRIPTION
### Description
Adds a metadata class `Revisions` that let's the user enable `w:trackRevisions` on the `word/settings.xml` file

### Reason
The settings writer didn't have a way to enable the setting for tracking revisions

### Impact
Users can now enable track revisions option

### Issue
Issue #622 

### Checklist
- [x] Did I write tests for this change?
- [ ] Is documentation complete?