### PR TITLE
loosen zendframework constraints, extend building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 php:
     - 5.3
+      env:
+        - PREFER_LOWEST=true
     - 5.4
     - 5.5
     - 5.6
@@ -25,7 +27,8 @@ before_install:
 before_script:
     ## Composer
     - composer self-update
-    - composer install --prefer-source
+    - if [ -z "$PREFER_LOWEST" ]; then composer install --prefer-source; fi
+    - if [ "$PREFER_LOWEST" == 'true' ]; then composer install --prefer-source --prefer-lowest; fi
     ## PHPDocumentor
     - mkdir -p build/docs
     - mkdir -p build/coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
     ## Composer
     - composer self-update
     - if [ -z "$PREFER_LOWEST" ]; then composer install --prefer-source; fi
-    - if [ "$PREFER_LOWEST" == 'true' ]; then composer install --prefer-source --prefer-lowest; fi
+    - if [ "$PREFER_LOWEST" == 'true' ]; then composer update --prefer-source --prefer-lowest; fi
     ## PHPDocumentor
     - mkdir -p build/docs
     - mkdir -p build/coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: php
 
 matrix:
     include:
-      - 5.3
+      - php: 5.3
       env:
         - PREFER_LOWEST=true
-      - 5.4
-      - 5.5
-      - 5.6
-      - 7.0
-      - hhvm
+      - php: 5.4
+      - php: 5.5
+      - php: 5.6
+      - php: 7.0
+      - php: hhvm
     allow_failures:
         - php: 7.0
         - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: php
 
-php:
-    - 5.3
+matrix:
+    include:
+      - 5.3
       env:
         - PREFER_LOWEST=true
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
-    - hhvm
-
-matrix:
+      - 5.4
+      - 5.5
+      - 5.6
+      - 7.0
+      - hhvm
     allow_failures:
         - php: 7.0
         - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,17 @@ language: php
 
 matrix:
     include:
-      - php: 5.3
+    - php: 5.3
       env:
-        - PREFER_LOWEST=true
-      - php: 5.4
-      - php: 5.5
-      - php: 5.6
-      - php: 7.0
-      - php: hhvm
+          - PREFER_LOWEST=true
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: hhvm
     allow_failures:
-        - php: 7.0
-        - php: hhvm
+    - php: 7.0
+    - php: hhvm
 
 env:
     global:

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
     "require": {
         "php": ">=5.3.3",
         "ext-xml": "*",
-        "zendframework/zend-escaper": "2.4.*",
-        "zendframework/zend-stdlib": "2.4.*",
-        "zendframework/zend-validator": "2.4.*",
+        "zendframework/zend-escaper": "^2.4.0",
+        "zendframework/zend-stdlib": "^2.4.0",
+        "zendframework/zend-validator": "^2.4.0",
         "phpoffice/common": "0.2.*"
     },
     "require-dev": {


### PR DESCRIPTION
As mentioned here https://github.com/PHPOffice/PHPWord/pull/903#issuecomment-272100136 I would like to loosen the zendframework constraints

While depending on `zendframework/* ^2.4` ...
* It would not allow a downgrade to ZF >= 2.0 and <2.4
* PHPWord would stay PHP 5.3 compatible while using ZF 2.4
* You can use ZF 2.5 with "newer" PHP versions

While doing that I would like to extend the build on travis with php5.3 and --prefer-lowest option on composer install to test that the oldest possible composition of components will still work.