### PR TITLE
Allow to change cell width unit

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -119,7 +119,9 @@ class Html
             'h6'        => array('Heading',     null,   $element,   $styles,    null,   'Heading6',     null),
             '#text'     => array('Text',        $node,  $element,   $styles,    null,   null,           null),
             'strong'    => array('Property',    null,   null,       $styles,    null,   'bold',         true),
+            'b'         => array('Property',    null,   null,       $styles,    null,   'bold',         true),
             'em'        => array('Property',    null,   null,       $styles,    null,   'italic',       true),
+            'i'         => array('Property',    null,   null,       $styles,    null,   'italic',       true),
             'sup'       => array('Property',    null,   null,       $styles,    null,   'superScript',  true),
             'sub'       => array('Property',    null,   null,       $styles,    null,   'subScript',    true),
             'table'     => array('Table',       $node,  $element,   $styles,    null,   'addTable',     true),
@@ -128,6 +130,7 @@ class Html
             'ul'        => array('List',        null,   null,       $styles,    $data,  3,              null),
             'ol'        => array('List',        null,   null,       $styles,    $data,  7,              null),
             'li'        => array('ListItem',    $node,  $element,   $styles,    $data,  null,           null),
+            'span'      => array('Text',        $node,  $element,   $styles,    null,   null,           null),
         );
 
         $newElement = null;
@@ -197,6 +200,10 @@ class Html
     {
         $styles['paragraph'] = self::parseInlineStyle($node, $styles['paragraph']);
         $newElement = $element->addTextRun($styles['paragraph']);
+
+        if ($node->firstChild->nodeName === 'ul') {
+            return null;
+        }
 
         return $newElement;
     }
@@ -326,7 +333,7 @@ class Html
         if (count($cNodes) > 0) {
             $text = '';
             foreach ($cNodes as $cNode) {
-                if ($cNode->nodeName == '#text') {
+                if ($cNode->nodeName == '#text' || $cNode->nodeName == 'span') {
                     $text = $cNode->nodeValue;
                 }
             }

--- a/src/PhpWord/Style/Cell.php
+++ b/src/PhpWord/Style/Cell.php
@@ -56,6 +56,13 @@ class Cell extends Border
     const DEFAULT_BORDER_COLOR = '000000';
 
     /**
+     * @const string Cell width units http://officeopenxml.com/WPtableCellProperties-Width.php
+     */
+    const WIDTH_AUTO = 'auto'; // Automatically determined width
+    const WIDTH_PERCENT = 'pct'; // Width in fiftieths (1/50) of a percent (1% = 50 unit)
+    const WIDTH_TWIP = 'dxa'; // Width in twentieths (1/20) of a point (twip)
+
+    /**
      * Vertical align (top, center, both, bottom)
      *
      * @var string
@@ -92,6 +99,11 @@ class Cell extends Border
      * @var \PhpOffice\PhpWord\Style\Shading
      */
     private $shading;
+
+    /**
+     * @var string Width unit
+     */
+    private $unit = self::WIDTH_TWIP;
 
     /**
      * Get vertical align.
@@ -232,6 +244,30 @@ class Cell extends Border
     public function setShading($value = null)
     {
         $this->setObjectVal($value, 'Shading', $this->shading);
+
+        return $this;
+    }
+
+    /**
+     * Get width unit
+     *
+     * @return string
+     */
+    public function getUnit()
+    {
+        return $this->unit;
+    }
+
+    /**
+     * Set width unit
+     *
+     * @param string $value
+     * @return Cell
+     */
+    public function setUnit($value)
+    {
+        $enum = array(self::WIDTH_AUTO, self::WIDTH_PERCENT, self::WIDTH_TWIP);
+        $this->unit = $this->setEnumVal($value, $enum, $this->unit);
 
         return $this;
     }

--- a/src/PhpWord/Writer/Word2007/Style/Cell.php
+++ b/src/PhpWord/Writer/Word2007/Style/Cell.php
@@ -47,10 +47,12 @@ class Cell extends AbstractStyle
         $xmlWriter->startElement('w:tcPr');
 
         // Width
-        $xmlWriter->startElement('w:tcW');
-        $xmlWriter->writeAttribute('w:w', $this->width);
-        $xmlWriter->writeAttribute('w:type', 'dxa');
-        $xmlWriter->endElement(); // w:tcW
+        if (!is_null($this->width)) {
+            $xmlWriter->startElement('w:tcW');
+            $xmlWriter->writeAttribute('w:w', $this->width);
+            $xmlWriter->writeAttribute('w:type', $style->getUnit());
+            $xmlWriter->endElement(); // w:tcW
+        }
 
         // Text direction
         $textDir = $style->getTextDirection();


### PR DESCRIPTION
The width default cell unit was `dxa`.
With this patch, the width unit of a cell can be changed in the cell style.