### PR TITLE
Add possibility to show/hide spelling and grammatical errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ composer.lock
 composer.phar
 vendor
 /report
+/build
 /samples/resources
 /samples/results
 /.settings

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -109,8 +109,8 @@ Zip class
 By default, PHPWord uses `Zip extension <http://php.net/manual/en/book.zip.php>`__
 to deal with ZIP compressed archives and files inside them. If you can't have
 Zip extension installed on your server, you can use pure PHP library
-alternative, `PclZip <http://www.phpconcept.net/pclzip/>`__, which
-included with PHPWord.
+alternative, `PclZip <http://www.phpconcept.net/pclzip/>`__, which is
+included in PHPWord.
 
 .. code-block:: php
 
@@ -129,6 +129,17 @@ To turn it on set ``outputEscapingEnabled`` option to ``true`` in your PHPWord c
 .. code-block:: php
 
     \PhpOffice\PhpWord\Settings::setOutputEscapingEnabled(true);
+
+Spelling and grammatical checks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default spelling and grammatical errors are shown as soon as you open a word document.
+For big documents this can slow down the opening of the document. You can hide the spelling and/or grammatical errors with:
+
+.. code-block:: php
+
+    \PhpOffice\PhpWord\Settings::setSpellingErrorsHidden(true);
+    \PhpOffice\PhpWord\Settings::setGrammaticalErrorsHidden(true);
 
 Default font
 ~~~~~~~~~~~~

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -183,3 +183,16 @@ points to twips.
     $sectionStyle->setMarginLeft(\PhpOffice\PhpWord\Shared\Converter::inchToTwip(.5));
     // 2 cm right margin
     $sectionStyle->setMarginRight(\PhpOffice\PhpWord\Shared\Converter::cmToTwip(2));
+
+Language
+--------
+
+You can hide spelling errors:
+
+.. code-block:: php
+    \PhpOffice\PhpWord\Settings::setSpellingErrorsHidden(true);
+
+And hide grammatical errors:
+
+.. code-block:: php
+    \PhpOffice\PhpWord\Settings::setGrammaticalErrorsHidden(true);

--- a/src/PhpWord/Settings.php
+++ b/src/PhpWord/Settings.php
@@ -120,6 +120,18 @@ class Settings
     private static $defaultFontSize = self::DEFAULT_FONT_SIZE;
 
     /**
+     * Hide spelling errors
+     * @var boolean
+     */
+    private static $spellingErrorsHidden = false;
+
+    /**
+     * Hide grammatical errors
+     * @var boolean
+     */
+    private static $grammaticalErrorsHidden = false;
+
+    /**
      * The user defined temporary directory.
      *
      * @var string
@@ -391,6 +403,46 @@ class Settings
         }
 
         return false;
+    }
+
+    /**
+     * Are spelling errors hidden
+     *
+     * @return boolean
+     */
+    public static function isSpellingErrorsHidden()
+    {
+        return self::$spellingErrorsHidden;
+    }
+    
+    /**
+     * Hide spelling errors
+     *
+     * @param boolean $spellingErrorsHidden
+     */
+    public static function setSpellingErrorsHidden($spellingErrorsHidden)
+    {
+        self::$spellingErrorsHidden = $spellingErrorsHidden;
+    }
+
+    /**
+     * Are grammatical errors hidden
+     *
+     * @return boolean
+     */
+    public static function isGrammaticalErrorsHidden()
+    {
+        return self::$grammaticalErrorsHidden;
+    }
+
+    /**
+     * Hide grammatical errors
+     *
+     * @param boolean $grammaticalErrorsHidden
+     */
+    public static function setGrammaticalErrorsHidden($grammaticalErrorsHidden)
+    {
+        self::$grammaticalErrorsHidden = $grammaticalErrorsHidden;
     }
 
     /**

--- a/src/PhpWord/Writer/Word2007/Part/Settings.php
+++ b/src/PhpWord/Writer/Word2007/Part/Settings.php
@@ -17,6 +17,8 @@
 
 namespace PhpOffice\PhpWord\Writer\Word2007\Part;
 
+use PhpOffice\PhpWord\Settings as DocumentSettings;
+
 /**
  * Word2007 settings part writer: word/settings.xml
  *
@@ -104,6 +106,8 @@ class Settings extends AbstractPart
             'w:hyphenationZone' => array('@attributes' => array('w:val' => '425')),
             'w:characterSpacingControl' => array('@attributes' => array('w:val' => 'doNotCompress')),
             'w:themeFontLang' => array('@attributes' => array('w:val' => 'en-US')),
+            'w:hideSpellingErrors' => array('@attributes' => array('w:val' => DocumentSettings::isSpellingErrorsHidden() ? 'true' : 'false')),
+            'w:hideGrammaticalErrors' => array('@attributes' => array('w:val' => DocumentSettings::isGrammaticalErrorsHidden() ? 'true' : 'false')),
             'w:decimalSymbol' => array('@attributes' => array('w:val' => '.')),
             'w:listSeparator' => array('@attributes' => array('w:val' => ';')),
             'w:compat' => array(),

--- a/tests/PhpWord/SettingsTest.php
+++ b/tests/PhpWord/SettingsTest.php
@@ -115,6 +115,20 @@ class SettingsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test set/get spelling and grammar
+     */
+    public function testSetGetSpellingGrammar()
+    {
+        $this->assertFalse(Settings::isSpellingErrorsHidden());
+        Settings::setSpellingErrorsHidden(true);
+        $this->assertTrue(Settings::isSpellingErrorsHidden());
+
+        $this->assertFalse(Settings::isGrammaticalErrorsHidden());
+        Settings::setGrammaticalErrorsHidden(true);
+        $this->assertTrue(Settings::isGrammaticalErrorsHidden());
+    }
+
+    /**
      * Test load config
      */
     public function testLoadConfig()

--- a/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
@@ -18,6 +18,7 @@ namespace PhpOffice\PhpWord\Writer\Word2007\Part;
 
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\TestHelperDOCX;
+use PhpOffice\PhpWord\Settings;
 
 /**
  * Test class for PhpOffice\PhpWord\Writer\Word2007\Part\Settings
@@ -65,5 +66,42 @@ class SettingsTest extends \PHPUnit_Framework_TestCase
         $path = '/w:settings/w:compat/w:compatSetting';
         $this->assertTrue($doc->elementExists($path, $file));
         $this->assertEquals($phpWord->getCompatibility()->getOoxmlVersion(), 15);
+    }
+
+    /**
+     * Test language
+     */
+    public function testLanguage()
+    {
+        $phpWord = new PhpWord();
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $file = 'word/settings.xml';
+
+        $path = '/w:settings/w:themeFontLang';
+        $this->assertTrue($doc->elementExists($path, $file));
+        $element = $doc->getElement($path, $file);
+        
+        $this->assertEquals('en-US', $element->getAttribute('w:val'));
+    }
+
+    /**
+     * Test spelling
+     */
+    public function testSpelling()
+    {
+        $phpWord = new PhpWord();
+        Settings::setSpellingErrorsHidden(true);
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $file = 'word/settings.xml';
+
+        $path = '/w:settings/w:hideSpellingErrors';
+        $this->assertTrue($doc->elementExists($path, $file));
+        $element = $doc->getElement($path, $file);
+        
+        $this->assertEquals('true', $element->getAttribute('w:val'));
     }
 }

--- a/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
@@ -74,11 +74,11 @@ class SettingsTest extends \PHPUnit_Framework_TestCase
     public function testLanguage()
     {
         $phpWord = new PhpWord();
-
+        
         $doc = TestHelperDOCX::getDocument($phpWord);
-
+        
         $file = 'word/settings.xml';
-
+        
         $path = '/w:settings/w:themeFontLang';
         $this->assertTrue($doc->elementExists($path, $file));
         $element = $doc->getElement($path, $file);
@@ -93,14 +93,16 @@ class SettingsTest extends \PHPUnit_Framework_TestCase
     {
         $phpWord = new PhpWord();
         Settings::setSpellingErrorsHidden(true);
-
+        
         $doc = TestHelperDOCX::getDocument($phpWord);
-
+        
         $file = 'word/settings.xml';
-
+        
         $path = '/w:settings/w:hideSpellingErrors';
         $this->assertTrue($doc->elementExists($path, $file));
         $element = $doc->getElement($path, $file);
+        
+        $this->assertEquals('true', $element->getAttribute('w:val'));
     }
 
     /**
@@ -110,9 +112,14 @@ class SettingsTest extends \PHPUnit_Framework_TestCase
     {
         $phpWord = new PhpWord();
         Settings::setEvenAndOddHeaders(true);
+        
+        $doc = TestHelperDOCX::getDocument($phpWord);
+        
+        $file = 'word/settings.xml';
+        
         $path = '/w:settings/w:evenAndOddHeaders';
         $this->assertTrue($doc->elementExists($path, $file));
-
+        
         $element = $doc->getElement($path, $file);
         $this->assertEquals('true', $element->getAttribute('w:val'));
     }


### PR DESCRIPTION
This pull request allows you set hide spelling and/or grammatical errors.
Simply use it as this
```php
\PhpOffice\PhpWord\Settings::setSpellingErrorsHidden(true);
\PhpOffice\PhpWord\Settings::setGrammaticalErrorsHidden(true);
```
This corresponds to the following option in Word:
![image](https://cloud.githubusercontent.com/assets/6959414/22396102/420980c4-e551-11e6-91ab-8575607247ef.png)


This does not fix issue #542 as I did not update the reader to read the settings.xml file.
Anyone feel free to do so :-)