### PR TITLE
fix image loading over https

### DIFF
--- a/samples/Sample_13_Images.php
+++ b/samples/Sample_13_Images.php
@@ -20,6 +20,12 @@ $source = 'http://php.net/images/logos/php-med-trans-light.gif';
 $section->addText("Remote image from: {$source}");
 $section->addImage($source);
 
+// Image from string
+$source = 'resources/_mars.jpg';
+$fileContent = file_get_contents($source);
+$section->addText("Image from string");
+$section->addImage($fileContent);
+
 //Wrapping style
 $text = str_repeat('Hello World! ', 15);
 $wrappingStyles = array('inline', 'behind', 'infront', 'square', 'tight');

--- a/src/PhpWord/Element/Image.php
+++ b/src/PhpWord/Element/Image.php
@@ -340,6 +340,8 @@ class Image extends AbstractElement
             call_user_func($this->imageFunc, $imageResource);
             $imageBinary = ob_get_contents();
             ob_end_clean();
+        } elseif ($this->sourceType == self::SOURCE_STRING) {
+            $imageBinary = $this->source;
         } else {
             $fileHandle = fopen($actualSource, 'rb', false);
             if ($fileHandle !== false) {
@@ -366,33 +368,31 @@ class Image extends AbstractElement
     /**
      * Check memory image, supported type, image functions, and proportional width/height.
      *
-     * @param string $source
-     *
      * @return void
      *
      * @throws \PhpOffice\PhpWord\Exception\InvalidImageException
      * @throws \PhpOffice\PhpWord\Exception\UnsupportedImageTypeException
      */
-    private function checkImage($source)
+    private function checkImage()
     {
-        $this->setSourceType($source);
+        $this->setSourceType();
 
         // Check image data
         if ($this->sourceType == self::SOURCE_ARCHIVE) {
-            $imageData = $this->getArchiveImageSize($source);
+            $imageData = $this->getArchiveImageSize($this->source);
         } else if ($this->sourceType == self::SOURCE_STRING) {
-            $imageData = $this->getStringImageSize($source);
+            $imageData = $this->getStringImageSize($this->source);
         } else {
-            $imageData = @getimagesize($source);
+            $imageData = @getimagesize($this->source);
         }
         if (!is_array($imageData)) {
-            throw new InvalidImageException(sprintf('Invalid image: %s', $source));
+            throw new InvalidImageException(sprintf('Invalid image: %s', $this->source));
         }
         list($actualWidth, $actualHeight, $imageType) = $imageData;
 
         // Check image type support
         $supportedTypes = array(IMAGETYPE_JPEG, IMAGETYPE_GIF, IMAGETYPE_PNG);
-        if ($this->sourceType != self::SOURCE_GD) {
+        if ($this->sourceType != self::SOURCE_GD && $this->sourceType != self::SOURCE_STRING) {
             $supportedTypes = array_merge($supportedTypes, array(IMAGETYPE_BMP, IMAGETYPE_TIFF_II, IMAGETYPE_TIFF_MM));
         }
         if (!in_array($imageType, $supportedTypes)) {
@@ -408,21 +408,26 @@ class Image extends AbstractElement
     /**
      * Set source type.
      *
-     * @param string $source
      * @return void
      */
-    private function setSourceType($source)
+    private function setSourceType()
     {
-        if (stripos(strrev($source), strrev('.php')) === 0) {
+        if (stripos(strrev($this->source), strrev('.php')) === 0) {
             $this->memoryImage = true;
             $this->sourceType = self::SOURCE_GD;
-        } elseif (strpos($source, 'zip://') !== false) {
+        } elseif (strpos($this->source, 'zip://') !== false) {
             $this->memoryImage = false;
             $this->sourceType = self::SOURCE_ARCHIVE;
-        } elseif (filter_var($source, FILTER_VALIDATE_URL) !== false) {
+        } elseif (filter_var($this->source, FILTER_VALIDATE_URL) !== false) {
             $this->memoryImage = true;
-            $this->sourceType = self::SOURCE_GD;
-        } elseif (@file_exists($source)) {
+            if (strpos($this->source, 'https') === 0) {
+                $fileContent = file_get_contents($this->source);
+                $this->source = $fileContent;
+                $this->sourceType = self::SOURCE_STRING;
+            } else {
+                $this->sourceType = self::SOURCE_GD;
+            }
+        } elseif (@file_exists($this->source)) {
             $this->memoryImage = false;
             $this->sourceType = self::SOURCE_LOCAL;
         } else {
@@ -496,18 +501,18 @@ class Image extends AbstractElement
     {
         switch ($this->imageType) {
             case 'image/png':
-                $this->imageCreateFunc = 'imagecreatefrompng';
+                $this->imageCreateFunc = $this->sourceType == self::SOURCE_STRING ? 'imagecreatefromstring' : 'imagecreatefrompng';
                 $this->imageFunc = 'imagepng';
                 $this->imageExtension = 'png';
                 break;
             case 'image/gif':
-                $this->imageCreateFunc = 'imagecreatefromgif';
+                $this->imageCreateFunc = $this->sourceType == self::SOURCE_STRING ? 'imagecreatefromstring' : 'imagecreatefromgif';
                 $this->imageFunc = 'imagegif';
                 $this->imageExtension = 'gif';
                 break;
             case 'image/jpeg':
             case 'image/jpg':
-                $this->imageCreateFunc = 'imagecreatefromjpeg';
+                $this->imageCreateFunc = $this->sourceType == self::SOURCE_STRING ? 'imagecreatefromstring' : 'imagecreatefromjpeg';
                 $this->imageFunc = 'imagejpeg';
                 $this->imageExtension = 'jpg';
                 break;

--- a/tests/PhpWord/Element/ImageTest.php
+++ b/tests/PhpWord/Element/ImageTest.php
@@ -131,7 +131,15 @@ class ImageTest extends \PHPUnit_Framework_TestCase
      */
     public function testUnsupportedImage()
     {
-        $object = new Image('http://samples.libav.org/image-samples/RACECAR.BMP');
+        //disable ssl verification, never do this in real application, you should pass the certiciate instead!!!
+        $arrContextOptions = array(
+            "ssl" => array(
+                "verify_peer" => false,
+                "verify_peer_name" => false,
+            ),
+        );
+        stream_context_set_default($arrContextOptions);
+        $object = new Image('https://samples.libav.org/image-samples/RACECAR.BMP');
         $object->getSource();
     }
 
@@ -194,7 +202,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(md5($source), $image->getMediaId());
         $this->assertEquals('image/jpeg', $image->getImageType());
         $this->assertEquals('jpg', $image->getImageExtension());
-        $this->assertEquals('imagecreatefromjpeg', $image->getImageCreateFunction());
+        $this->assertEquals('imagecreatefromstring', $image->getImageCreateFunction());
         $this->assertEquals('imagejpeg', $image->getImageFunction());
         $this->assertTrue($image->isMemImage());
     }


### PR DESCRIPTION
this fixes issue #983 
As images are now loaded using file_get_contents, it is possible to modify the stream context using stream_context_set_default(...).
In ImageTest I'm using 
```php
        $arrContextOptions = array(
            "ssl" => array(
                "verify_peer" => false,
                "verify_peer_name" => false,
            ),
        );
        stream_context_set_default($arrContextOptions);
```
which you should obviously not do in a production environment, instead you should pass the certificate to use to connect to the remote url:
```php
        $arrContextOptions = array(
            "ssl" => array(
                "cafile" => "/path/to/bundle/cacert.pem",
                "verify_peer" => true,
                "verify_peer_name" => true,
            ),
        );
        stream_context_set_default($arrContextOptions);
```
[set thread on stackoverflow](http://stackoverflow.com/questions/26148701/file-get-contents-ssl-operation-failed-with-code-1-and-more)
