### PR TITLE
Fix type var memory_limit in pclzip.lib

### DIFF
--- a/src/PhpWord/Shared/PCLZip/pclzip.lib.php
+++ b/src/PhpWord/Shared/PCLZip/pclzip.lib.php
@@ -1836,6 +1836,7 @@
     $v_memory_limit = ini_get('memory_limit');
     $v_memory_limit = trim($v_memory_limit);
     $last = strtolower(substr($v_memory_limit, -1));
+    $v_memory_limit = (int) $v_memory_limit;
 
     if($last == 'g')
         //$v_memory_limit = $v_memory_limit*1024*1024*1024;


### PR DESCRIPTION
Fix notice in PHP 7
PHP Notice – yii\base\ErrorException
A non well formed numeric value encountered