### PR TITLE
Fix: different footer for first page

### DIFF
--- a/src/PhpWord/Element/Section.php
+++ b/src/PhpWord/Element/Section.php
@@ -181,6 +181,11 @@ class Section extends AbstractContainer
                 return true;
             }
         }
+        foreach ($this->footers as $footer) {
+            if ($footer->getType() == Header::FIRST) {
+                return true;
+            }
+        }
         return false;
     }
 


### PR DESCRIPTION
Sample 12 shows how to add a different header for the first page:
```
// Add first page header
$header = $section->addHeader();
$header->firstPage();
...
// Add header for all other pages
$subsequent = $section->addHeader();
```
This is supposed to work also for footers (since `Header` itself is a subclass of `Footer`), but it's currently broken because `Section::hasDifferentFirstPage()` only checks if a first-page specific header exists, but doesn't check for a first-page specific footer, too.

This PR adds the missing check, fixing the rendering of footers with type `Footer::FIRST`.