### PR TITLE
Fix requirements from zend to be looser.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
     "require": {
         "php": ">=5.3.3",
         "ext-xml": "*",
-        "zendframework/zend-escaper": "2.4.*",
-        "zendframework/zend-stdlib": "2.4.*",
-        "phpoffice/common": "0.2.*"
+        "zendframework/zend-escaper": "~2.4",
+        "zendframework/zend-stdlib": "~2.4",
+        "phpoffice/common": "~0.2"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",


### PR DESCRIPTION
Resolves issue #1044:
Switch  dependencies from Asterisk version numbers to [Tilde Version Range.](https://getcomposer.org/doc/articles/versions.md#tilde-version-range-)