### PR TITLE
Allow zendframework/zend-escaper up to 2.5.x ?

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-xml": "*",
-        "zendframework/zend-escaper": "2.4.*",
+        "zendframework/zend-escaper": "2.5.*",
         "zendframework/zend-stdlib": "2.4.*",
         "zendframework/zend-validator": "2.4.*",
         "phpoffice/common": "0.2.*"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "phpoffice/phpword",
+    "name": "artusamak/phpword",
     "description": "PHPWord - A pure PHP library for reading and writing word processing documents (OOXML, ODF, RTF, HTML, PDF)",
     "keywords": [
         "PHP", "PHPOffice", "office", "PHPWord", "word", "template", "template processor", "reader", "writer",


### PR DESCRIPTION
Hello, thanks for this libray, i'm eager to be able to test it against a Drupal 8 project.
In order to do that, we need to be able to meet a minimum version requirement.
Drupal requires zendframork/zend-feeds that requires zendframework/zend-escaper to be in ^2.5.
Your actual version constraint is against 2.4.* and of course 2.4.x and 2.5.x and concurrent releases.
I'm starting this thread to see if the 2.5.x branch is working and hope it may be integrated in your core release soon.