### PR TITLE
Doc elements, fix syntax code-block::php

### DIFF
--- a/docs/elements.rst
+++ b/docs/elements.rst
@@ -138,9 +138,9 @@ Page breaks
 There are two ways to insert a page breaks, using the ``addPageBreak``
 method or using the ``pageBreakBefore`` style of paragraph.
 
-:: code-block:: php
+.. code-block:: php
 
-    \\$section->addPageBreak();
+    $section->addPageBreak();
 
 Lists
 -----


### PR DESCRIPTION
Use the correct syntax for code-block, remove the comment in code-block.
currently render like so
![phpword](https://user-images.githubusercontent.com/3001652/30758942-838588be-9ffe-11e7-86c7-dd7cf83ba558.PNG)
