### PR TITLE
Working Block functions

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -326,18 +326,26 @@ class TemplateProcessor
      *
      * @return string|null
      */
-    public function cloneBlock($blockname, $clones = 1, $replace = true, $incrementVariables = true, $throwexception = false)
-    {
+    public function cloneBlock(
+        $blockname,
+        $clones = 1,
+        $replace = true,
+        $incrementVariables = true,
+        $throwexception = false
+    ) {
         $S_search = '${'  . $blockname . '}';
         $E_search = '${/' . $blockname . '}';
 
         $S_tagPos = strpos($this->tempDocumentMainPart, $S_search);
         $E_tagPos = strpos($this->tempDocumentMainPart, $E_search, $S_tagPos);
         if (!$S_tagPos || !$E_tagPos) {
-            if($throwexception)
-                throw new Exception("Can not find block '$blockname', template variable not found or variable contains markup.");
-            else
+            if ($throwexception) {
+                throw new Exception(
+                    "Can not find block '$blockname', template variable not found or variable contains markup."
+                );
+            } else {
                 return null; # Block not found, return null
+            }
         }
 
         $S_blockStart = $this->findBlockStart($S_tagPos);
@@ -350,13 +358,14 @@ class TemplateProcessor
         
         $xmlBlock = $this->getSlice($S_blockEnd, $E_blockStart);
 
-        if($replace){
+        if ($replace) {
             $result = $this->getSlice(0, $S_blockStart);
             for ($i = 1; $i <= $clones; $i++) {
-                if($incrementVariables)
+                if ($incrementVariables) {
                     $result .= preg_replace('/\$\{(.*?)\}/', '\${\\1#' . $i . '}', $xmlBlock);
-                else
+                } else {
                     $result .= $xmlBlock;
+                }
             }
             $result .= $this->getSlice($E_blockEnd);
 
@@ -374,7 +383,8 @@ class TemplateProcessor
      *
      * @return string|null
      */
-    public function getBlock($blockname, $throwexception = false){
+    public function getBlock($blockname, $throwexception = false)
+    {
         return $this->cloneBlock($blockname, 1, false, $throwexception);
     }
     /**
@@ -394,9 +404,13 @@ class TemplateProcessor
         $S_tagPos = strpos($this->tempDocumentMainPart, $S_search);
         $E_tagPos = strpos($this->tempDocumentMainPart, $E_search, $S_tagPos);
         if (!$S_tagPos || !$E_tagPos) {
-            if($throwexception)
-                throw new Exception("Can not find block '$blockname', template variable not found or variable contains markup.");
-            else return false;
+            if ($throwexception) {
+                throw new Exception(
+                    "Can not find block '$blockname', template variable not found or variable contains markup."
+                );
+            } else {
+                return false;
+            }
         }
 
         $S_blockStart = $this->findBlockStart($S_tagPos);
@@ -585,10 +599,18 @@ class TemplateProcessor
      */
     protected function findRowStart($offset)
     {
-        $rowStart = strrpos($this->tempDocumentMainPart, '<w:tr ', ((strlen($this->tempDocumentMainPart) - $offset) * -1));
+        $rowStart = strrpos(
+            $this->tempDocumentMainPart,
+            '<w:tr ',
+            ((strlen($this->tempDocumentMainPart) - $offset) * -1)
+        );
 
         if (!$rowStart) {
-            $rowStart = strrpos($this->tempDocumentMainPart, '<w:tr>', ((strlen($this->tempDocumentMainPart) - $offset) * -1));
+            $rowStart = strrpos(
+                $this->tempDocumentMainPart,
+                '<w:tr>',
+                ((strlen($this->tempDocumentMainPart) - $offset) * -1)
+            );
         }
         if (!$rowStart) {
             throw new Exception('Can not find the start position of the row to clone.');
@@ -605,13 +627,21 @@ class TemplateProcessor
      * @return integer
      *
      * @throws \PhpOffice\PhpWord\Exception\Exception
-     */ 
+     */
     protected function findBlockStart($offset)
     {
-        $blockStart = strrpos($this->tempDocumentMainPart, '<w:p ', ((strlen($this->tempDocumentMainPart) - $offset) * -1));
+        $blockStart = strrpos(
+            $this->tempDocumentMainPart,
+            '<w:p ',
+            ((strlen($this->tempDocumentMainPart) - $offset) * -1)
+        );
 
         if (!$blockStart) {
-            $blockStart = strrpos($this->tempDocumentMainPart, '<w:p>', ((strlen($this->tempDocumentMainPart) - $offset) * -1));
+            $blockStart = strrpos(
+                $this->tempDocumentMainPart,
+                '<w:p>',
+                ((strlen($this->tempDocumentMainPart) - $offset) * -1)
+            );
         }
         if (!$blockStart) {
             throw new Exception('Can not find the start position of the row to clone.');


### PR DESCRIPTION
I removed the regexp (although I had a working regexp, it seems PHP7 does not like multiple non-greedy patterns. The need to anchor the query to <?xml> is very dirty. Strange, because http://regex101.com/ and Perl have no problem with the same regexp. I'm quite good at regular expressions, so it pains me not using them). 
So I implemented the findBlockStart() and findBlockEnd() (same way that cloneRow() is implemented) that searches upto a paragraph change <w:p>, This has been tested with LibreOffice generated docx (that features <w:p>) and real MSOffice documents (that features extra parameters, nb: <w:p w:rsidR="00AC46F7" w:rsidRDefault="00AC46F7" w:rsidP="00AC46F7">). As well as a few new testcases to cover the new functionality.

What is new?

    cloneBlocks with variables inside now expand like cloneRows, with #n at the end (and you can get the old behavior back with an extra parameter)
    Block functions now use the same method as Row functions to detect start/end (marginally faster)
    Block functions now return sensible information instead of void
    you can throw exceptions if you can not find a block (enabled by an extra function parameter)
    getBlock() implemented
    Complete coverage of unit tests (including obvious missing tests) for Block functions. the good stuff.
    Multiple same named blocks behave as before (you can replace them one by one)
    Went through phpcs and phpunit to test everything. All tests pass* All formatting passes*

Files modified:
./src/PhpWord/TemplateProcessor.php
./tests/PhpWord/TemplateProcessorTest.php

OpenTemplateProcessor is a subclass that allows access to the private fields in TemplateProcessor. This is required for good testing of the output results (read the generated internal xml).

Tested with:
phpunit --bootstrap autoload.php phpoffice/PHPWord/tests/PhpWord/TemplateProcessorTest.php
phpcs ./src/PhpWord/TemplateProcessor.php ./tests/PhpWord/TemplateProcessorTest.php --standard=PSR2  



Todo: Tested under PHP 7.0.22 maybe try older versions too (although no PHP7-only code has been used). Also: new here, so if I'm doing things wrong, just tell me.