### PR TITLE
Fbnil patch blocks

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -333,33 +333,33 @@ class TemplateProcessor
         $incrementVariables = true,
         $throwexception = false
     ) {
-        $S_search = '${'  . $blockname . '}';
-        $E_search = '${/' . $blockname . '}';
+        $startSearch = '${'  . $blockname . '}';
+        $endSearch = '${/' . $blockname . '}';
 
-        $S_tagPos = strpos($this->tempDocumentMainPart, $S_search);
-        $E_tagPos = strpos($this->tempDocumentMainPart, $E_search, $S_tagPos);
-        if (!$S_tagPos || !$E_tagPos) {
+        $startTagPos = strpos($this->tempDocumentMainPart, $startSearch);
+        $EndTagPos = strpos($this->tempDocumentMainPart, $endSearch, $startTagPos);
+        if (!$startTagPos || !$EndTagPos) {
             if ($throwexception) {
                 throw new Exception(
                     "Can not find block '$blockname', template variable not found or variable contains markup."
                 );
             } else {
-                return null; # Block not found, return null
+                return null; // Block not found, return null
             }
         }
 
-        $S_blockStart = $this->findBlockStart($S_tagPos);
-        $S_blockEnd = $this->findBlockEnd($S_tagPos);
-        #$xmlStart = $this->getSlice($S_blockStart, $S_blockEnd);
+        $startBlockStart = $this->findBlockStart($startTagPos);
+        $startBlockEnd = $this->findBlockEnd($startTagPos);
+        // $xmlStart = $this->getSlice($startBlockStart, $startBlockEnd);
 
-        $E_blockStart = $this->findBlockStart($E_tagPos);
-        $E_blockEnd = $this->findBlockEnd($E_tagPos);
-        #$xmlEnd = $this->getSlice($E_blockStart, $E_blockEnd);
+        $endBlockStart = $this->findBlockStart($EndTagPos);
+        $endBlockEnd = $this->findBlockEnd($EndTagPos);
+        // $xmlEnd = $this->getSlice($endBlockStart, $E_blockEnd);
         
-        $xmlBlock = $this->getSlice($S_blockEnd, $E_blockStart);
+        $xmlBlock = $this->getSlice($startBlockEnd, $endBlockStart);
 
         if ($replace) {
-            $result = $this->getSlice(0, $S_blockStart);
+            $result = $this->getSlice(0, $startBlockStart);
             for ($i = 1; $i <= $clones; $i++) {
                 if ($incrementVariables) {
                     $result .= preg_replace('/\$\{(.*?)\}/', '\${\\1#' . $i . '}', $xmlBlock);
@@ -398,12 +398,12 @@ class TemplateProcessor
      */
     public function replaceBlock($blockname, $replacement, $throwexception = false)
     {
-        $S_search = '${'  . $blockname . '}';
-        $E_search = '${/' . $blockname . '}';
+        $startSearch = '${'  . $blockname . '}';
+        $endSearch = '${/' . $blockname . '}';
 
-        $S_tagPos = strpos($this->tempDocumentMainPart, $S_search);
-        $E_tagPos = strpos($this->tempDocumentMainPart, $E_search, $S_tagPos);
-        if (!$S_tagPos || !$E_tagPos) {
+        $startTagPos = strpos($this->tempDocumentMainPart, $startSearch);
+        $EndTagPos = strpos($this->tempDocumentMainPart, $endSearch, $startTagPos);
+        if (!$startTagPos || !$EndTagPos) {
             if ($throwexception) {
                 throw new Exception(
                     "Can not find block '$blockname', template variable not found or variable contains markup."
@@ -413,17 +413,13 @@ class TemplateProcessor
             }
         }
 
-        $S_blockStart = $this->findBlockStart($S_tagPos);
-        $S_blockEnd = $this->findBlockEnd($S_tagPos);
-        #$xmlStart = $this->getSlice($S_blockStart, $S_blockEnd);
+        $startBlockStart = $this->findBlockStart($startTagPos);
+        $startBlockEnd = $this->findBlockEnd($startTagPos);
 
-        $E_blockStart = $this->findBlockStart($E_tagPos);
-        $E_blockEnd = $this->findBlockEnd($E_tagPos);
-        #$xmlEnd = $this->getSlice($E_blockStart, $E_blockEnd);
+        $endBlockStart = $this->findBlockStart($EndTagPos);
+        $E_blockEnd = $this->findBlockEnd($EndTagPos);
         
-        $xmlBlock = $this->getSlice($S_blockEnd, $E_blockStart);
-        
-        $result  = $this->getSlice(0, $S_blockStart);
+        $result  = $this->getSlice(0, $startBlockStart);
         $result .= $replacement;
         $result .= $this->getSlice($E_blockEnd);
 

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -326,18 +326,26 @@ class TemplateProcessor
      *
      * @return string|null
      */
-    public function cloneBlock($blockname, $clones = 1, $replace = true, $incrementVariables = true, $throwexception = false)
-    {
+    public function cloneBlock(
+        $blockname,
+        $clones = 1,
+        $replace = true,
+        $incrementVariables = true,
+        $throwexception = false
+    ) {
         $S_search = '${'  . $blockname . '}';
         $E_search = '${/' . $blockname . '}';
 
         $S_tagPos = strpos($this->tempDocumentMainPart, $S_search);
         $E_tagPos = strpos($this->tempDocumentMainPart, $E_search, $S_tagPos);
         if (!$S_tagPos || !$E_tagPos) {
-            if($throwexception)
-                throw new Exception("Can not find block '$blockname', template variable not found or variable contains markup.");
-            else
+            if ($throwexception) {
+                throw new Exception(
+                    "Can not find block '$blockname', template variable not found or variable contains markup."
+                );
+            } else {
                 return null; # Block not found, return null
+            }
         }
 
         $S_blockStart = $this->findBlockStart($S_tagPos);
@@ -350,13 +358,14 @@ class TemplateProcessor
         
         $xmlBlock = $this->getSlice($S_blockEnd, $E_blockStart);
 
-        if($replace){
+        if ($replace) {
             $result = $this->getSlice(0, $S_blockStart);
             for ($i = 1; $i <= $clones; $i++) {
-                if($incrementVariables)
+                if ($incrementVariables) {
                     $result .= preg_replace('/\$\{(.*?)\}/', '\${\\1#' . $i . '}', $xmlBlock);
-                else
+                } else {
                     $result .= $xmlBlock;
+                }
             }
             $result .= $this->getSlice($E_blockEnd);
 
@@ -374,7 +383,8 @@ class TemplateProcessor
      *
      * @return string|null
      */
-    public function getBlock($blockname, $throwexception = false){
+    public function getBlock($blockname, $throwexception = false)
+    {
         return $this->cloneBlock($blockname, 1, false, $throwexception);
     }
     /**
@@ -394,9 +404,13 @@ class TemplateProcessor
         $S_tagPos = strpos($this->tempDocumentMainPart, $S_search);
         $E_tagPos = strpos($this->tempDocumentMainPart, $E_search, $S_tagPos);
         if (!$S_tagPos || !$E_tagPos) {
-            if($throwexception)
-                throw new Exception("Can not find block '$blockname', template variable not found or variable contains markup.");
-            else return false;
+            if ($throwexception) {
+                throw new Exception(
+                    "Can not find block '$blockname', template variable not found or variable contains markup."
+                );
+            } else {
+                return false;
+            }
         }
 
         $S_blockStart = $this->findBlockStart($S_tagPos);
@@ -585,10 +599,18 @@ class TemplateProcessor
      */
     protected function findRowStart($offset)
     {
-        $rowStart = strrpos($this->tempDocumentMainPart, '<w:tr ', ((strlen($this->tempDocumentMainPart) - $offset) * -1));
+        $rowStart = strrpos(
+            $this->tempDocumentMainPart,
+            '<w:tr ',
+            ((strlen($this->tempDocumentMainPart) - $offset) * -1)
+        );
 
         if (!$rowStart) {
-            $rowStart = strrpos($this->tempDocumentMainPart, '<w:tr>', ((strlen($this->tempDocumentMainPart) - $offset) * -1));
+            $rowStart = strrpos(
+                $this->tempDocumentMainPart,
+                '<w:tr>',
+                ((strlen($this->tempDocumentMainPart) - $offset) * -1)
+            );
         }
         if (!$rowStart) {
             throw new Exception('Can not find the start position of the row to clone.');
@@ -605,13 +627,21 @@ class TemplateProcessor
      * @return integer
      *
      * @throws \PhpOffice\PhpWord\Exception\Exception
-     */ 
+     */
     protected function findBlockStart($offset)
     {
-        $blockStart = strrpos($this->tempDocumentMainPart, '<w:p ', ((strlen($this->tempDocumentMainPart) - $offset) * -1));
+        $blockStart = strrpos(
+            $this->tempDocumentMainPart,
+            '<w:p ',
+            ((strlen($this->tempDocumentMainPart) - $offset) * -1)
+        );
 
         if (!$blockStart) {
-            $blockStart = strrpos($this->tempDocumentMainPart, '<w:p>', ((strlen($this->tempDocumentMainPart) - $offset) * -1));
+            $blockStart = strrpos(
+                $this->tempDocumentMainPart,
+                '<w:p>',
+                ((strlen($this->tempDocumentMainPart) - $offset) * -1)
+            );
         }
         if (!$blockStart) {
             throw new Exception('Can not find the start position of the row to clone.');


### PR DESCRIPTION
What is new?
- cloneBlock() with variables inside now expand like cloneRow() does, with #n at the end (and you can get the old behavior back with an extra parameter)
- Block functions now return sensible information instead of void
- you can throw exceptions if you can not find a block (enabled by an extra parameter)
- getBlock() implemented
- Multiple same named blocks behave as before (you can replace them one by one)
- Testcases! Now we cover a lot more (for Block functions)
- Scrutinize, phpunit and phpcs compliant now (third try, fingers crossed)

Details:
I removed the regular expression (which did not work). I got one working (fairly good at regexp), but it seems PHP7 does not like multiple non-greedy patterns. The need to anchor the query to <?xml> is very dirty). 
So I implemented the findBlockStart() and findBlockEnd(), similar to what cloneRow() uses, that search upto a paragraph change <w:p>, This has been tested with LibreOffice generated docx (that features <w:p>) and real MSOffice documents (that features extra parameters, nb: <w:p w:rsidR="00AC46F7" w:rsidRDefault="00AC46F7" w:rsidP="00AC46F7">). As well as a few new testcases to cover the new functionality.

Future: getRow(), cloneRow($search, $numberOfClones, $incrementVariables = true)
setImage() (replaces only the file inside the zip, not the formatting)

Todo: Tested under PHP 7.0.22 maybe try older versions too (although no PHP7-only have been used).