### PR TITLE
FBnil patch blocks

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -665,7 +665,7 @@ class TemplateProcessor
         }
         if (!$tagStart) {
             if ($throwexception) {
-                throw new Exception('Can not find the start position of the row to clone.');
+                throw new Exception('Can not find the start position of the item to clone.');
             } else {
                 return 0;
             }

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -262,22 +262,33 @@ class TemplateProcessor
      * @param string $search
      * @param integer $numberOfClones
      *
-     * @return void
+     * @return string|null
      *
      * @throws \PhpOffice\PhpWord\Exception\Exception
      */
-    public function cloneRow($search, $numberOfClones)
-    {
+    public function cloneRow(
+        $search,
+        $numberOfClones = 1,
+        $replace = true,
+        $incrementVariables = true,
+        $throwexception = false
+    ) {
         if ('${' !== substr($search, 0, 2) && '}' !== substr($search, -1)) {
             $search = '${' . $search . '}';
         }
 
         $tagPos = strpos($this->tempDocumentMainPart, $search);
         if (!$tagPos) {
-            throw new Exception("Can not clone row, template variable not found or variable contains markup.");
+            if ($throwexception) {
+                throw new Exception(
+                    "Can not clone row, template variable not found or variable contains markup."
+                );
+            } else {
+                return null;
+            }
         }
 
-        $rowStart = $this->findRowStart($tagPos);
+        $rowStart = $this->findRowStart($tagPos, $throwexception);
         $rowEnd = $this->findRowEnd($tagPos);
         $xmlRow = $this->getSlice($rowStart, $rowEnd);
 
@@ -286,7 +297,7 @@ class TemplateProcessor
             // $extraRowStart = $rowEnd;
             $extraRowEnd = $rowEnd;
             while (true) {
-                $extraRowStart = $this->findRowStart($extraRowEnd + 1);
+                $extraRowStart = $this->findRowStart($extraRowEnd + 1, $throwexception);
                 $extraRowEnd = $this->findRowEnd($extraRowEnd + 1);
 
                 // If extraRowEnd is lower then 7, there was no next row found.
@@ -306,13 +317,21 @@ class TemplateProcessor
             $xmlRow = $this->getSlice($rowStart, $rowEnd);
         }
 
-        $result = $this->getSlice(0, $rowStart);
-        for ($i = 1; $i <= $numberOfClones; $i++) {
-            $result .= preg_replace('/\$\{(.*?)\}/', '\${\\1#' . $i . '}', $xmlRow);
-        }
-        $result .= $this->getSlice($rowEnd);
+        if ($replace) {
+            $result = $this->getSlice(0, $rowStart);
+            for ($i = 1; $i <= $numberOfClones; $i++) {
+                if ($incrementVariables) {
+                    $result .= preg_replace('/\$\{(.*?)\}/', '\${\\1#' . $i . '}', $xmlRow);
+                } else {
+                    $result .= $xmlRow;
+                }
+            }
+            $result .= $this->getSlice($rowEnd);
 
-        $this->tempDocumentMainPart = $result;
+            $this->tempDocumentMainPart = $result;
+        }
+
+        return $xmlRow;
     }
 
     /**
@@ -326,39 +345,58 @@ class TemplateProcessor
      *
      * @return string|null
      */
-    public function cloneBlock($blockname, $clones = 1, $replace = true, $incrementVariables = true, $throwexception = false)
-    {
-        $S_search = '${'  . $blockname . '}';
-        $E_search = '${/' . $blockname . '}';
+    public function cloneBlock(
+        $blockname,
+        $clones = 1,
+        $replace = true,
+        $incrementVariables = true,
+        $throwexception = false
+    ) {
+        $startSearch = '${'  . $blockname . '}';
+        $endSearch = '${/' . $blockname . '}';
 
-        $S_tagPos = strpos($this->tempDocumentMainPart, $S_search);
-        $E_tagPos = strpos($this->tempDocumentMainPart, $E_search, $S_tagPos);
-        if (!$S_tagPos || !$E_tagPos) {
-            if($throwexception)
-                throw new Exception("Can not find block '$blockname', template variable not found or variable contains markup.");
-            else
-                return null; # Block not found, return null
+        $startTagPos = strpos($this->tempDocumentMainPart, $startSearch);
+        $endTagPos = strpos($this->tempDocumentMainPart, $endSearch, $startTagPos);
+        if (!$startTagPos || !$endTagPos) {
+            if ($throwexception) {
+                throw new Exception(
+                    "Can not find block '$blockname', template variable not found or variable contains markup."
+                );
+            } else {
+                return null; // Block not found, return null
+            }
         }
 
-        $S_blockStart = $this->findBlockStart($S_tagPos);
-        $S_blockEnd = $this->findBlockEnd($S_tagPos);
-        #$xmlStart = $this->getSlice($S_blockStart, $S_blockEnd);
+        $startBlockStart = $this->findBlockStart($startTagPos, $throwexception);
+        $startBlockEnd = $this->findBlockEnd($startTagPos);
+        // $xmlStart = $this->getSlice($startBlockStart, $startBlockEnd);
 
-        $E_blockStart = $this->findBlockStart($E_tagPos);
-        $E_blockEnd = $this->findBlockEnd($E_tagPos);
-        #$xmlEnd = $this->getSlice($E_blockStart, $E_blockEnd);
-        
-        $xmlBlock = $this->getSlice($S_blockEnd, $E_blockStart);
+        $endBlockStart = $this->findBlockStart($endTagPos, $throwexception);
+        $endBlockEnd = $this->findBlockEnd($endTagPos);
+        // $xmlEnd = $this->getSlice($endBlockStart, $endBlockEnd);
 
-        if($replace){
-            $result = $this->getSlice(0, $S_blockStart);
-            for ($i = 1; $i <= $clones; $i++) {
-                if($incrementVariables)
-                    $result .= preg_replace('/\$\{(.*?)\}/', '\${\\1#' . $i . '}', $xmlBlock);
-                else
-                    $result .= $xmlBlock;
+        if (!$startBlockStart || !$startBlockEnd || !$endBlockStart || !$endBlockEnd) {
+            if ($throwexception) {
+                throw new Exception(
+                    "Can not find paragraph around block '$blockname'"
+                );
+            } else {
+                return false;
             }
-            $result .= $this->getSlice($E_blockEnd);
+        }
+
+        $xmlBlock = $this->getSlice($startBlockEnd, $endBlockStart);
+
+        if ($replace) {
+            $result = $this->getSlice(0, $startBlockStart);
+            for ($i = 1; $i <= $clones; $i++) {
+                if ($incrementVariables) {
+                    $result .= preg_replace('/\$\{(.*?)\}/', '\${\\1#' . $i . '}', $xmlBlock);
+                } else {
+                    $result .= $xmlBlock;
+                }
+            }
+            $result .= $this->getSlice($endBlockEnd);
 
             $this->tempDocumentMainPart = $result;
         }
@@ -374,9 +412,24 @@ class TemplateProcessor
      *
      * @return string|null
      */
-    public function getBlock($blockname, $throwexception = false){
-        return $this->cloneBlock($blockname, 1, false, $throwexception);
+    public function getBlock($blockname, $throwexception = false)
+    {
+        return $this->cloneBlock($blockname, 1, false, false, $throwexception);
     }
+
+    /**
+     * Get a row. (first block found)
+     *
+     * @param string $rowname
+     * @param boolean $throwexception
+     *
+     * @return string|null
+     */
+    public function getRow($rowname, $throwexception = false)
+    {
+        return $this->cloneRow($rowname, 1, false, false, $throwexception);
+    }
+
     /**
      * Replace a block.
      *
@@ -388,33 +441,44 @@ class TemplateProcessor
      */
     public function replaceBlock($blockname, $replacement, $throwexception = false)
     {
-        $S_search = '${'  . $blockname . '}';
-        $E_search = '${/' . $blockname . '}';
+        $startSearch = '${'  . $blockname . '}';
+        $endSearch = '${/' . $blockname . '}';
 
-        $S_tagPos = strpos($this->tempDocumentMainPart, $S_search);
-        $E_tagPos = strpos($this->tempDocumentMainPart, $E_search, $S_tagPos);
-        if (!$S_tagPos || !$E_tagPos) {
-            if($throwexception)
-                throw new Exception("Can not find block '$blockname', template variable not found or variable contains markup.");
-            else return false;
+        $startTagPos = strpos($this->tempDocumentMainPart, $startSearch);
+        $endTagPos = strpos($this->tempDocumentMainPart, $endSearch, $startTagPos);
+
+        if (!$startTagPos || !$endTagPos) {
+            if ($throwexception) {
+                throw new Exception(
+                    "Can not find block '$blockname', template variable not found or variable contains markup."
+                );
+            } else {
+                return false;
+            }
         }
 
-        $S_blockStart = $this->findBlockStart($S_tagPos);
-        $S_blockEnd = $this->findBlockEnd($S_tagPos);
-        #$xmlStart = $this->getSlice($S_blockStart, $S_blockEnd);
+        $startBlockStart = $this->findBlockStart($startTagPos, $throwexception);
+        $startBlockEnd = $this->findBlockEnd($startTagPos);
 
-        $E_blockStart = $this->findBlockStart($E_tagPos);
-        $E_blockEnd = $this->findBlockEnd($E_tagPos);
-        #$xmlEnd = $this->getSlice($E_blockStart, $E_blockEnd);
-        
-        $xmlBlock = $this->getSlice($S_blockEnd, $E_blockStart);
-        
-        $result  = $this->getSlice(0, $S_blockStart);
+        $endBlockStart = $this->findBlockStart($endTagPos, $throwexception);
+        $endBlockEnd = $this->findBlockEnd($endTagPos);
+
+        if (!$startBlockStart || !$startBlockEnd || !$endBlockStart || !$endBlockEnd) {
+            if ($throwexception) {
+                throw new Exception(
+                    "Can not find paragraph around block '$blockname'"
+                );
+            } else {
+                return false;
+            }
+        }
+
+        $result  = $this->getSlice(0, $startBlockStart);
         $result .= $replacement;
-        $result .= $this->getSlice($E_blockEnd);
+        $result .= $this->getSlice($endBlockEnd);
 
         $this->tempDocumentMainPart = $result;
-        
+
         return true;
     }
 
@@ -575,61 +639,82 @@ class TemplateProcessor
     }
 
     /**
+     * Find the start position of the nearest tag before $offset.
+     *
+     * @param string $tag
+     * @param integer $offset
+     * @@param boolean $throwexception
+     *
+     * @return integer
+     *
+     * @throws \PhpOffice\PhpWord\Exception\Exception
+     */
+    protected function findTagLeft($tag, $offset = 0, $throwexception = false)
+    {
+        $tagStart = strrpos(
+            $this->tempDocumentMainPart,
+            substr($tag, 0, -1) . ' ',
+            ((strlen($this->tempDocumentMainPart) - $offset) * -1)
+        );
+
+        if (!$tagStart) {
+            $tagStart = strrpos(
+                $this->tempDocumentMainPart,
+                $tag,
+                ((strlen($this->tempDocumentMainPart) - $offset) * -1)
+            );
+        }
+        if (!$tagStart) {
+            if ($throwexception) {
+                throw new Exception('Can not find the start position of the row to clone.');
+            } else {
+                return 0;
+            }
+        }
+
+        return $tagStart;
+    }
+
+    /**
      * Find the start position of the nearest table row before $offset.
      *
      * @param integer $offset
+     * @param boolean $throwexception
      *
      * @return integer
      *
      * @throws \PhpOffice\PhpWord\Exception\Exception
      */
-    protected function findRowStart($offset)
+    protected function findRowStart($offset, $throwexception)
     {
-        $rowStart = strrpos($this->tempDocumentMainPart, '<w:tr ', ((strlen($this->tempDocumentMainPart) - $offset) * -1));
-
-        if (!$rowStart) {
-            $rowStart = strrpos($this->tempDocumentMainPart, '<w:tr>', ((strlen($this->tempDocumentMainPart) - $offset) * -1));
-        }
-        if (!$rowStart) {
-            throw new Exception('Can not find the start position of the row to clone.');
-        }
-
-        return $rowStart;
+        return $this->findTagLeft('<w:tr>', $offset, $throwexception);
     }
 
     /**
-     * Find the start position of the nearest paragraph (<w:p ...>) before $offset.
+     * Find the start position of the nearest paragraph before $offset.
      *
      * @param integer $offset
+     * @param boolean $throwexception
      *
      * @return integer
      *
      * @throws \PhpOffice\PhpWord\Exception\Exception
-     */ 
-    protected function findBlockStart($offset)
+     */
+    protected function findBlockStart($offset, $throwexception)
     {
-        $blockStart = strrpos($this->tempDocumentMainPart, '<w:p ', ((strlen($this->tempDocumentMainPart) - $offset) * -1));
-
-        if (!$blockStart) {
-            $blockStart = strrpos($this->tempDocumentMainPart, '<w:p>', ((strlen($this->tempDocumentMainPart) - $offset) * -1));
-        }
-        if (!$blockStart) {
-            throw new Exception('Can not find the start position of the row to clone.');
-        }
-
-        return $blockStart;
+        return $this->findTagLeft('<w:p>', $offset, $throwexception);
     }
-    
+
     /**
-     * Find the end position of the nearest paragraph (</w:p>) after $offset.
+     * Find the end position of the nearest tag after $offset.
      *
      * @param integer $offset
      *
      * @return integer
      */
-    protected function findRowEnd($offset)
+    protected function findTagRight($tag, $offset = 0)
     {
-        return strpos($this->tempDocumentMainPart, '</w:tr>', $offset) + 7;
+        return strpos($this->tempDocumentMainPart, $tag, $offset) + strlen($tag);
     }
 
     /**
@@ -639,9 +724,21 @@ class TemplateProcessor
      *
      * @return integer
      */
+    protected function findRowEnd($offset)
+    {
+        return $this->findTagRight('</w:tr>', $offset);
+    }
+
+    /**
+     * Find the end position of the nearest paragraph after $offset.
+     *
+     * @param integer $offset
+     *
+     * @return integer
+     */
     protected function findBlockEnd($offset)
     {
-        return strpos($this->tempDocumentMainPart, '</w:p>', $offset) + 6;
+        return $this->findTagRight('</w:p>', $offset);
     }
 
     /**

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -300,8 +300,7 @@ class TemplateProcessor
                 $extraRowStart = $this->findRowStart($extraRowEnd + 1, $throwexception);
                 $extraRowEnd = $this->findRowEnd($extraRowEnd + 1);
 
-                // If extraRowEnd is lower then 7, there was no next row found.
-                if ($extraRowEnd < 7) {
+                if (!$extraRowEnd) {
                     break;
                 }
 
@@ -714,7 +713,12 @@ class TemplateProcessor
      */
     protected function findTagRight($tag, $offset = 0)
     {
-        return strpos($this->tempDocumentMainPart, $tag, $offset) + strlen($tag);
+        $pos = strpos($this->tempDocumentMainPart, $tag, $offset);
+        if ($pos) {
+            return $pos + strlen($tag);
+        } else {
+            return 0;
+        }
     }
 
     /**

--- a/tests/PhpWord/TemplateProcessorTest.php
+++ b/tests/PhpWord/TemplateProcessorTest.php
@@ -157,6 +157,10 @@ final class TemplateProcessorTest extends \PHPUnit_Framework_TestCase
      * @covers ::setValue
      * @covers ::cloneRow
      * @covers ::saveAs
+     * @covers ::findTagLeft
+     * @covers ::findTagRight
+     * @covers ::findBlockEnd
+     * @covers ::findBlockStart
      * @test
      */
     public function testCloneRow()
@@ -176,6 +180,53 @@ final class TemplateProcessorTest extends \PHPUnit_Framework_TestCase
         $docFound = file_exists($docName);
         unlink($docName);
         $this->assertTrue($docFound);
+    }
+
+    /**
+     * @covers ::getRow
+     * @covers ::saveAs
+     * @covers ::findRowStart
+     * @covers ::findRowEnd
+     * @covers ::findTagLeft
+     * @covers ::findTagRight
+     * @test
+     */
+    public function testGetRow()
+    {
+        $templateProcessor = new TemplateProcessor(__DIR__ . '/_files/templates/clone-merge.docx');
+        $initialArray = array('tableHeader', 'userId', 'userName', 'userLocation');
+        $finalArray = array(
+            'tableHeader',
+            'userId#1', 'userName#1', 'userLocation#1',
+            'userId#2', 'userName#2', 'userLocation#2'
+        );
+        $row = $templateProcessor->getRow('userId');
+        $this->assertNotEmpty($row);
+        $this->assertEquals(
+            $initialArray,
+            $templateProcessor->getVariables()
+        );
+        $row = $templateProcessor->cloneRow('userId', 2);
+        $this->assertStringStartsWith('<w:tr', $row);
+        $this->assertStringEndsWith('</w:tr>', $row);
+        $this->assertNotEmpty($row);
+        $this->assertEquals(
+            $finalArray,
+            $templateProcessor->getVariables()
+        );
+
+        $docName = 'test-getRow-result.docx';
+        $templateProcessor->saveAs($docName);
+        $docFound = file_exists($docName);
+        $this->assertTrue($docFound);
+        if ($docFound) {
+            $templateProcessorNEWFILE = $this->getOpenTemplateProcessor($docName);
+            $this->assertEquals(
+                $finalArray,
+                $templateProcessorNEWFILE->getVariables()
+            );
+            unlink($docName);
+        }
     }
 
     /**
@@ -201,10 +252,34 @@ final class TemplateProcessorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Convoluted way to get a helper class, without using include_once (not allowed by phpcs)
+     * or inline (not allowed by phpcs) or touching the autoload.php (and make it accessible to users)
+     * this helper class returns a TemplateProcessor that allows access to private variables
+     * like tempDocumentMainPart, see the functions that use it for usage.
+     * eval is evil, but phpcs and phpunit made me do it!
+     */
+    private function getOpenTemplateProcessor($name)
+    {
+        if (!file_exists($name) || !is_readable($name)) {
+            return null;
+        }
+        $ESTR =
+            'class OpenTemplateProcessor extends \PhpOffice\PhpWord\TemplateProcessor {'
+            . 'public function __construct($instance){return parent::__construct($instance);}'
+            . 'public function __get($key){return $this->$key;}'
+            . 'public function __set($key, $val){return $this->$key = $val;} };'
+            . 'return new OpenTemplateProcessor("'.$name.'");';
+        return eval($ESTR);
+    }
+    /**
      * @covers ::cloneBlock
      * @covers ::deleteBlock
      * @covers ::getBlock
      * @covers ::saveAs
+     * @covers ::findBlockEnd
+     * @covers ::findBlockStart
+     * @covers ::findTagLeft
+     * @covers ::findTagRight
      * @test
      */
     public function testCloneDeleteBlock()
@@ -223,10 +298,10 @@ final class TemplateProcessorTest extends \PHPUnit_Framework_TestCase
         $templateProcessor->deleteBlock('DELETEME');
         $templateProcessor->saveAs($docName);
         $docFound = file_exists($docName);
-        if($docFound){
+        if ($docFound) {
             # Great, so we saved the replaced document, so we open that new document
             # note that we need to access private variables, so we use a sub-class
-            $templateProcessorNEWFILE = new OpenTemplateProcessor($docName);
+            $templateProcessorNEWFILE = $this->getOpenTemplateProcessor($docName);
             # We test that all Block variables have been replaced (thus, getVariables() is empty)
             $this->assertEquals(
                 [],
@@ -234,7 +309,8 @@ final class TemplateProcessorTest extends \PHPUnit_Framework_TestCase
                 "All block variables should have been replaced"
             );
             # we cloned block CLONEME $clone_times times, so let's count to $clone_times
-            $this->assertEquals($clone_times,
+            $this->assertEquals(
+                $clone_times,
                 substr_count($templateProcessorNEWFILE->tempDocumentMainPart, $xmlblock),
                 "Block should be present $clone_times in the document"
             );
@@ -244,9 +320,16 @@ final class TemplateProcessorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($docFound);
     }
 
+    /**
+     * @covers ::cloneBlock
+     * @covers ::getVariables
+     * @covers ::getBlock
+     * @covers ::setValue
+     * @test
+     */
     public function testCloneIndexedBlock()
     {
-        $templateProcessor = new OpenTemplateProcessor(__DIR__ . '/_files/templates/blank.docx');
+        $templateProcessor = $this->getOpenTemplateProcessor(__DIR__ . '/_files/templates/blank.docx');
         # we will fake a block with a variable inside it, as there is no template document yet.
         $XMLTXT = '<w:p>This ${repeats} a few times</w:p>';
         $XMLSTR = '<?xml><w:p>${MYBLOCK}</w:p>' . $XMLTXT . '<w:p>${/MYBLOCK}</w:p>';
@@ -274,9 +357,9 @@ final class TemplateProcessorTest extends \PHPUnit_Framework_TestCase
         );
 
         $ARR = [
-            'repeats#1' => 'ONE', 
-            'repeats#2' => 'TWO', 
-            'repeats#3' => 'THREE', 
+            'repeats#1' => 'ONE',
+            'repeats#2' => 'TWO',
+            'repeats#3' => 'THREE',
             'repeats#4' => 'FOUR'
         ];
         $templateProcessor->setValue(array_keys($ARR), array_values($ARR));
@@ -288,10 +371,11 @@ final class TemplateProcessorTest extends \PHPUnit_Framework_TestCase
 
         # now we test the order of replacement: ONE,TWO,THREE then FOUR
         $STR = "";
-        foreach($ARR as $k => $v){
-            $STR .= str_replace('${repeats}',$v, $XMLTXT);
+        foreach ($ARR as $k => $v) {
+            $STR .= str_replace('${repeats}', $v, $XMLTXT);
         }
-        $this->assertEquals(1,
+        $this->assertEquals(
+            1,
             substr_count($templateProcessor->tempDocumentMainPart, $STR),
             "order of replacement should be: ONE,TWO,THREE then FOUR"
         );
@@ -308,35 +392,17 @@ final class TemplateProcessorTest extends \PHPUnit_Framework_TestCase
         );
 
         # we cloned block CLONEME 4 times, so let's count
-        $this->assertEquals(4,
+        $this->assertEquals(
+            4,
             substr_count($templateProcessor->tempDocumentMainPart, $XMLTXT),
             'detects new variable $repeats to be present 4 times'
         );
 
         # we cloned block CLONEME 4 times, so let's see that there is no space between these blocks
-        $this->assertEquals(1,
+        $this->assertEquals(
+            1,
             substr_count($templateProcessor->tempDocumentMainPart, $XMLTXT.$XMLTXT.$XMLTXT.$XMLTXT),
             "The four times cloned block should be the same as four times the block"
         );
-    }
-
-}
-
-/**
- * used by testCloneDeleteBlock and testCloneIndexedBlock to access private variables in a TemplateProcessor
- * @test
- */
-class OpenTemplateProcessor extends \PhpOffice\PhpWord\TemplateProcessor
-{
-    public function __construct($instance) {
-        return parent::__construct($instance);
-    }
-
-    public function __get($key) {
-        return $this->$key;
-    }
-
-    public function __set($key, $val) {
-        return $this->$key = $val;
     }
 }


### PR DESCRIPTION
I removed the regexp (although I had a working regexp, it seems PHP7 does not like multiple non-greedy patterns. The need to anchor the query to <?xml> is very dirty). 
So I implemented the findBlockStart() and findBlockEnd() that search upto a paragraph change <w:p>, This has been tested with LibreOffice generated docx (that features <w:p>) and real MSOffice documents (that features extra parameters, nb: <w:p w:rsidR="00AC46F7" w:rsidRDefault="00AC46F7" w:rsidP="00AC46F7">). As well as a few new testcases to cover the new functionality.

What is new?

- Blocks with variables inside now expand like Rows, with #n at the end (and you can get the old behavior back with an extra parameter)
- Block functions now use the same method as Row functions to detect start/end
- Block functions now return sensible information instead of void
- You can optionally throw exceptions if you can not find a block (enabled by an extra function parameter)
- getBlock() implemented
- Complete coverage of unit tests (including obvious missing tests) for Block functions
- Multiple same named blocks behave as before (you can replace them one by one)
- Went through phpcs and phpunit to test everything. All tests pass* All formatting passes*

Files modified:
./src/PhpWord/TemplateProcessor.php
./tests/PhpWord/OpenTemplateProcessor.php
./tests/PhpWord/TemplateProcessorTest.php

OpenTemplateProcessor is a subclass that allows access to the private fields in TemplateProcessor. This is required for good testing of the output results.

Tested with:
- phpunit --bootstrap autoload.php phpoffice/PHPWord/tests/PhpWord/TemplateProcessorTest.php
- phpcs ./src/PhpWord/TemplateProcessor.php ./tests/PhpWord/TemplateProcessorTest.php --standard=PSR2


Todo: Tested under PHP 7.0.22 maybe try older versions too (although no PHP7-only have been used).
