### PR TITLE
Fixed illegal offset Exception on save W'07 doc

### DIFF
--- a/src/PhpWord/Writer/Word2007/Part/Settings.php
+++ b/src/PhpWord/Writer/Word2007/Part/Settings.php
@@ -268,11 +268,14 @@ class Settings extends AbstractPart
     {
         $compatibility = $this->getParentWriter()->getPhpWord()->getCompatibility();
         if ($compatibility->getOoxmlVersion() !== null) {
-            $this->settings['w:compat']['w:compatSetting'] = array('@attributes' => array(
-                'w:name'    => 'compatibilityMode',
-                'w:uri'     => 'http://schemas.microsoft.com/office/word',
-                'w:val'     => $compatibility->getOoxmlVersion(),
-            ));
+            $this->settings['w:compat'] = array(
+                'w:compatSetting' => array('@attributes' => array(
+                    'w:name'    => 'compatibilityMode',
+                    'w:uri'     => 'http://schemas.microsoft.com/office/word',
+                    'w:val'     => $compatibility->getOoxmlVersion(),
+                ))
+            );
+
         }
     }
 }


### PR DESCRIPTION
`$this->settings['w:compat']` was the `string` type value. Don't ask me why)