### PR TITLE
HTML (and PDF) style fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ vendor
 phpword.ini
 /.buildpath
 /.project
+/nbproject

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This is the last version to support PHP 5.3
 - Impossible to add element PreserveText in Section - @rvanlaak #452
 - Added missing options for numbering format - @troosan #1041
 - Fixed impossibility to set a different footer for first page - @ctrlaltca #1116
+- Fixed styles not being applied by HTML writer, better pdf output - @sarke #1047 #500 #1139
 
 v0.13.0 (31 July 2016)
 -------------------

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "squizlabs/php_codesniffer": "1.*",
         "phpmd/phpmd": "2.*",
         "phploc/phploc": "2.*",
-        "dompdf/dompdf":"0.6.*",
+        "dompdf/dompdf":"^0.8.1",
         "tecnickcom/tcpdf": "6.*",
         "mpdf/mpdf": "5.*"
     },

--- a/samples/Sample_Header.php
+++ b/samples/Sample_Header.php
@@ -14,8 +14,7 @@ Settings::loadConfig();
 
 $dompdfPath = $vendorDirPath . '/dompdf/dompdf';
 if (file_exists($dompdfPath)) {
-    define('DOMPDF_ENABLE_AUTOLOAD', false);
-    Settings::setPdfRenderer(Settings::PDF_RENDERER_DOMPDF, $vendorDirPath . '/dompdf/dompdf');
+    Settings::setPdfRenderer(Settings::PDF_RENDERER_DOMPDF, $dompdfPath);
 }
 
 // Set writers

--- a/samples/Sample_Header.php
+++ b/samples/Sample_Header.php
@@ -12,6 +12,12 @@ define('IS_INDEX', SCRIPT_FILENAME == 'index');
 
 Settings::loadConfig();
 
+$dompdfPath = $vendorDirPath . '/dompdf/dompdf';
+if (file_exists($dompdfPath)) {
+    define('DOMPDF_ENABLE_AUTOLOAD', false);
+    Settings::setPdfRenderer(Settings::PDF_RENDERER_DOMPDF, $vendorDirPath . '/dompdf/dompdf');
+}
+
 // Set writers
 $writers = array('Word2007' => 'docx', 'ODText' => 'odt', 'RTF' => 'rtf', 'HTML' => 'html', 'PDF' => 'pdf');
 

--- a/src/PhpWord/Writer/HTML/Element/Text.php
+++ b/src/PhpWord/Writer/HTML/Element/Text.php
@@ -122,6 +122,10 @@ class Text extends AbstractElement
             }
             $content .= "<p{$style}>";
         }
+        
+        if (method_exists($this->element, 'getFontStyle')) {
+            $style = $this->getFontStyle();
+        }
 
         return $content;
     }
@@ -167,6 +171,10 @@ class Text extends AbstractElement
             $styleWriter = new ParagraphStyleWriter($paragraphStyle);
             $style = $styleWriter->write();
         }
+        elseif (is_string($paragraphStyle)) {
+            $style = $paragraphStyle;
+        }
+
         if ($style) {
             $attribute = $pStyleIsObject ? 'style' : 'class';
             $style = " {$attribute}=\"{$style}\"";
@@ -191,6 +199,10 @@ class Text extends AbstractElement
             $styleWriter = new FontStyleWriter($fontStyle);
             $style = $styleWriter->write();
         }
+        elseif (is_string($fontStyle)) {
+            $style = $fontStyle;
+        }
+		
         if ($style) {
             $attribute = $fStyleIsObject ? 'style' : 'class';
             $this->openingTags = "<span {$attribute}=\"{$style}\">";

--- a/src/PhpWord/Writer/HTML/Element/Text.php
+++ b/src/PhpWord/Writer/HTML/Element/Text.php
@@ -170,8 +170,7 @@ class Text extends AbstractElement
         if ($pStyleIsObject) {
             $styleWriter = new ParagraphStyleWriter($paragraphStyle);
             $style = $styleWriter->write();
-        }
-        elseif (is_string($paragraphStyle)) {
+        } elseif (is_string($paragraphStyle)) {
             $style = $paragraphStyle;
         }
 
@@ -198,11 +197,10 @@ class Text extends AbstractElement
         if ($fStyleIsObject) {
             $styleWriter = new FontStyleWriter($fontStyle);
             $style = $styleWriter->write();
-        }
-        elseif (is_string($fontStyle)) {
+        } elseif (is_string($fontStyle)) {
             $style = $fontStyle;
         }
-		
+
         if ($style) {
             $attribute = $fStyleIsObject ? 'style' : 'class';
             $this->openingTags = "<span {$attribute}=\"{$style}\">";

--- a/src/PhpWord/Writer/HTML/Element/Text.php
+++ b/src/PhpWord/Writer/HTML/Element/Text.php
@@ -124,7 +124,7 @@ class Text extends AbstractElement
         }
         
         if (method_exists($this->element, 'getFontStyle')) {
-            $style = $this->getFontStyle();
+            $this->getFontStyle();
         }
 
         return $content;

--- a/src/PhpWord/Writer/HTML/Style/Font.php
+++ b/src/PhpWord/Writer/HTML/Style/Font.php
@@ -52,12 +52,16 @@ class Font extends AbstractStyle
         $css['background'] = $this->getValueIf($fgColor != '', $fgColor);
         $css['font-weight'] = $this->getValueIf($style->isBold(), 'bold');
         $css['font-style'] = $this->getValueIf($style->isItalic(), 'italic');
-        $css['vertical-align'] = $this->getValueIf($style->isSuperScript(), 'italic');
         $css['vertical-align'] = $this->getValueIf($style->isSuperScript(), 'super');
-        $css['vertical-align'] = $this->getValueIf($style->isSubScript(), 'sub');
+        $css['vertical-align'] .= $this->getValueIf($style->isSubScript(), 'sub');
         $css['text-decoration'] = '';
         $css['text-decoration'] .= $this->getValueIf($underline, 'underline ');
         $css['text-decoration'] .= $this->getValueIf($lineThrough, 'line-through ');
+        $css['text-transform'] = $this->getValueIf($style->isAllCaps(), 'uppercase');
+        $css['font-variant'] = $this->getValueIf($style->isSmallCaps(), 'small-caps');
+
+        $spacing = $style->getSpacing();
+        $css['letter-spacing'] = $this->getValueIf(!is_null($spacing), ($spacing / 20) . 'pt');
 
         return $this->assembleCss($css);
     }

--- a/src/PhpWord/Writer/HTML/Style/Paragraph.php
+++ b/src/PhpWord/Writer/HTML/Style/Paragraph.php
@@ -85,6 +85,11 @@ class Paragraph extends AbstractStyle
             $css['margin-top'] = $this->getValueIf(!is_null($before), ($before / 20) . 'pt');
             $css['margin-bottom'] = $this->getValueIf(!is_null($after), ($after / 20) . 'pt');
         }
+        else {
+            // default paragragh margin to match document. Browsers default to 1em
+            $css['margin-top'] = '0';
+            $css['margin-bottom'] = '0';
+        }
 
         return $this->assembleCss($css);
     }

--- a/src/PhpWord/Writer/HTML/Style/Paragraph.php
+++ b/src/PhpWord/Writer/HTML/Style/Paragraph.php
@@ -84,8 +84,7 @@ class Paragraph extends AbstractStyle
             $after = $spacing->getAfter();
             $css['margin-top'] = $this->getValueIf(!is_null($before), ($before / 20) . 'pt');
             $css['margin-bottom'] = $this->getValueIf(!is_null($after), ($after / 20) . 'pt');
-        }
-        else {
+        } else {
             // default paragragh margin to match document. Browsers default to 1em
             $css['margin-top'] = '0';
             $css['margin-bottom'] = '0';

--- a/src/PhpWord/Writer/PDF/AbstractRenderer.php
+++ b/src/PhpWord/Writer/PDF/AbstractRenderer.php
@@ -32,7 +32,7 @@ abstract class AbstractRenderer extends HTML
     /**
      * Name of renderer include file
      *
-     * @var string
+     * @var string|false
      */
     protected $includeFile;
 
@@ -83,15 +83,18 @@ abstract class AbstractRenderer extends HTML
     public function __construct(PhpWord $phpWord)
     {
         parent::__construct($phpWord);
-        $includeFile = Settings::getPdfRendererPath() . '/' . $this->includeFile;
-        if (file_exists($includeFile)) {
-            /** @noinspection PhpIncludeInspection Dynamic includes */
-            require_once $includeFile;
-        } else {
-            // @codeCoverageIgnoreStart
-            // Can't find any test case. Uncomment when found.
-            throw new Exception('Unable to load PDF Rendering library');
-            // @codeCoverageIgnoreEnd
+        
+        if ($this->includeFile !== false) {
+            $includeFile = Settings::getPdfRendererPath() . '/' . $this->includeFile;
+            if (file_exists($includeFile)) {
+                /** @noinspection PhpIncludeInspection Dynamic includes */
+                require_once $includeFile;
+            } else {
+                // @codeCoverageIgnoreStart
+                // Can't find any test case. Uncomment when found.
+                throw new Exception('Unable to load PDF Rendering library');
+                // @codeCoverageIgnoreEnd
+            }
         }
     }
 

--- a/src/PhpWord/Writer/PDF/DomPDF.php
+++ b/src/PhpWord/Writer/PDF/DomPDF.php
@@ -30,9 +30,9 @@ class DomPDF extends AbstractRenderer implements WriterInterface
     /**
      * Name of renderer include file
      *
-     * @var string
+     * @var string|false
      */
-    protected $includeFile = 'dompdf_config.inc.php';
+    protected $includeFile = false;
 
     /**
      * Save PhpWord to file.
@@ -49,9 +49,9 @@ class DomPDF extends AbstractRenderer implements WriterInterface
         $orientation = 'portrait';
 
         //  Create PDF
-        $pdf = new \DOMPDF();
-        $pdf->set_paper(strtolower($paperSize), $orientation);
-        $pdf->load_html($this->getContent());
+        $pdf = new \Dompdf\Dompdf();
+        $pdf->setPaper($paperSize, $orientation);
+        $pdf->loadHtml($this->getContent());
         $pdf->render();
 
         //  Write to file


### PR DESCRIPTION
- fix for HTML writer not including classes on tags
- autoload dompdf for samples if installed in vendor folder, and updated to 8.1.0
- fixed HTML superscript, and added allcaps, smallcaps, and letter-spacing
- added default HTML paragraph margin of 0 to match document style

Fixes #1047 and #500, and partially for #1139.