### PR TITLE
Allow reading of TargetMode for external images

### DIFF
--- a/src/PhpWord/Reader/Word2007.php
+++ b/src/PhpWord/Reader/Word2007.php
@@ -148,6 +148,7 @@ class Word2007 extends AbstractReader implements ReaderInterface
             $rId = $xmlReader->getAttribute('Id', $node);
             $type = $xmlReader->getAttribute('Type', $node);
             $target = $xmlReader->getAttribute('Target', $node);
+            $mode = $xmlReader->getAttribute('TargetMode', $node);
 
             // Remove URL prefixes from $type to make it easier to read
             $type = str_replace($metaPrefix, '', $type);
@@ -155,12 +156,12 @@ class Word2007 extends AbstractReader implements ReaderInterface
             $docPart = str_replace('.xml', '', $target);
 
             // Do not add prefix to link source
-            if (!in_array($type, array('hyperlink'))) {
+            if ($type != 'hyperlink' && $mode != 'External') {
                 $target = $targetPrefix . $target;
             }
 
             // Push to return array
-            $rels[$rId] = array('type' => $type, 'target' => $target, 'docPart' => $docPart);
+            $rels[$rId] = array('type' => $type, 'target' => $target, 'docPart' => $docPart, 'targetMode' => $mode);
         }
         ksort($rels);
 

--- a/src/PhpWord/Shared/PCLZip/pclzip.lib.php
+++ b/src/PhpWord/Shared/PCLZip/pclzip.lib.php
@@ -205,14 +205,14 @@
     var $magic_quotes_status;
 
   // --------------------------------------------------------------------------------
-  // Function : PclZip()
+  // Function : __construct()
   // Description :
   //   Creates a PclZip object and set the name of the associated Zip archive
   //   filename.
   //   Note that no real action is taken, if the archive does not exist it is not
   //   created. Use create() for that.
   // --------------------------------------------------------------------------------
-  function PclZip($p_zipname)
+  function __construct($p_zipname)
   {
 
     // ----- Tests the zlib
@@ -226,7 +226,7 @@
     $this->zip_fd = 0;
     $this->magic_quotes_status = -1;
 
-    // ----- Return
+    // ----- Constructors should not Return anything
     return;
   }
   // --------------------------------------------------------------------------------


### PR DESCRIPTION
Abstract: 
    This patch changes the reader in order to handle TargetMode="External"
Closes: 
    https://github.com/PHPOffice/PHPWord/issues/1173

Explanation:

When reading from documents.xml.rels, we not often see external images, like this:
`<Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="https://somewhere/image.png" TargetMode="External"/>`

The TargetMode needs to be read and understood, to NOT default to a ZIP container for type "image" if the image is external.
Failing to do so results in an InvalidImageException while reading the file.
