### PR TITLE
489: Fix z-index size too big in 64bit OS

### DIFF
--- a/src/PhpWord/Writer/Word2007/Style/Frame.php
+++ b/src/PhpWord/Writer/Word2007/Style/Frame.php
@@ -28,6 +28,8 @@ use PhpOffice\PhpWord\Writer\Word2007\Element\ParagraphAlignment;
  */
 class Frame extends AbstractStyle
 {
+    const PHP_32BIT_INT_MAX = 2147483647;
+
     /**
      * Write style.
      *
@@ -41,7 +43,8 @@ class Frame extends AbstractStyle
         }
         $xmlWriter = $this->getXmlWriter();
 
-        $zIndices = array(FrameStyle::WRAP_INFRONT => PHP_INT_MAX, FrameStyle::WRAP_BEHIND => -PHP_INT_MAX);
+        $maxZIndex = min(PHP_INT_MAX, self::PHP_32BIT_INT_MAX);
+        $zIndices = array(FrameStyle::WRAP_INFRONT => $maxZIndex, FrameStyle::WRAP_BEHIND => -$maxZIndex);
 
         $properties = array(
             'width'     => 'width',


### PR DESCRIPTION
This is a fix for https://github.com/PHPOffice/PHPWord/issues/489

## Issue summary 
In 64bit OS, `PHP_INT_MAX = 9223372036854775807`, and it seems to be too big for MicrosoftWord XML to handle.

## Solution
Enforce the max value to `2147483647`, which is the value of PHP_INT_MAX of 32 bit OS.