### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpoffice/common": "^0.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.*",
+        "phpunit/phpunit": "^4.8.36",
         "phpdocumentor/phpdocumentor":"2.*",
         "twig/twig":"1.27",
         "squizlabs/php_codesniffer": "^2.7",

--- a/tests/PhpWord/Collection/CollectionTest.php
+++ b/tests/PhpWord/Collection/CollectionTest.php
@@ -24,7 +24,7 @@ use PhpOffice\PhpWord\Element\Footnote;
  *
  * Using concrete class Footnotes instead of AbstractCollection
  */
-class CollectionTest extends \PHPUnit_Framework_TestCase
+class CollectionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test collection

--- a/tests/PhpWord/ComplexType/FootnotePropertiesTest.php
+++ b/tests/PhpWord/ComplexType/FootnotePropertiesTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\SimpleType\NumberFormat;
  * @coversDefaultClass \PhpOffice\PhpWord\ComplexType\FootnoteProperties
  * @runTestsInSeparateProcesses
  */
-class FootnotePropertiesTest extends \PHPUnit_Framework_TestCase
+class FootnotePropertiesTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test setting style with normal value

--- a/tests/PhpWord/ComplexType/ProofStateTest.php
+++ b/tests/PhpWord/ComplexType/ProofStateTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\ComplexType;
  *
  * @coversDefaultClass \PhpOffice\PhpWord\ComplexType\ProofState
  */
-class ProofStateTest extends \PHPUnit_Framework_TestCase
+class ProofStateTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Tests the getters and setters

--- a/tests/PhpWord/Element/AbstractElementTest.php
+++ b/tests/PhpWord/Element/AbstractElementTest.php
@@ -20,7 +20,7 @@ namespace PhpOffice\PhpWord\Element;
 /**
  * Test class for PhpOffice\PhpWord\Element\AbstractElement
  */
-class AbstractElementTest extends \PHPUnit_Framework_TestCase
+class AbstractElementTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test set/get element index

--- a/tests/PhpWord/Element/BookmarkTest.php
+++ b/tests/PhpWord/Element/BookmarkTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Element;
  *
  * @runTestsInSeparateProcesses
  */
-class BookmarkTest extends \PHPUnit_Framework_TestCase
+class BookmarkTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * New instance

--- a/tests/PhpWord/Element/CellTest.php
+++ b/tests/PhpWord/Element/CellTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Element;
  *
  * @runTestsInSeparateProcesses
  */
-class CellTest extends \PHPUnit_Framework_TestCase
+class CellTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * New instance

--- a/tests/PhpWord/Element/CheckBoxTest.php
+++ b/tests/PhpWord/Element/CheckBoxTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\Style\Font;
  *
  * @runTestsInSeparateProcesses
  */
-class CheckBoxTest extends \PHPUnit_Framework_TestCase
+class CheckBoxTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Construct

--- a/tests/PhpWord/Element/CommentTest.php
+++ b/tests/PhpWord/Element/CommentTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Element;
  *
  * @runTestsInSeparateProcesses
  */
-class CommentTest extends \PHPUnit_Framework_TestCase
+class CommentTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * New instance

--- a/tests/PhpWord/Element/FieldTest.php
+++ b/tests/PhpWord/Element/FieldTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Element;
  *
  * @runTestsInSeparateProcesses
  */
-class FieldTest extends \PHPUnit_Framework_TestCase
+class FieldTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * New instance

--- a/tests/PhpWord/Element/FooterTest.php
+++ b/tests/PhpWord/Element/FooterTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Element;
  *
  * @runTestsInSeparateProcesses
  */
-class FooterTest extends \PHPUnit_Framework_TestCase
+class FooterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * New instance

--- a/tests/PhpWord/Element/FootnoteTest.php
+++ b/tests/PhpWord/Element/FootnoteTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Element;
  *
  * @runTestsInSeparateProcesses
  */
-class FootnoteTest extends \PHPUnit_Framework_TestCase
+class FootnoteTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * New instance without parameter

--- a/tests/PhpWord/Element/HeaderTest.php
+++ b/tests/PhpWord/Element/HeaderTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Element;
  *
  * @runTestsInSeparateProcesses
  */
-class HeaderTest extends \PHPUnit_Framework_TestCase
+class HeaderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * New instance

--- a/tests/PhpWord/Element/ImageTest.php
+++ b/tests/PhpWord/Element/ImageTest.php
@@ -24,7 +24,7 @@ use PhpOffice\PhpWord\SimpleType\Jc;
  *
  * @runTestsInSeparateProcesses
  */
-class ImageTest extends \PHPUnit_Framework_TestCase
+class ImageTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * New instance

--- a/tests/PhpWord/Element/LineTest.php
+++ b/tests/PhpWord/Element/LineTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Element;
  * @coversDefaultClass \PhpOffice\PhpWord\Element\Line
  * @runTestsInSeparateProcesses
  */
-class LineTest extends \PHPUnit_Framework_TestCase
+class LineTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Create new instance

--- a/tests/PhpWord/Element/LinkTest.php
+++ b/tests/PhpWord/Element/LinkTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\Style\Font;
  * @coversDefaultClass \PhpOffice\PhpWord\Element\Link
  * @runTestsInSeparateProcesses
  */
-class LinkTest extends \PHPUnit_Framework_TestCase
+class LinkTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Create new instance

--- a/tests/PhpWord/Element/ListItemRunTest.php
+++ b/tests/PhpWord/Element/ListItemRunTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Element;
  *
  * @runTestsInSeparateProcesses
  */
-class ListItemRunTest extends \PHPUnit_Framework_TestCase
+class ListItemRunTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * New instance

--- a/tests/PhpWord/Element/ListItemTest.php
+++ b/tests/PhpWord/Element/ListItemTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Element;
  * @coversDefaultClass \PhpOffice\PhpWord\Element\ListItem
  * @runTestsInSeparateProcesses
  */
-class ListItemTest extends \PHPUnit_Framework_TestCase
+class ListItemTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Get text object

--- a/tests/PhpWord/Element/ObjectTest.php
+++ b/tests/PhpWord/Element/ObjectTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Element;
  * @coversDefaultClass \PhpOffice\PhpWord\Element\Object
  * @runTestsInSeparateProcesses
  */
-class ObjectTest extends \PHPUnit_Framework_TestCase
+class ObjectTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Create new instance with supported files, 4 character extention

--- a/tests/PhpWord/Element/PageBreakTest.php
+++ b/tests/PhpWord/Element/PageBreakTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Element;
  * @coversDefaultClass \PhpOffice\PhpWord\Element\PageBreak
  * @runTestsInSeparateProcesses
  */
-class PageBreakTest extends \PHPUnit_Framework_TestCase
+class PageBreakTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Executed before each method of the class

--- a/tests/PhpWord/Element/PreserveTextTest.php
+++ b/tests/PhpWord/Element/PreserveTextTest.php
@@ -24,7 +24,7 @@ use PhpOffice\PhpWord\SimpleType\Jc;
  *
  * @runTestsInSeparateProcesses
  */
-class PreserveTextTest extends \PHPUnit_Framework_TestCase
+class PreserveTextTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Create new instance

--- a/tests/PhpWord/Element/RowTest.php
+++ b/tests/PhpWord/Element/RowTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Element;
  * @coversDefaultClass \PhpOffice\PhpWord\Element\Row
  * @runTestsInSeparateProcesses
  */
-class RowTest extends \PHPUnit_Framework_TestCase
+class RowTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Create new instance

--- a/tests/PhpWord/Element/SDTTest.php
+++ b/tests/PhpWord/Element/SDTTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Element;
  *
  * @coversDefaultClass \PhpOffice\PhpWord\Element\SDT
  */
-class SDTTest extends \PHPUnit_Framework_TestCase
+class SDTTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Create new instance

--- a/tests/PhpWord/Element/SectionTest.php
+++ b/tests/PhpWord/Element/SectionTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\Style;
  * @coversDefaultClass \PhpOffice\PhpWord\Element\Section
  * @runTestsInSeparateProcesses
  */
-class SectionTest extends \PHPUnit_Framework_TestCase
+class SectionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @covers ::setStyle

--- a/tests/PhpWord/Element/TOCTest.php
+++ b/tests/PhpWord/Element/TOCTest.php
@@ -24,7 +24,7 @@ use PhpOffice\PhpWord\PhpWord;
  *
  * @runTestsInSeparateProcesses
  */
-class TOCTest extends \PHPUnit_Framework_TestCase
+class TOCTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Construct with font and TOC style in array format

--- a/tests/PhpWord/Element/TableTest.php
+++ b/tests/PhpWord/Element/TableTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Element;
  * @coversDefaultClass \PhpOffice\PhpWord\Element\Table
  * @runTestsInSeparateProcesses
  */
-class TableTest extends \PHPUnit_Framework_TestCase
+class TableTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Create new instance

--- a/tests/PhpWord/Element/TextBoxTest.php
+++ b/tests/PhpWord/Element/TextBoxTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Element;
  * @coversDefaultClass \PhpOffice\PhpWord\Element\TextBox
  * @runTestsInSeparateProcesses
  */
-class TextBoxTest extends \PHPUnit_Framework_TestCase
+class TextBoxTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Create new instance

--- a/tests/PhpWord/Element/TextBreakTest.php
+++ b/tests/PhpWord/Element/TextBreakTest.php
@@ -26,7 +26,7 @@ use PhpOffice\PhpWord\Style\Paragraph;
  * @coversDefaultClass \PhpOffice\PhpWord\Element\TextBreak
  * @runTestsInSeparateProcesses
  */
-class TextBreakTest extends \PHPUnit_Framework_TestCase
+class TextBreakTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Construct with empty value

--- a/tests/PhpWord/Element/TextRunTest.php
+++ b/tests/PhpWord/Element/TextRunTest.php
@@ -24,7 +24,7 @@ use PhpOffice\PhpWord\PhpWord;
  *
  * @runTestsInSeparateProcesses
  */
-class TextRunTest extends \PHPUnit_Framework_TestCase
+class TextRunTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * New instance

--- a/tests/PhpWord/Element/TextTest.php
+++ b/tests/PhpWord/Element/TextTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\Style\Font;
  *
  * @runTestsInSeparateProcesses
  */
-class TextTest extends \PHPUnit_Framework_TestCase
+class TextTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * New instance

--- a/tests/PhpWord/Element/TitleTest.php
+++ b/tests/PhpWord/Element/TitleTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Element;
  * @coversDefaultClass \PhpOffice\PhpWord\Element\Title
  * @runTestsInSeparateProcesses
  */
-class TitleTest extends \PHPUnit_Framework_TestCase
+class TitleTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Create new instance

--- a/tests/PhpWord/Exception/CopyFileExceptionTest.php
+++ b/tests/PhpWord/Exception/CopyFileExceptionTest.php
@@ -21,7 +21,7 @@ namespace PhpOffice\PhpWord\Exception;
  * @covers \PhpOffice\PhpWord\Exception\CopyFileException
  * @coversDefaultClass \PhpOffice\PhpWord\Exception\CopyFileException
  */
-class CopyFileExceptionTest extends \PHPUnit_Framework_TestCase
+class CopyFileExceptionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * CopyFileException can be thrown.

--- a/tests/PhpWord/Exception/CreateTemporaryFileExceptionTest.php
+++ b/tests/PhpWord/Exception/CreateTemporaryFileExceptionTest.php
@@ -21,7 +21,7 @@ namespace PhpOffice\PhpWord\Exception;
  * @covers \PhpOffice\PhpWord\Exception\CreateTemporaryFileException
  * @coversDefaultClass \PhpOffice\PhpWord\Exception\CreateTemporaryFileException
  */
-class CreateTemporaryFileExceptionTest extends \PHPUnit_Framework_TestCase
+class CreateTemporaryFileExceptionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * CreateTemporaryFileException can be thrown.

--- a/tests/PhpWord/Exception/ExceptionTest.php
+++ b/tests/PhpWord/Exception/ExceptionTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Exception;
  * @coversDefaultClass \PhpOffice\PhpWord\Exception\Exception
  * @runTestsInSeparateProcesses
  */
-class ExceptionTest extends \PHPUnit_Framework_TestCase
+class ExceptionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Throw new exception

--- a/tests/PhpWord/Exception/InvalidImageExceptionTest.php
+++ b/tests/PhpWord/Exception/InvalidImageExceptionTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Exception;
  * @coversDefaultClass \PhpOffice\PhpWord\Exception\InvalidImageException
  * @runTestsInSeparateProcesses
  */
-class InvalidImageExceptionTest extends \PHPUnit_Framework_TestCase
+class InvalidImageExceptionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Throw new exception

--- a/tests/PhpWord/Exception/InvalidStyleExceptionTest.php
+++ b/tests/PhpWord/Exception/InvalidStyleExceptionTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Exception;
  * @coversDefaultClass \PhpOffice\PhpWord\Exception\InvalidStyleException
  * @runTestsInSeparateProcesses
  */
-class InvalidStyleExceptionTest extends \PHPUnit_Framework_TestCase
+class InvalidStyleExceptionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Throw new exception

--- a/tests/PhpWord/Exception/UnsupportedImageTypeExceptionTest.php
+++ b/tests/PhpWord/Exception/UnsupportedImageTypeExceptionTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Exception;
  * @coversDefaultClass \PhpOffice\PhpWord\Exception\UnsupportedImageTypeExceptionTest
  * @runTestsInSeparateProcesses
  */
-class UnsupportedImageTypeExceptionTest extends \PHPUnit_Framework_TestCase
+class UnsupportedImageTypeExceptionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Throw new exception

--- a/tests/PhpWord/IOFactoryTest.php
+++ b/tests/PhpWord/IOFactoryTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord;
  *
  * @runTestsInSeparateProcesses
  */
-class IOFactoryTest extends \PHPUnit_Framework_TestCase
+class IOFactoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Create existing writer

--- a/tests/PhpWord/MediaTest.php
+++ b/tests/PhpWord/MediaTest.php
@@ -24,7 +24,7 @@ use PhpOffice\PhpWord\Element\Image;
  *
  * @runTestsInSeparateProcesses
  */
-class MediaTest extends \PHPUnit_Framework_TestCase
+class MediaTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Get section media elements

--- a/tests/PhpWord/Metadata/DocInfoTest.php
+++ b/tests/PhpWord/Metadata/DocInfoTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Metadata;
  *
  * @runTestsInSeparateProcesses
  */
-class DocInfoTest extends \PHPUnit_Framework_TestCase
+class DocInfoTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Creator

--- a/tests/PhpWord/Metadata/SettingsTest.php
+++ b/tests/PhpWord/Metadata/SettingsTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\SimpleType\Zoom;
  *
  * @runTestsInSeparateProcesses
  */
-class SettingsTest extends \PHPUnit_Framework_TestCase
+class SettingsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * EvenAndOddHeaders

--- a/tests/PhpWord/PhpWordTest.php
+++ b/tests/PhpWord/PhpWordTest.php
@@ -24,7 +24,7 @@ use PhpOffice\PhpWord\Metadata\DocInfo;
  *
  * @runTestsInSeparateProcesses
  */
-class PhpWordTest extends \PHPUnit_Framework_TestCase
+class PhpWordTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test object creation

--- a/tests/PhpWord/Reader/HTMLTest.php
+++ b/tests/PhpWord/Reader/HTMLTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\IOFactory;
  * @coversDefaultClass \PhpOffice\PhpWord\Reader\HTML
  * @runTestsInSeparateProcesses
  */
-class HTMLTest extends \PHPUnit_Framework_TestCase
+class HTMLTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test load

--- a/tests/PhpWord/Reader/MsDocTest.php
+++ b/tests/PhpWord/Reader/MsDocTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\IOFactory;
  * @coversDefaultClass \PhpOffice\PhpWord\Reader\MsDoc
  * @runTestsInSeparateProcesses
  */
-class MsDocTest extends \PHPUnit_Framework_TestCase
+class MsDocTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test canRead() method

--- a/tests/PhpWord/Reader/ODTextTest.php
+++ b/tests/PhpWord/Reader/ODTextTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\IOFactory;
  * @coversDefaultClass \PhpOffice\PhpWord\Reader\ODText
  * @runTestsInSeparateProcesses
  */
-class ODTextTest extends \PHPUnit_Framework_TestCase
+class ODTextTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Load

--- a/tests/PhpWord/Reader/RTFTest.php
+++ b/tests/PhpWord/Reader/RTFTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\IOFactory;
  * @coversDefaultClass \PhpOffice\PhpWord\Reader\RTF
  * @runTestsInSeparateProcesses
  */
-class RTFTest extends \PHPUnit_Framework_TestCase
+class RTFTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test load

--- a/tests/PhpWord/Reader/Word2007Test.php
+++ b/tests/PhpWord/Reader/Word2007Test.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\IOFactory;
  * @coversDefaultClass \PhpOffice\PhpWord\Reader\Word2007
  * @runTestsInSeparateProcesses
  */
-class Word2007Test extends \PHPUnit_Framework_TestCase
+class Word2007Test extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test canRead() method

--- a/tests/PhpWord/SettingsTest.php
+++ b/tests/PhpWord/SettingsTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord;
  * @coversDefaultClass \PhpOffice\PhpWord\Settings
  * @runTestsInSeparateProcesses
  */
-class SettingsTest extends \PHPUnit_Framework_TestCase
+class SettingsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test set/get compatibity option

--- a/tests/PhpWord/Shared/ConverterTest.php
+++ b/tests/PhpWord/Shared/ConverterTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Shared;
  *
  * @coversDefaultClass \PhpOffice\PhpWord\Shared\Converter
  */
-class ConverterTest extends \PHPUnit_Framework_TestCase
+class ConverterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test unit conversion functions with various numbers

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -22,7 +22,7 @@ use PhpOffice\PhpWord\Element\Section;
 /**
  * Test class for PhpOffice\PhpWord\Shared\Html
  */
-class HtmlTest extends \PHPUnit_Framework_TestCase
+class HtmlTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test unit conversion functions with various numbers

--- a/tests/PhpWord/Shared/ZipArchiveTest.php
+++ b/tests/PhpWord/Shared/ZipArchiveTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\Settings;
  * @coversDefaultClass \PhpOffice\PhpWord\Shared\ZipArchive
  * @runTestsInSeparateProcesses
  */
-class ZipArchiveTest extends \PHPUnit_Framework_TestCase
+class ZipArchiveTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test close method exception: Working in local, not working in Travis

--- a/tests/PhpWord/Style/AbstractStyleTest.php
+++ b/tests/PhpWord/Style/AbstractStyleTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Style;
  *
  * @runTestsInSeparateProcesses
  */
-class AbstractStyleTest extends \PHPUnit_Framework_TestCase
+class AbstractStyleTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test set style by array

--- a/tests/PhpWord/Style/CellTest.php
+++ b/tests/PhpWord/Style/CellTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Style;
  * @coversDefaultClass \PhpOffice\PhpWord\Style\Cell
  * @runTestsInSeparateProcesses
  */
-class CellTest extends \PHPUnit_Framework_TestCase
+class CellTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test setting style with normal value

--- a/tests/PhpWord/Style/FontTest.php
+++ b/tests/PhpWord/Style/FontTest.php
@@ -26,7 +26,7 @@ use PhpOffice\PhpWord\TestHelperDOCX;
  *
  * @runTestsInSeparateProcesses
  */
-class FontTest extends \PHPUnit_Framework_TestCase
+class FontTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Tear down after each test

--- a/tests/PhpWord/Style/ImageTest.php
+++ b/tests/PhpWord/Style/ImageTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\SimpleType\Jc;
  * @coversDefaultClass \PhpOffice\PhpWord\Style\Image
  * @runTestsInSeparateProcesses
  */
-class ImageTest extends \PHPUnit_Framework_TestCase
+class ImageTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test setting style with normal value

--- a/tests/PhpWord/Style/IndentationTest.php
+++ b/tests/PhpWord/Style/IndentationTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Style;
  *
  * @coversDefaultClass \PhpOffice\PhpWord\Style\Indentation
  */
-class IndentationTest extends \PHPUnit_Framework_TestCase
+class IndentationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test get/set

--- a/tests/PhpWord/Style/LanguageTest.php
+++ b/tests/PhpWord/Style/LanguageTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Style;
  *
  * @coversDefaultClass \PhpOffice\PhpWord\Style\Language
  */
-class LanguageTest extends \PHPUnit_Framework_TestCase
+class LanguageTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test get/set

--- a/tests/PhpWord/Style/LineNumberingTest.php
+++ b/tests/PhpWord/Style/LineNumberingTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Style;
  *
  * @coversDefaultClass \PhpOffice\PhpWord\Style\LineNumbering
  */
-class LineNumberingTest extends \PHPUnit_Framework_TestCase
+class LineNumberingTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test get/set

--- a/tests/PhpWord/Style/LineTest.php
+++ b/tests/PhpWord/Style/LineTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Style;
  * @coversDefaultClass \PhpOffice\PhpWord\Style\Image
  * @runTestsInSeparateProcesses
  */
-class LineTest extends \PHPUnit_Framework_TestCase
+class LineTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test setting style with normal value

--- a/tests/PhpWord/Style/ListItemTest.php
+++ b/tests/PhpWord/Style/ListItemTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Style;
  * @coversDefaultClass \PhpOffice\PhpWord\Style\ListItem
  * @runTestsInSeparateProcesses
  */
-class ListItemTest extends \PHPUnit_Framework_TestCase
+class ListItemTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test construct

--- a/tests/PhpWord/Style/NumberingLevelTest.php
+++ b/tests/PhpWord/Style/NumberingLevelTest.php
@@ -24,7 +24,7 @@ use PhpOffice\PhpWord\SimpleType\Jc;
  *
  * @runTestsInSeparateProcesses
  */
-class NumberingLevelTest extends \PHPUnit_Framework_TestCase
+class NumberingLevelTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test setting style with normal value

--- a/tests/PhpWord/Style/NumberingTest.php
+++ b/tests/PhpWord/Style/NumberingTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Style;
  *
  * @coversDefaultClass \PhpOffice\PhpWord\Style\Numbering
  */
-class NumberingTest extends \PHPUnit_Framework_TestCase
+class NumberingTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test get/set

--- a/tests/PhpWord/Style/PaperTest.php
+++ b/tests/PhpWord/Style/PaperTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\TestHelperDOCX;
  *
  * @runTestsInSeparateProcesses
  */
-class PaperTest extends \PHPUnit_Framework_TestCase
+class PaperTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Tear down after each test

--- a/tests/PhpWord/Style/ParagraphTest.php
+++ b/tests/PhpWord/Style/ParagraphTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\TestHelperDOCX;
  *
  * @runTestsInSeparateProcesses
  */
-class ParagraphTest extends \PHPUnit_Framework_TestCase
+class ParagraphTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Tear down after each test

--- a/tests/PhpWord/Style/RowTest.php
+++ b/tests/PhpWord/Style/RowTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Style;
  * @coversDefaultClass \PhpOffice\PhpWord\Style\Row
  * @runTestsInSeparateProcesses
  */
-class RowTest extends \PHPUnit_Framework_TestCase
+class RowTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test properties with boolean value

--- a/tests/PhpWord/Style/SectionTest.php
+++ b/tests/PhpWord/Style/SectionTest.php
@@ -23,7 +23,7 @@ namespace PhpOffice\PhpWord\Style;
  * @coversDefaultClass \PhpOffice\PhpWord\Element\Section
  * @runTestsInSeparateProcesses
  */
-class SectionTest extends \PHPUnit_Framework_TestCase
+class SectionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Executed before each method of the class

--- a/tests/PhpWord/Style/ShadingTest.php
+++ b/tests/PhpWord/Style/ShadingTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Style;
  *
  * @coversDefaultClass \PhpOffice\PhpWord\Style\Shading
  */
-class ShadingTest extends \PHPUnit_Framework_TestCase
+class ShadingTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test get/set

--- a/tests/PhpWord/Style/SpacingTest.php
+++ b/tests/PhpWord/Style/SpacingTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Style;
  *
  * @coversDefaultClass \PhpOffice\PhpWord\Style\Spacing
  */
-class SpacingTest extends \PHPUnit_Framework_TestCase
+class SpacingTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test get/set

--- a/tests/PhpWord/Style/TOCTest.php
+++ b/tests/PhpWord/Style/TOCTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Style;
  *
  * @coversDefaultClass \PhpOffice\PhpWord\Style\TOC
  */
-class TOCTest extends \PHPUnit_Framework_TestCase
+class TOCTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test get/set

--- a/tests/PhpWord/Style/TabTest.php
+++ b/tests/PhpWord/Style/TabTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord\Style;
  *
  * @coversDefaultClass \PhpOffice\PhpWord\Style\Tab
  */
-class TabTest extends \PHPUnit_Framework_TestCase
+class TabTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test get/set

--- a/tests/PhpWord/Style/TableTest.php
+++ b/tests/PhpWord/Style/TableTest.php
@@ -24,7 +24,7 @@ use PhpOffice\PhpWord\SimpleType\JcTable;
  *
  * @runTestsInSeparateProcesses
  */
-class TableTest extends \PHPUnit_Framework_TestCase
+class TableTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test class construction

--- a/tests/PhpWord/Style/TextBoxTest.php
+++ b/tests/PhpWord/Style/TextBoxTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\SimpleType\Jc;
  * @coversDefaultClass \PhpOffice\PhpWord\Style\Image
  * @runTestsInSeparateProcesses
  */
-class TextBoxTest extends \PHPUnit_Framework_TestCase
+class TextBoxTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test setting style with normal value

--- a/tests/PhpWord/StyleTest.php
+++ b/tests/PhpWord/StyleTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\SimpleType\Jc;
  * @coversDefaultClass \PhpOffice\PhpWord\Style
  * @runTestsInSeparateProcesses
  */
-class StyleTest extends \PHPUnit_Framework_TestCase
+class StyleTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Add and get paragraph, font, link, title, and table styles

--- a/tests/PhpWord/TemplateProcessorTest.php
+++ b/tests/PhpWord/TemplateProcessorTest.php
@@ -22,7 +22,7 @@ namespace PhpOffice\PhpWord;
  * @coversDefaultClass \PhpOffice\PhpWord\TemplateProcessor
  * @runTestsInSeparateProcesses
  */
-final class TemplateProcessorTest extends \PHPUnit_Framework_TestCase
+final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Template can be saved in temporary location.

--- a/tests/PhpWord/Writer/HTML/ElementTest.php
+++ b/tests/PhpWord/Writer/HTML/ElementTest.php
@@ -24,7 +24,7 @@ use PhpOffice\PhpWord\Writer\HTML\Element\Text;
 /**
  * Test class for PhpOffice\PhpWord\Writer\HTML\Element subnamespace
  */
-class ElementTest extends \PHPUnit_Framework_TestCase
+class ElementTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test unmatched elements

--- a/tests/PhpWord/Writer/HTML/PartTest.php
+++ b/tests/PhpWord/Writer/HTML/PartTest.php
@@ -22,7 +22,7 @@ use PhpOffice\PhpWord\Writer\HTML\Part\Body;
 /**
  * Test class for PhpOffice\PhpWord\Writer\HTML\Part subnamespace
  */
-class PartTest extends \PHPUnit_Framework_TestCase
+class PartTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test get parent writer exception

--- a/tests/PhpWord/Writer/HTML/StyleTest.php
+++ b/tests/PhpWord/Writer/HTML/StyleTest.php
@@ -20,7 +20,7 @@ namespace PhpOffice\PhpWord\Writer\HTML;
 /**
  * Test class for PhpOffice\PhpWord\Writer\HTML\Style subnamespace
  */
-class StyleTest extends \PHPUnit_Framework_TestCase
+class StyleTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test empty styles

--- a/tests/PhpWord/Writer/HTMLTest.php
+++ b/tests/PhpWord/Writer/HTMLTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\SimpleType\Jc;
  *
  * @runTestsInSeparateProcesses
  */
-class HTMLTest extends \PHPUnit_Framework_TestCase
+class HTMLTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Construct

--- a/tests/PhpWord/Writer/ODText/ElementTest.php
+++ b/tests/PhpWord/Writer/ODText/ElementTest.php
@@ -22,7 +22,7 @@ use PhpOffice\Common\XMLWriter;
 /**
  * Test class for PhpOffice\PhpWord\Writer\ODText\Element subnamespace
  */
-class ElementTest extends \PHPUnit_Framework_TestCase
+class ElementTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test unmatched elements

--- a/tests/PhpWord/Writer/ODText/Part/AbstractPartTest.php
+++ b/tests/PhpWord/Writer/ODText/Part/AbstractPartTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\Writer\ODText;
  * @coversDefaultClass \PhpOffice\PhpWord\Writer\ODText\Part\AbstractPart
  * @runTestsInSeparateProcesses
  */
-class AbstractPartTest extends \PHPUnit_Framework_TestCase
+class AbstractPartTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * covers   ::setParentWriter

--- a/tests/PhpWord/Writer/ODText/Part/ContentTest.php
+++ b/tests/PhpWord/Writer/ODText/Part/ContentTest.php
@@ -27,7 +27,7 @@ use PhpOffice\PhpWord\TestHelperDOCX;
  * @coversDefaultClass \PhpOffice\PhpWord\Writer\ODText\Part\Content
  * @runTestsInSeparateProcesses
  */
-class ContentTest extends \PHPUnit_Framework_TestCase
+class ContentTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Executed before each method of the class

--- a/tests/PhpWord/Writer/ODText/StyleTest.php
+++ b/tests/PhpWord/Writer/ODText/StyleTest.php
@@ -22,7 +22,7 @@ use PhpOffice\Common\XMLWriter;
 /**
  * Test class for PhpOffice\PhpWord\Writer\ODText\Style subnamespace
  */
-class StyleTest extends \PHPUnit_Framework_TestCase
+class StyleTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test empty styles

--- a/tests/PhpWord/Writer/ODTextTest.php
+++ b/tests/PhpWord/Writer/ODTextTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\SimpleType\Jc;
  *
  * @runTestsInSeparateProcesses
  */
-class ODTextTest extends \PHPUnit_Framework_TestCase
+class ODTextTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Construct

--- a/tests/PhpWord/Writer/PDF/DomPDFTest.php
+++ b/tests/PhpWord/Writer/PDF/DomPDFTest.php
@@ -26,7 +26,7 @@ use PhpOffice\PhpWord\Writer\PDF;
  *
  * @runTestsInSeparateProcesses
  */
-class DomPDFTest extends \PHPUnit_Framework_TestCase
+class DomPDFTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test construct

--- a/tests/PhpWord/Writer/PDF/MPDFTest.php
+++ b/tests/PhpWord/Writer/PDF/MPDFTest.php
@@ -26,7 +26,7 @@ use PhpOffice\PhpWord\Writer\PDF;
  *
  * @runTestsInSeparateProcesses
  */
-class MPDFTest extends \PHPUnit_Framework_TestCase
+class MPDFTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test construct

--- a/tests/PhpWord/Writer/PDF/TCPDFTest.php
+++ b/tests/PhpWord/Writer/PDF/TCPDFTest.php
@@ -26,7 +26,7 @@ use PhpOffice\PhpWord\Writer\PDF;
  *
  * @runTestsInSeparateProcesses
  */
-class TCPDFTest extends \PHPUnit_Framework_TestCase
+class TCPDFTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test construct

--- a/tests/PhpWord/Writer/PDFTest.php
+++ b/tests/PhpWord/Writer/PDFTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\Settings;
  *
  * @runTestsInSeparateProcesses
  */
-class PDFTest extends \PHPUnit_Framework_TestCase
+class PDFTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test normal construct

--- a/tests/PhpWord/Writer/RTF/ElementTest.php
+++ b/tests/PhpWord/Writer/RTF/ElementTest.php
@@ -22,7 +22,7 @@ use PhpOffice\PhpWord\Writer\RTF;
 /**
  * Test class for PhpOffice\PhpWord\Writer\RTF\Element subnamespace
  */
-class ElementTest extends \PHPUnit_Framework_TestCase
+class ElementTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test unmatched elements

--- a/tests/PhpWord/Writer/RTF/StyleTest.php
+++ b/tests/PhpWord/Writer/RTF/StyleTest.php
@@ -20,7 +20,7 @@ namespace PhpOffice\PhpWord\Writer\RTF;
 /**
  * Test class for PhpOffice\PhpWord\Writer\RTF\Style subnamespace
  */
-class StyleTest extends \PHPUnit_Framework_TestCase
+class StyleTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test empty styles

--- a/tests/PhpWord/Writer/RTFTest.php
+++ b/tests/PhpWord/Writer/RTFTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\SimpleType\Jc;
  *
  * @runTestsInSeparateProcesses
  */
-class RTFTest extends \PHPUnit_Framework_TestCase
+class RTFTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Construct

--- a/tests/PhpWord/Writer/Word2007/ElementTest.php
+++ b/tests/PhpWord/Writer/Word2007/ElementTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\TestHelperDOCX;
 /**
  * Test class for PhpOffice\PhpWord\Writer\Word2007\Element subnamespace
  */
-class ElementTest extends \PHPUnit_Framework_TestCase
+class ElementTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Executed before each method of the class

--- a/tests/PhpWord/Writer/Word2007/Part/AbstractPartTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/AbstractPartTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\Writer\Word2007;
  * @coversDefaultClass \PhpOffice\PhpWord\Writer\Word2007\Part\AbstractWriterPart
  * @runTestsInSeparateProcesses
  */
-class AbstractPartTest extends \PHPUnit_Framework_TestCase
+class AbstractPartTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * covers   ::setParentWriter

--- a/tests/PhpWord/Writer/Word2007/Part/CommentsTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/CommentsTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\TestHelperDOCX;
  *
  * @runTestsInSeparateProcesses
  */
-class CommentsTest extends \PHPUnit_Framework_TestCase
+class CommentsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Executed before each method of the class

--- a/tests/PhpWord/Writer/Word2007/Part/DocumentTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/DocumentTest.php
@@ -29,7 +29,7 @@ use PhpOffice\PhpWord\TestHelperDOCX;
  *
  * @runTestsInSeparateProcesses
  */
-class DocumentTest extends \PHPUnit_Framework_TestCase
+class DocumentTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Executed before each method of the class

--- a/tests/PhpWord/Writer/Word2007/Part/FooterTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/FooterTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\Writer\Word2007;
  * @coversDefaultClass \PhpOffice\PhpWord\Writer\Word2007\Part\Footer
  * @runTestsInSeparateProcesses
  */
-class FooterTest extends \PHPUnit_Framework_TestCase
+class FooterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Write footer

--- a/tests/PhpWord/Writer/Word2007/Part/FootnotesTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/FootnotesTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\TestHelperDOCX;
  * @coversNothing
  * @runTestsInSeparateProcesses
  */
-class FootnotesTest extends \PHPUnit_Framework_TestCase
+class FootnotesTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()
     {

--- a/tests/PhpWord/Writer/Word2007/Part/HeaderTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/HeaderTest.php
@@ -24,7 +24,7 @@ use PhpOffice\PhpWord\Writer\Word2007;
  *
  * @runTestsInSeparateProcesses
  */
-class HeaderTest extends \PHPUnit_Framework_TestCase
+class HeaderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Write header

--- a/tests/PhpWord/Writer/Word2007/Part/NumberingTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/NumberingTest.php
@@ -29,7 +29,7 @@ use PhpOffice\PhpWord\TestHelperDOCX;
  * @runTestsInSeparateProcesses
  * @since 0.10.0
  */
-class NumberingTest extends \PHPUnit_Framework_TestCase
+class NumberingTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Executed before each method of the class

--- a/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
@@ -30,7 +30,7 @@ use PhpOffice\PhpWord\TestHelperDOCX;
  *
  * @coversDefaultClass \PhpOffice\PhpWord\Writer\Word2007\Part\Settings
  */
-class SettingsTest extends \PHPUnit_Framework_TestCase
+class SettingsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Executed before each method of the class

--- a/tests/PhpWord/Writer/Word2007/Part/StylesTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/StylesTest.php
@@ -29,7 +29,7 @@ use PhpOffice\PhpWord\TestHelperDOCX;
  * @coversDefaultClass \PhpOffice\PhpWord\Writer\Word2007\Part\Styles
  * @runTestsInSeparateProcesses
  */
-class StylesTest extends \PHPUnit_Framework_TestCase
+class StylesTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Executed before each method of the class

--- a/tests/PhpWord/Writer/Word2007/PartTest.php
+++ b/tests/PhpWord/Writer/Word2007/PartTest.php
@@ -24,7 +24,7 @@ use PhpOffice\PhpWord\Writer\Word2007\Part\RelsPart;
  *
  * Covers miscellaneous tests
  */
-class PartTest extends \PHPUnit_Framework_TestCase
+class PartTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test exception when no type or target assigned to a relation

--- a/tests/PhpWord/Writer/Word2007/Style/FontTest.php
+++ b/tests/PhpWord/Writer/Word2007/Style/FontTest.php
@@ -25,7 +25,7 @@ use PhpOffice\PhpWord\TestHelperDOCX;
  * @coversDefaultClass \PhpOffice\PhpWord\Writer\Word2007\Style\Font
  * @runTestsInSeparateProcesses
  */
-class FontTest extends \PHPUnit_Framework_TestCase
+class FontTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Executed before each method of the class

--- a/tests/PhpWord/Writer/Word2007/StyleTest.php
+++ b/tests/PhpWord/Writer/Word2007/StyleTest.php
@@ -22,7 +22,7 @@ use PhpOffice\Common\XMLWriter;
 /**
  * Test class for PhpOffice\PhpWord\Writer\Word2007\Style subnamespace
  */
-class StyleTest extends \PHPUnit_Framework_TestCase
+class StyleTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test empty styles

--- a/tests/PhpWord/Writer/Word2007Test.php
+++ b/tests/PhpWord/Writer/Word2007Test.php
@@ -26,7 +26,7 @@ use PhpOffice\PhpWord\TestHelperDOCX;
  *
  * @runTestsInSeparateProcesses
  */
-class Word2007Test extends \PHPUnit_Framework_TestCase
+class Word2007Test extends \PHPUnit\Framework\TestCase
 {
     /**
      * Tear down after each test


### PR DESCRIPTION
I use the `\PHPUnit\Framework\TestCase` notation instead of `\PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just needed to bump PHPUnit version to [`4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21), to keep compatibility.