### PR TITLE
Allow to force an update of all fields on opening a document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ This is the last version to support PHP 5.3
 - Support for Comments - @troosan #1067
 - Support for paragraph textAlignment - @troosan #1165
 - Add support for HTML underline tag <u> in addHtml - @zNightFalLz #1186
-- Allow to change cell width unit - guillaume-ro-fr #986
+- Allow to change cell width unit - @guillaume-ro-fr #986
 - Allow to change the line height rule @troosan
+- Allow to force an update of all fields on opening a document - @troosan #951
 
 ### Fixed
 - Loosen dependency to Zend

--- a/docs/elements.rst
+++ b/docs/elements.rst
@@ -297,7 +297,7 @@ Your TOC can only be generated if you have add at least one title (See "Titles")
 
 Options for ``$tocStyle``:
 
-- ``tabLeader``. Fill type between the title text and the page number. Use the defined constants in PHPWord\\Style\\TOC.
+- ``tabLeader``. Fill type between the title text and the page number. Use the defined constants in ``\PhpOffice\PhpWord\Style\TOC``.
 - ``tabPos``. The position of the tab where the page number appears in twips.
 - ``indent``. The indent factor of the titles in twips.
 

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -271,3 +271,12 @@ points to twips.
     $sectionStyle->setMarginLeft(\PhpOffice\PhpWord\Shared\Converter::inchToTwip(.5));
     // 2 cm right margin
     $sectionStyle->setMarginRight(\PhpOffice\PhpWord\Shared\Converter::cmToTwip(2));
+
+Automatically Recalculate Fields on Open
+----------------------------------------
+
+To force an update of the fields present in the document, set updateFields to true
+
+.. code-block:: php
+
+    $phpWord->getSettings()->setUpdateFields(true);

--- a/samples/Sample_17_TitleTOC.php
+++ b/samples/Sample_17_TitleTOC.php
@@ -4,6 +4,7 @@ include_once 'Sample_Header.php';
 // New Word document
 echo date('H:i:s'), ' Create new PhpWord object', EOL;
 $phpWord = new \PhpOffice\PhpWord\PhpWord();
+$phpWord->getSettings()->setUpdateFields(true);
 
 // New section
 $section = $phpWord->addSection();

--- a/src/PhpWord/Metadata/Settings.php
+++ b/src/PhpWord/Metadata/Settings.php
@@ -117,6 +117,13 @@ class Settings
     private $themeFontLang;
 
     /**
+     * Automatically Recalculate Fields on Open
+     *
+     * @var bool
+     */
+    private $updateFields = false;
+
+    /**
      * Radix Point for Field Code Evaluation
      *
      * @var string
@@ -343,6 +350,22 @@ class Settings
     public function setThemeFontLang($themeFontLang)
     {
         $this->themeFontLang = $themeFontLang;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasUpdateFields()
+    {
+        return $this->updateFields;
+    }
+
+    /**
+     * @param bool $updateFields
+     */
+    public function setUpdateFields($updateFields)
+    {
+        $this->updateFields = $updateFields === null ? false : $updateFields;
     }
 
     /**

--- a/src/PhpWord/Writer/Word2007/Part/Settings.php
+++ b/src/PhpWord/Writer/Word2007/Part/Settings.php
@@ -147,6 +147,7 @@ class Settings extends AbstractPart
         $this->setOnOffValue('w:doNotTrackMoves', $documentSettings->hasDoNotTrackMoves());
         $this->setOnOffValue('w:doNotTrackFormatting', $documentSettings->hasDoNotTrackFormatting());
         $this->setOnOffValue('w:evenAndOddHeaders', $documentSettings->hasEvenAndOddHeaders());
+        $this->setOnOffValue('w:updateFields', $documentSettings->hasUpdateFields());
 
         $this->setThemeFontLang($documentSettings->getThemeFontLang());
         $this->setRevisionView($documentSettings->getRevisionView());

--- a/src/PhpWord/Writer/Word2007/Style/Font.php
+++ b/src/PhpWord/Writer/Word2007/Style/Font.php
@@ -104,6 +104,7 @@ class Font extends AbstractStyle
 
         // Bold, italic
         $xmlWriter->writeElementIf($style->isBold(), 'w:b');
+        $xmlWriter->writeElementIf($style->isBold(), 'w:bCs');
         $xmlWriter->writeElementIf($style->isItalic(), 'w:i');
         $xmlWriter->writeElementIf($style->isItalic(), 'w:iCs');
 

--- a/tests/PhpWord/Metadata/SettingsTest.php
+++ b/tests/PhpWord/Metadata/SettingsTest.php
@@ -153,4 +153,14 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $oSettings->setZoom(Zoom::FULL_PAGE);
         $this->assertEquals('fullPage', $oSettings->getZoom());
     }
+
+    /**
+     * Test Update Fields on update
+     */
+    public function testUpdateFields()
+    {
+        $oSettings = new Settings();
+        $oSettings->setUpdateFields(true);
+        $this->assertTrue($oSettings->hasUpdateFields());
+    }
 }


### PR DESCRIPTION
# Description

When setting the updateFields to true Word will request to update the fields when opening the document.

Fixes #951

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run phpunit, phpcs, php-cs-fixer, phpmd
- [x] The new code is covered by unit tests
- [x] I have update the documentation to describe the changes
