### PR TITLE
Documentation - Fixed paragraph style list

### DIFF
--- a/docs/styles.rst
+++ b/docs/styles.rst
@@ -63,8 +63,7 @@ Paragraph
 
 Available Paragraph style options:
 
-- ``alignment``. Supports all alignment modes since 1st Edition of ECMA-376 standard up till ISO/IEC 29500:2012.
-See ``\PhpOffice\PhpWord\SimpleType\Jc`` class for the details.
+- ``alignment``. Supports all alignment modes since 1st Edition of ECMA-376 standard up till ISO/IEC 29500:2012. See ``\PhpOffice\PhpWord\SimpleType\Jc`` class for the details.
 - ``basedOn``. Parent style.
 - ``hanging``. Hanging by how much.
 - ``indent``. Indent by how much.


### PR DESCRIPTION
# Description

The line break after the first bullet breaks the rest of the list items. Alternatively we could nest that line.

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run phpunit, phpcs, php-cs-fixer, phpmd
- [ ] The new code is covered by unit tests
- [ ] I have update the documentation to describe the changes
