### PR TITLE
Parse html align attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 v0.15.0 (?? ??? 2018)
 ----------------------
 ### Added
-- Parsing of "align" HTML attribute - @troosan
+- Parsing of "align" HTML attribute - @troosan #1231
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+v0.15.0 (?? ??? 2018)
+----------------------
+### Added
+- Parsing of "align" HTML attribute - @troosan
+
+### Fixed
+
 v0.14.0 (29 Dec 2017)
 ----------------------
 This release fixes several bugs and adds some new features.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ $objWriter->save('helloWorld.html');
 /* Note: we skip PDF, because "HTML-to-PDF" approach is used to create PDF documents. */
 ```
 
-More examples are provided in the [samples folder](samples/). You can also read the [Developers' Documentation](http://phpword.readthedocs.org/) and the [API Documentation](http://phpoffice.github.io/PHPWord/docs/master/) for more detail.
+More examples are provided in the [samples folder](samples/). For an easy access to those samples launch `php -S localhost:8000` in the samples directory then browse to [http://localhost:8000](http://localhost:8000) to view the samples.
+You can also read the [Developers' Documentation](http://phpword.readthedocs.org/) and the [API Documentation](http://phpoffice.github.io/PHPWord/docs/master/) for more detail.
 
 ## Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -35,15 +35,27 @@
         }
     ],
     "scripts": {
+        "test": [
+            "./vendor/bin/phpunit --color=always"
+        ],
+        "test-no-coverage": [
+            "./vendor/bin/phpunit --color=always --no-coverage"
+        ],
         "check": [
             "./vendor/bin/php-cs-fixer fix --ansi --dry-run --diff",
             "./vendor/bin/phpcs --report-width=200 --report-summary  --report-full samples/ src/ tests/ --ignore=src/PhpWord/Shared/PCLZip --standard=PSR2 -n",
             "./vendor/bin/phpmd src/,tests/ text ./phpmd.xml.dist --exclude pclzip.lib.php",
-            "./vendor/bin/phpunit --color=always"
+            "@test"
         ],
         "fix": [
             "./vendor/bin/php-cs-fixer fix --ansi"
         ]
+    },
+    "scripts-descriptions": {
+        "test": "Runs all unit tests",
+        "test-no-coverage": "Runs all unit tests, without code coverage",
+        "check": "Runs PHP CheckStyle and PHP Mess detector",
+        "fix": "Fixes issues found by PHP-CS"
     },
     "require": {
         "php": "^5.3.3 || ^7.0",

--- a/samples/Sample_26_Html.php
+++ b/samples/Sample_26_Html.php
@@ -28,7 +28,7 @@ $html .= '<ul>
                 </li>
             </ul>';
 
-$html .= '<table style="width: 50%; border: 6px #0000FF double;">
+$html .= '<table align="center" style="width: 50%; border: 6px #0000FF double;">
                 <thead>
                     <tr style="background-color: #FF0000; text-align: center; color: #FFFFFF; font-weight: bold; ">
                         <th style="width: 50pt">header a</th>

--- a/samples/Sample_Header.php
+++ b/samples/Sample_Header.php
@@ -43,13 +43,19 @@ $pageHeading = IS_INDEX ? '' : "<h1>{$pageHeading}</h1>";
 // Populate samples
 $files = '';
 if ($handle = opendir('.')) {
-    while (false !== ($file = readdir($handle))) {
+    $sampleFiles = array();
+    while (false !== ($sampleFile = readdir($handle))) {
+        $sampleFiles[] = $sampleFile;
+    }
+    sort($sampleFiles);
+    closedir($handle);
+
+    foreach ($sampleFiles as $file) {
         if (preg_match('/^Sample_\d+_/', $file)) {
             $name = str_replace('_', ' ', preg_replace('/(Sample_|\.php)/', '', $file));
             $files .= "<li><a href='{$file}'>{$name}</a></li>";
         }
     }
-    closedir($handle);
 }
 
 /**
@@ -78,6 +84,11 @@ function write($phpWord, $filename, $writers)
     }
 
     $result .= getEndingNotes($writers);
+    $result .= '<pre><code>';
+    if (file_exists($filename . '.php')) {
+        $result .= highlight_file($filename . '.php', true);
+    }
+    $result .= '</code></pre>';
 
     return $result;
 }

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -85,6 +85,8 @@ class Html
                     case 'style':
                         $styles = self::parseStyle($attribute, $styles);
                         break;
+                    case 'align':
+                        $styles['alignment'] = self::mapAlign($attribute->value);
                 }
             }
         }
@@ -431,20 +433,7 @@ class Html
                     }
                     break;
                 case 'text-align':
-                    switch ($cValue) {
-                        case 'left':
-                            $styles['alignment'] = Jc::START;
-                            break;
-                        case 'right':
-                            $styles['alignment'] = Jc::END;
-                            break;
-                        case 'center':
-                            $styles['alignment'] = Jc::CENTER;
-                            break;
-                        case 'justify':
-                            $styles['alignment'] = Jc::BOTH;
-                            break;
-                    }
+                    $styles['alignment'] = self::mapAlign($cValue);
                     break;
                 case 'font-size':
                     $styles['size'] = Converter::cssToPoint($cValue);
@@ -582,6 +571,28 @@ class Html
             default:
                 return 'single';
         }
+    }
+
+    /**
+     * Transforms a HTML/CSS alignment into a \PhpOffice\PhpWord\SimpleType\Jc
+     *
+     * @param string $cssAlignment
+     * @return string|null
+     */
+    private static function mapAlign($cssAlignment)
+    {
+        switch ($cssAlignment) {
+            case 'left':
+                return Jc::START;
+            case 'right':
+                return Jc::END;
+            case 'center':
+                return Jc::CENTER;
+            case 'justify':
+                return Jc::BOTH;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -187,7 +187,7 @@ class HtmlTest extends \PHPUnit\Framework\TestCase
     {
         $phpWord = new \PhpOffice\PhpWord\PhpWord();
         $section = $phpWord->addSection();
-        $html = '<table style="width: 50%; border: 6px #0000FF solid;">
+        $html = '<table align="left" style="width: 50%; border: 6px #0000FF solid;">
                 <thead>
                     <tr style="background-color: #FF0000; text-align: center; color: #FFFFFF; font-weight: bold; ">
                         <th style="width: 50pt">header a</th>
@@ -205,6 +205,8 @@ class HtmlTest extends \PHPUnit\Framework\TestCase
         $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
         $this->assertTrue($doc->elementExists('/w:document/w:body/w:tbl'));
         $this->assertTrue($doc->elementExists('/w:document/w:body/w:tbl/w:tr/w:tc'));
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:tbl/w:tblPr/w:jc'));
+        $this->assertEquals(Jc::START, $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tblPr/w:jc', 'w:val'));
     }
 
     /**


### PR DESCRIPTION
### Description
This pull request provides 2 improvements
- parsing of the `align` HTML attribute
- showing the source code when running the samples in a browser

Fixes #1230 #895 

### Checklist:

- [x] I have run `composer check` and no errors were reported
- [x] The new code is covered by unit tests
- [x] I have update the documentation to describe the changes
