### PR TITLE
Incorrect width for image

### DIFF
--- a/src/PhpWord/Style/Image.php
+++ b/src/PhpWord/Style/Image.php
@@ -61,7 +61,7 @@ class Image extends Frame
     public function __construct()
     {
         parent::__construct();
-        $this->setUnit(self::UNIT_PT);
+        $this->setUnit(self::UNIT_PX);
 
         // Backward compatibility setting
         // @todo Remove on 1.0.0


### PR DESCRIPTION
Perhaps more correctly for the images $this->setUnit (self :: UNIT_PX) instead of $this->setUnit (self :: UNIT_PT);


