### PR TITLE
Add parsing of HTML links

### DIFF
--- a/samples/Sample_26_Html.php
+++ b/samples/Sample_26_Html.php
@@ -10,6 +10,8 @@ $html = '<h1>Adding element via HTML</h1>';
 $html .= '<p>Some well formed HTML snippet needs to be used</p>';
 $html .= '<p>With for example <strong>some<sup>1</sup> <em>inline</em> formatting</strong><sub>1</sub></p>';
 
+$html .= '<p>A link to <a href="http://phpword.readthedocs.io/">Read the docs</a></p>';
+
 $html .= '<p style="margin-top: 240pt;">Unordered (bulleted) list:</p>';
 $html .= '<ul><li>Item 1</li><li>Item 2</li><ul><li>Item 2.1</li><li>Item 2.1</li></ul></ul>';
 

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -142,6 +142,7 @@ class Html
             'li'        => array('ListItem',    $node,  $element,   $styles,    $data,  null,           null),
             'img'       => array('Image',       $node,  $element,   $styles,    null,   null,           null),
             'br'        => array('LineBreak',   null,   $element,   $styles,    null,   null,           null),
+            'a'         => array('Link',        $node,  $element,   $styles,    null,   null,           null),
         );
 
         $newElement = null;
@@ -642,5 +643,27 @@ class Html
     private static function parseLineBreak($element)
     {
         $element->addTextBreak();
+    }
+
+    /**
+     * Parse link node
+     *
+     * @param \DOMNode $node
+     * @param \PhpOffice\PhpWord\Element\AbstractContainer $element
+     * @param array $styles
+     */
+    private static function parseLink($node, $element, &$styles)
+    {
+        $target = null;
+        foreach ($node->attributes as $attribute) {
+            switch ($attribute->name) {
+                case 'href':
+                    $target = $attribute->value;
+                    break;
+            }
+        }
+        self::parseInlineStyle($node, $styles['font']);
+
+        return $element->addLink($target, $node->textContent, $styles['font'], $styles['paragraph']);
     }
 }

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -341,4 +341,17 @@ class HtmlTest extends \PHPUnit\Framework\TestCase
         $this->assertStringMatchesFormat('%Smso-position-horizontal:right%S', $doc->getElementAttribute($baseXpath . '[1]/w:pict/v:shape', 'style'));
         $this->assertStringMatchesFormat('%Smso-position-horizontal:left%S', $doc->getElementAttribute($baseXpath . '[2]/w:pict/v:shape', 'style'));
     }
+
+    public function testParseLink()
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<p><a href="http://phpword.readthedocs.io/" style="text-decoration: underline">link text</a></p>';
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:hyperlink'));
+        $this->assertEquals('link text', $doc->getElement('/w:document/w:body/w:p/w:hyperlink/w:r/w:t')->nodeValue);
+    }
 }


### PR DESCRIPTION
### Description

Add parsing of `<a href="">`

Fixes #1255 

### Checklist:

- [x] I have run `composer check` and no errors were reported
- [x] The new code is covered by unit tests
- [ ] I have update the documentation to describe the changes
