### PR TITLE
BadMethodCallException on nested html lists on valid HTML

### DIFF
--- a/samples/Sample_26_Html.php
+++ b/samples/Sample_26_Html.php
@@ -29,10 +29,13 @@ $html .= '<ol>
             <ol>
                 <li>List 2 item 1</li>
                 <li>List 2 item 2</li>
-                <ol>
-                    <li>sub list 1</li>
-                    <li>sub list 2</li>
-                </ol>
+                <li>
+                    <ol>
+                        <li>sub list 1</li>
+                        <li>sub list 2</li>
+                    </ol>
+                </li>
+                
                 <li>List 2 item 3</li>
                 <ol>
                     <li>sub list 1, restarts with a</li>

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -273,6 +273,43 @@ class HtmlTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Tests parsing of nested ul/li
+     */
+    public function testOrderedNestedListNumbering()
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<ol>
+                <li>List 1 item 1</li>
+                <li>List 1 item 2</li>
+            </ol>
+            <p>Some Text</p>
+            <ol>
+                <li>List 2 item 1</li>
+                <li>
+                    <ol>
+                        <li>sub list 1</li>
+                        <li>sub list 2</li>
+                    </ol>
+                </li>
+            </ol>';
+        Html::addHtml($section, $html, false, false);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        echo $doc->printXml();
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:pPr/w:numPr/w:numId'));
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:t'));
+
+        $this->assertEquals('List 1 item 1', $doc->getElement('/w:document/w:body/w:p[1]/w:r/w:t')->nodeValue);
+        $this->assertEquals('List 2 item 1', $doc->getElement('/w:document/w:body/w:p[4]/w:r/w:t')->nodeValue);
+
+        $firstListnumId = $doc->getElementAttribute('/w:document/w:body/w:p[1]/w:pPr/w:numPr/w:numId', 'w:val');
+        $secondListnumId = $doc->getElementAttribute('/w:document/w:body/w:p[4]/w:pPr/w:numPr/w:numId', 'w:val');
+
+        $this->assertNotEquals($firstListnumId, $secondListnumId);
+    }
+
+    /**
      * Tests parsing of ul/li
      */
     public function testParseListWithFormat()


### PR DESCRIPTION
### Description

We did not consider nested html lists as edge case in #1239.
Additionally the markup in the Sample 26 is invalid. When nesting lists the `<ol>` should be in a `<li>` not outside (compare https://www.w3schools.com/html/html_lists.asp).

I corrected the documentation an added a test which fails with

`BadMethodCallException : Cannot add ListItemRun in ListItemRun.
 /opt/Development/PHPWord/src/PhpWord/Element/AbstractContainer.php:230
 /opt/Development/PHPWord/src/PhpWord/Element/AbstractContainer.php:130
 /opt/Development/PHPWord/src/PhpWord/Element/AbstractContainer.php:112
 /opt/Development/PHPWord/src/PhpWord/Shared/Html.php:438
 /opt/Development/PHPWord/src/PhpWord/Shared/Html.php:163
 /opt/Development/PHPWord/src/PhpWord/Shared/Html.php:195
 /opt/Development/PHPWord/src/PhpWord/Shared/Html.php:177
 /opt/Development/PHPWord/src/PhpWord/Shared/Html.php:440
 /opt/Development/PHPWord/src/PhpWord/Shared/Html.php:163
 /opt/Development/PHPWord/src/PhpWord/Shared/Html.php:195
 /opt/Development/PHPWord/src/PhpWord/Shared/Html.php:177
 /opt/Development/PHPWord/src/PhpWord/Shared/Html.php:195
 /opt/Development/PHPWord/src/PhpWord/Shared/Html.php:177
 /opt/Development/PHPWord/src/PhpWord/Shared/Html.php:70
 /opt/Development/PHPWord/tests/PhpWord/Shared/HtmlTest.php:296`
 
Assertions in Test are not correct yet, I did not know how the markup would be.

I see this PR as WIP, I think you are much faster in tackling this than me, hopefully this PR helps a bit.

### Checklist:

- [ ] I have run `composer check` and no errors were reported
- [ ] The new code is covered by unit tests
- [ ] I have update the documentation to describe the changes
