### PR TITLE
fix typo in test method name

### DIFF
--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -243,7 +243,7 @@ class HtmlTest extends \PHPUnit\Framework\TestCase
     /**
      * Tests parsing of ul/li
      */
-    public function tesOrderedListNumbering()
+    public function testOrderedListNumbering()
     {
         $phpWord = new \PhpOffice\PhpWord\PhpWord();
         $section = $phpWord->addSection();


### PR DESCRIPTION
### Description

Minor typo in Test introduced in #1239

### Checklist:

- [x ] I have run `composer check` and no errors were reported
- [ ] The new code is covered by unit tests
- [ ] I have update the documentation to describe the changes
