### PR TITLE
Fix parsing of textbreaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ v0.15.0 (?? ??? 2018)
 - Parsing of CSS `direction` instruction, HTML `lang` attribute, formatting inside table cell - @troosan #1273 #1252 #1254
 
 ### Fixed
-- fix reading of docx default style - @troosan #1238
-- fix the size unit of when parsing html images - @troosan #1254
-- fixed HTML parsing of nested lists - @troosan #1265
+- Fix reading of docx default style - @troosan #1238
+- Fix the size unit of when parsing html images - @troosan #1254
+- Fixed HTML parsing of nested lists - @troosan #1265
 - Save PNG alpha information when using remote images. @samsullivan #779
+- fix parsing of `<w:br/>` tag. @troosan #1274
 
 
 

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -93,7 +93,7 @@ abstract class AbstractPart
      *
      * @param \PhpOffice\Common\XMLReader $xmlReader
      * @param \DOMElement $domNode
-     * @param mixed $parent
+     * @param \PhpOffice\PhpWord\Element\AbstractContainer $parent
      * @param string $docPart
      *
      * @todo Get font style for preserve text
@@ -177,7 +177,7 @@ abstract class AbstractPart
      *
      * @param \PhpOffice\Common\XMLReader $xmlReader
      * @param \DOMElement $domNode
-     * @param mixed $parent
+     * @param \PhpOffice\PhpWord\Element\AbstractContainer $parent
      * @param string $docPart
      * @param mixed $paragraphStyle
      *
@@ -226,7 +226,11 @@ abstract class AbstractPart
                     $textContent = "&lt;Object: {$target}>";
                     $parent->addText($textContent, $fontStyle, $paragraphStyle);
                 }
-            } else {
+            }
+            if ($xmlReader->elementExists('w:br', $domNode)) {
+                $parent->addTextBreak();
+            }
+            if ($xmlReader->elementExists('w:t', $domNode)) {
                 // TextRun
                 $textContent = $xmlReader->getValue('w:t', $domNode);
                 $parent->addText($textContent, $fontStyle, $paragraphStyle);

--- a/tests/PhpWord/Reader/Word2007/ElementTest.php
+++ b/tests/PhpWord/Reader/Word2007/ElementTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ * @copyright   2010-2017 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Reader\Word2007;
+
+use PhpOffice\PhpWord\AbstractTestReader;
+
+/**
+ * Test class for PhpOffice\PhpWord\Reader\Word2007\Element subnamespace
+ */
+class ElementTest extends AbstractTestReader
+{
+    /**
+     * Test reading of textbreak
+     */
+    public function testReadTextBreak()
+    {
+        $documentXml = '<w:p>
+            <w:r>
+                <w:br/>
+                <w:t xml:space="preserve">test string</w:t>
+            </w:r>
+        </w:p>';
+
+        $phpWord = $this->getDocumentFromString($documentXml);
+
+        $elements = $this->get($phpWord->getSections(), 0)->getElements();
+        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextBreak', $elements[0]);
+        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $elements[1]);
+        $this->assertEquals('test string', $elements[1]->getText());
+    }
+}

--- a/tests/PhpWord/_includes/AbstractTestReader.php
+++ b/tests/PhpWord/_includes/AbstractTestReader.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ * @copyright   2010-2017 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord;
+
+use PhpOffice\PhpWord\Reader\Word2007\Document;
+
+/**
+ * Base class for Word2007 reader tests
+ */
+abstract class AbstractTestReader extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Builds a PhpWord instance based on the xml passed
+     *
+     * @param string $documentXml
+     * @return \PhpOffice\PhpWord\PhpWord
+     */
+    protected function getDocumentFromString($documentXml)
+    {
+        $phpWord = new PhpWord();
+        $file = __DIR__ . '/../_files/temp.docx';
+        $zip = new \ZipArchive();
+        $zip->open($file, \ZipArchive::CREATE);
+        $zip->addFromString('document.xml', '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>' . $documentXml . '</w:body></w:document>');
+        $zip->close();
+        $documentReader = new Document($file, 'document.xml');
+        $documentReader->read($phpWord);
+        unlink($file);
+
+        return $phpWord;
+    }
+
+    /**
+     * Returns the element at position $index in the array
+     *
+     * @param array $array
+     * @param number $index
+     * @return mixed
+     */
+    protected function get(array $array, $index = 0)
+    {
+        return $array[$index];
+    }
+}


### PR DESCRIPTION
### Description
When loading an existing word document, textbreaks are not being parsed

Fixes #1274

### Checklist:

- [x] I have run `composer check` and no errors were reported
- [x] The new code is covered by unit tests
- [x] I have update the documentation to describe the changes
