### PR TITLE
Remove zend-stdlib dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,6 @@
         "php": "^5.3.3 || ^7.0",
         "ext-xml": "*",
         "zendframework/zend-escaper": "^2.2",
-        "zendframework/zend-stdlib": "^2.2 || ^3.0",
         "phpoffice/common": "^0.2"
     },
     "require-dev": {

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -17,13 +17,13 @@
 
 namespace PhpOffice\PhpWord;
 
+use PhpOffice\Common\Text;
 use PhpOffice\PhpWord\Escaper\RegExp;
 use PhpOffice\PhpWord\Escaper\Xml;
 use PhpOffice\PhpWord\Exception\CopyFileException;
 use PhpOffice\PhpWord\Exception\CreateTemporaryFileException;
 use PhpOffice\PhpWord\Exception\Exception;
 use PhpOffice\PhpWord\Shared\ZipArchive;
-use Zend\Stdlib\StringUtils;
 
 class TemplateProcessor
 {
@@ -192,7 +192,7 @@ class TemplateProcessor
      */
     protected static function ensureUtf8Encoded($subject)
     {
-        if (!StringUtils::isValidUtf8($subject)) {
+        if (!Text::isUTF8($subject)) {
             $subject = utf8_encode($subject);
         }
 


### PR DESCRIPTION
### Description

Fixes https://github.com/PHPOffice/PHPWord/issues/1256

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have update the documentation to describe the changes
