### PR TITLE
Improve attribute value of On/Off type

### DIFF
--- a/src/PhpWord/Writer/Word2007/Part/Settings.php
+++ b/src/PhpWord/Writer/Word2007/Part/Settings.php
@@ -174,11 +174,8 @@ class Settings extends AbstractPart
             return;
         }
 
-        if ($booleanValue) {
-            $this->settings[$settingName] = array('@attributes' => array());
-        } else {
-            $this->settings[$settingName] = array('@attributes' => array('w:val' => 'false'));
-        }
+        $value = $booleanValue ? 'true' : 'false';
+        $this->settings[$settingName] = array('@attributes' => array('w:val' => $value));
     }
 
     /**

--- a/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
@@ -196,6 +196,22 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('true', $element->getAttribute('w:val'));
     }
 
+    public function testUpdateFields()
+    {
+        $phpWord = new PhpWord();
+        $phpWord->getSettings()->setUpdateFields(true);
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $file = 'word/settings.xml';
+
+        $path = '/w:settings/w:updateFields';
+        $this->assertTrue($doc->elementExists($path, $file));
+
+        $element = $doc->getElement($path, $file);
+        $this->assertSame('true', $element->getAttribute('w:val'));
+    }
+
     /**
      * Test zoom percentage
      */
@@ -272,6 +288,38 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $element = $doc->getElement($path, $file);
         $this->assertEquals('false', $element->getAttribute('w:formatting'));
         $this->assertEquals('true', $element->getAttribute('w:comments'));
+    }
+
+    public function testHideSpellingErrors()
+    {
+        $phpWord = new PhpWord();
+        $phpWord->getSettings()->setHideSpellingErrors(true);
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $file = 'word/settings.xml';
+
+        $path = '/w:settings/w:hideSpellingErrors';
+        $this->assertTrue($doc->elementExists($path, $file));
+
+        $element = $doc->getElement($path, $file);
+        $this->assertSame('true', $element->getAttribute('w:val'));
+    }
+
+    public function testHideGrammaticalErrors()
+    {
+        $phpWord = new PhpWord();
+        $phpWord->getSettings()->setHideGrammaticalErrors(true);
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $file = 'word/settings.xml';
+
+        $path = '/w:settings/w:hideGrammaticalErrors';
+        $this->assertTrue($doc->elementExists($path, $file));
+
+        $element = $doc->getElement($path, $file);
+        $this->assertSame('true', $element->getAttribute('w:val'));
     }
 
     /**

--- a/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
@@ -174,7 +174,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($doc->elementExists($path, $file));
         $element = $doc->getElement($path, $file);
 
-        $this->assertNotEquals('false', $element->getAttribute('w:val'));
+        $this->assertSame('true', $element->getAttribute('w:val'));
     }
 
     /**
@@ -193,7 +193,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($doc->elementExists($path, $file));
 
         $element = $doc->getElement($path, $file);
-        $this->assertNotEquals('false', $element->getAttribute('w:val'));
+        $this->assertSame('true', $element->getAttribute('w:val'));
     }
 
     /**
@@ -247,7 +247,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($doc->elementExists($path, $file));
 
         $element = $doc->getElement($path, $file);
-        $this->assertNotEquals('false', $element->getAttribute('w:val'));
+        $this->assertSame('true', $element->getAttribute('w:val'));
     }
 
     /**
@@ -290,7 +290,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($doc->elementExists($path, $file));
 
         $element = $doc->getElement($path, $file);
-        $this->assertNotEquals('false', $element->getAttribute('w:val'));
+        $this->assertSame('true', $element->getAttribute('w:val'));
     }
 
     /**
@@ -309,7 +309,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($doc->elementExists($path, $file));
 
         $element = $doc->getElement($path, $file);
-        $this->assertNotEquals('false', $element->getAttribute('w:val'));
+        $this->assertSame('true', $element->getAttribute('w:val'));
     }
 
     /**
@@ -328,7 +328,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($doc->elementExists($path, $file));
 
         $element = $doc->getElement($path, $file);
-        $this->assertNotEquals('false', $element->getAttribute('w:val'));
+        $this->assertSame('true', $element->getAttribute('w:val'));
     }
 
     public function testAutoHyphenation()
@@ -344,7 +344,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($doc->elementExists($path, $file));
 
         $element = $doc->getElement($path, $file);
-        $this->assertNotEquals('false', $element->getAttribute('w:val'));
+        $this->assertSame('true', $element->getAttribute('w:val'));
     }
 
     public function testConsecutiveHyphenLimit()
@@ -392,6 +392,6 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($doc->elementExists($path, $file));
 
         $element = $doc->getElement($path, $file);
-        $this->assertNotEquals('false', $element->getAttribute('w:val'));
+        $this->assertSame('true', $element->getAttribute('w:val'));
     }
 }


### PR DESCRIPTION
### Description

According to http://www.datypic.com/sc/ooxml/t-w_ST_OnOff.html valid values for `w:ST_OnOff` are:
- true/false (<- the pair I chose)
- on/off
- 0/1

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have update the documentation to describe the changes
