### PR TITLE
Fix colspan and rowspan for tables in HTML Writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ v0.15.0 (?? ??? 2018)
 - Fix parsing of `<w:br/>` tag. @troosan #1274
 - Bookmark are not writton as internal link in html writer @troosan #1263
 - It should be possible to add a Footnote in a ListItemRun @troosan #1287 #1287
+- Fix colspan and rowspan for tables in HTML Writer @mattbolt #1292
 
 ### Changed
 - Remove zend-stdlib dependency @Trainmaster #1284

--- a/samples/Sample_09_Tables.php
+++ b/samples/Sample_09_Tables.php
@@ -113,20 +113,20 @@ $phpWord->addTableStyle('Colspan Rowspan', $styleTable);
 $table = $section->addTable('Colspan Rowspan');
 
 $row = $table->addRow();
-
-$row->addCell(null, array('vMerge' => 'restart'))->addText('A');
-$row->addCell(null, array('gridSpan' => 2, 'vMerge' => 'restart'))->addText('B');
-$row->addCell()->addText('1');
+$row->addCell(1000, array('vMerge' => 'restart'))->addText('A');
+$row->addCell(1000, array('gridSpan' => 2, 'vMerge' => 'restart'))->addText('B');
+$row->addCell(1000)->addText('1');
 
 $row = $table->addRow();
-$row->addCell(null, array('vMerge' => 'continue'));
-$row->addCell(null, array('vMerge' => 'continue', 'gridSpan' => 2));
-$row->addCell()->addText('2');
+$row->addCell(1000, array('vMerge' => 'continue'));
+$row->addCell(1000, array('vMerge' => 'continue', 'gridSpan' => 2));
+$row->addCell(1000)->addText('2');
+
 $row = $table->addRow();
-$row->addCell(null, array('vMerge' => 'continue'));
-$row->addCell()->addText('C');
-$row->addCell()->addText('D');
-$row->addCell()->addText('3');
+$row->addCell(1000, array('vMerge' => 'continue'));
+$row->addCell(1000)->addText('C');
+$row->addCell(1000)->addText('D');
+$row->addCell(1000)->addText('3');
 
 // 5. Nested table
 

--- a/src/PhpWord/Writer/HTML/Element/Table.php
+++ b/src/PhpWord/Writer/HTML/Element/Table.php
@@ -40,21 +40,22 @@ class Table extends AbstractElement
         $rowCount = count($rows);
         if ($rowCount > 0) {
             $content .= '<table>' . PHP_EOL;
-            for ($i = 0; $i < count($rows); $i++) {
+            for ($i = 0; $i < $rowCount; $i++) {
                 /** @var $row \PhpOffice\PhpWord\Element\Row Type hint */
                 $rowStyle = $rows[$i]->getStyle();
                 // $height = $row->getHeight();
                 $tblHeader = $rowStyle->isTblHeader();
                 $content .= '<tr>' . PHP_EOL;
                 $rowCells = $rows[$i]->getCells();
-                for ($j = 0; $j < count($rowCells); $j++) {
+                $rowCellCount = count($rowCells);
+                for ($j = 0; $j < $rowCellCount; $j++) {
                     $cellStyle = $rowCells[$j]->getStyle();
                     $cellColSpan = $cellStyle->getGridSpan();
                     $cellRowSpan = 1;
                     $cellVMerge = $cellStyle->getVMerge();
                     // If this is the first cell of the vertical merge, find out how man rows it spans
                     if ($cellVMerge === 'restart') {
-                        for ($k = $i + 1; $k < count($rows); $k++) {
+                        for ($k = $i + 1; $k < $rowCount; $k++) {
                             $kRowCells = $rows[$k]->getCells();
                             if (isset($kRowCells[$j])) {
                                 if ($kRowCells[$j]->getStyle()->getVMerge() === 'continue') {
@@ -70,14 +71,14 @@ class Table extends AbstractElement
                     // Ignore cells that are merged vertically with previous rows
                     if ($cellVMerge !== 'continue') {
                         $cellTag = $tblHeader ? 'th' : 'td';
-                        $cellColSpanAttr = (is_numeric($cellColSpan) && ($cellColSpan > 1) ? " colspan=\"{$cellColSpan}\"" : "");
-                        $cellRowSpanAttr = ($cellRowSpan > 1 ? " rowspan=\"{$cellRowSpan}\"" : "");
+                        $cellColSpanAttr = (is_numeric($cellColSpan) && ($cellColSpan > 1) ? " colspan=\"{$cellColSpan}\"" : '');
+                        $cellRowSpanAttr = ($cellRowSpan > 1 ? " rowspan=\"{$cellRowSpan}\"" : '');
                         $content .= "<{$cellTag}{$cellColSpanAttr}{$cellRowSpanAttr}>" . PHP_EOL;
                         $writer = new Container($this->parentWriter, $rowCells[$j]);
                         $content .= $writer->write();
                         if ($cellRowSpan > 1) {
                             // There shouldn't be any content in the subsequent merged cells, but lets check anyway
-                            for ($k = $i + 1; $k < count($rows); $k++) {
+                            for ($k = $i + 1; $k < $rowCount; $k++) {
                                 $kRowCells = $rows[$k]->getCells();
                                 if (isset($kRowCells[$j])) {
                                     if ($kRowCells[$j]->getStyle()->getVMerge() === 'continue') {

--- a/tests/PhpWord/Writer/HTML/ElementTest.php
+++ b/tests/PhpWord/Writer/HTML/ElementTest.php
@@ -18,6 +18,7 @@
 namespace PhpOffice\PhpWord\Writer\HTML;
 
 use PhpOffice\PhpWord\Element\Text as TextElement;
+use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Writer\HTML;
 use PhpOffice\PhpWord\Writer\HTML\Element\Text;
 
@@ -53,5 +54,72 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $object->setWithoutP(true);
 
         $this->assertEquals(htmlspecialchars('-A-', ENT_COMPAT, 'UTF-8'), $object->write());
+    }
+
+    /**
+     * Tests writing table with col span
+     */
+    public function testWriteColSpan()
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $table = $section->addTable();
+        $row1 = $table->addRow();
+        $cell11 = $row1->addCell(1000, array('gridSpan' => 2));
+        $cell11->addText('cell spanning 2 bellow');
+        $row2 = $table->addRow();
+        $cell21 = $row2->addCell(500);
+        $cell21->addText('first cell');
+        $cell22 = $row2->addCell(500);
+        $cell22->addText('second cell');
+
+        $dom = $this->getAsHTML($phpWord);
+        echo $dom->saveHTML();
+
+        $xpath = new \DOMXpath($dom);
+
+        $this->assertTrue($xpath->query('/html/body/table/tr[1]/td')->length == 1);
+        $this->assertEquals('2', $xpath->query('/html/body/table/tr/td[1]')->item(0)->attributes->getNamedItem('colspan')->textContent);
+        $this->assertTrue($xpath->query('/html/body/table/tr[2]/td')->length == 2);
+    }
+
+    /**
+     * Tests writing table with row span
+     */
+    public function testWriteRowSpan()
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $table = $section->addTable();
+
+        $row1 = $table->addRow();
+        $row1->addCell(1000, array('vMerge' => 'restart'))->addText('row spanning 3 bellow');
+        $row1->addCell(500)->addText('first cell being spanned');
+
+        $row2 = $table->addRow();
+        $row2->addCell(null, array('vMerge' => 'continue'));
+        $row2->addCell(500)->addText('second cell being spanned');
+
+        $row3 = $table->addRow();
+        $row3->addCell(null, array('vMerge' => 'continue'));
+        $row3->addCell(500)->addText('third cell being spanned');
+
+        $dom = $this->getAsHTML($phpWord);
+        echo $dom->saveHTML();
+
+        $xpath = new \DOMXpath($dom);
+
+        $this->assertTrue($xpath->query('/html/body/table/tr[1]/td')->length == 2);
+        $this->assertEquals('3', $xpath->query('/html/body/table/tr[1]/td[1]')->item(0)->attributes->getNamedItem('rowspan')->textContent);
+        $this->assertTrue($xpath->query('/html/body/table/tr[2]/td')->length == 1);
+    }
+
+    private function getAsHTML(PhpWord $phpWord)
+    {
+        $htmlWriter = new HTML($phpWord);
+        $dom = new \DOMDocument();
+        $dom->loadHTML($htmlWriter->getContent());
+
+        return $dom;
     }
 }


### PR DESCRIPTION
### Description

Adds support for rowspan and colspan in the HTML Writer. The GridSpan and VMerge cell styles were previously being ignored.

Fixes #1283 for documents created at runtime. A fix for #1291 is still required when reading a saved document with <w:vMerge> tags that don't have 'w:val="continue"' attributes.