### PR TITLE
Fix HTML parsing when style attribute is empty

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -452,8 +452,10 @@ class Html
     private static function parseStyle($attribute, $styles)
     {
         $properties = explode(';', trim($attribute->value, " \t\n\r\0\x0B;"));
+        
         foreach ($properties as $property) {
-            list($cKey, $cValue) = explode(':', $property, 2);
+          
+            list($cKey, $cValue) = array_pad(explode(':', $property, 2), 2, null);
             $cValue = trim($cValue);
             switch (trim($cKey)) {
                 case 'text-decoration':

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -452,9 +452,8 @@ class Html
     private static function parseStyle($attribute, $styles)
     {
         $properties = explode(';', trim($attribute->value, " \t\n\r\0\x0B;"));
-        
+
         foreach ($properties as $property) {
-          
             list($cKey, $cValue) = array_pad(explode(':', $property, 2), 2, null);
             $cValue = trim($cValue);
             switch (trim($cKey)) {

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -354,15 +354,14 @@ class HtmlTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:hyperlink'));
         $this->assertEquals('link text', $doc->getElement('/w:document/w:body/w:p/w:hyperlink/w:r/w:t')->nodeValue);
     }
-    
+
     public function testParseMalformedStyleIsIgnored()
     {
-      $phpWord = new \PhpOffice\PhpWord\PhpWord();
-      $section = $phpWord->addSection();
-      $html = '<p style="">text</p>';
-      Html::addHtml($section, $html);
-      $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
-      $this->assertFalse($doc->elementExists('/w:document/w:body/w:p[1]/w:pPr/w:jc'));
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<p style="">text</p>';
+        Html::addHtml($section, $html);
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        $this->assertFalse($doc->elementExists('/w:document/w:body/w:p[1]/w:pPr/w:jc'));
     }
-    
 }

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -354,4 +354,15 @@ class HtmlTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:hyperlink'));
         $this->assertEquals('link text', $doc->getElement('/w:document/w:body/w:p/w:hyperlink/w:r/w:t')->nodeValue);
     }
+    
+    public function testParseMalformedStyleIsIgnored()
+    {
+      $phpWord = new \PhpOffice\PhpWord\PhpWord();
+      $section = $phpWord->addSection();
+      $html = '<p style="">text</p>';
+      Html::addHtml($section, $html);
+      $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+      $this->assertFalse($doc->elementExists('/w:document/w:body/w:p[1]/w:pPr/w:jc'));
+    }
+    
 }


### PR DESCRIPTION
### Description

This fix the style parsing process when style is empty.
`list($a, $b) = $c` throw a notice if `$c` contain less than 2 entries.


### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have update the documentation to describe the changes
