### PR TITLE
Added new constant to Brazilian portuguese language

### DIFF
--- a/src/PhpWord/Style/Language.php
+++ b/src/PhpWord/Style/Language.php
@@ -59,6 +59,9 @@ final class Language extends AbstractStyle
     const HI_IN = 'hi-IN';
     const HI_IN_ID = 1081;
 
+    const PT_BR = 'pt-BR';
+    const PT_BR_ID = 1046;
+
     /**
      * Language ID, used for RTF document generation
      *


### PR DESCRIPTION
### Description

Added support to Brazilian Portuguese laungague. Because it's necessary to verify orthography the right language.

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have update the documentation to describe the changes
