### PR TITLE
add parsing of line-height and text-indent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ v0.15.0 (?? ??? 2018)
 - Add support for Hyphenation @Trainmaster #1282 (Document: `autoHyphenation`, `consecutiveHyphenLimit`, `hyphenationZone`, `doNotHyphenateCaps`, Paragraph: `suppressAutoHyphens`)
 - Added support for Floating Table Positioning (tblpPr) @anrikun #639
 - Added support for Image text wrapping distance @troosan #1310
+- Added parsing of CSS line-height and text-indent in HTML reader @troosan #1316
 
 ### Fixed
 - Fix reading of docx default style - @troosan #1238

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -520,6 +520,12 @@ class Html
                 case 'background-color':
                     $styles['bgColor'] = trim($cValue, '#');
                     break;
+                case 'line-height':
+                    $styles['lineHeight'] = $cValue;
+                    break;
+                case 'text-indent':
+                    $styles['indentation']['firstLine'] = Converter::cssToTwip($cValue);
+                    break;
                 case 'font-weight':
                     $tValue = false;
                     if (preg_match('#bold#', $cValue)) {

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -115,6 +115,34 @@ class HtmlTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test line-height style
+     */
+    public function testParseLineHeight()
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        Html::addHtml($section, '<p style="line-height: 1.5;">test</p>');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:pPr/w:spacing'));
+        $this->assertEquals(240 * 1.5, $doc->getElementAttribute('/w:document/w:body/w:p/w:pPr/w:spacing', 'w:line'));
+    }
+
+    /**
+     * Test text-indent style
+     */
+    public function testParseTextIndent()
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        Html::addHtml($section, '<p style="text-indent: 50px;">test</p>');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:pPr/w:ind'));
+        $this->assertEquals(750, $doc->getElementAttribute('/w:document/w:body/w:p/w:pPr/w:ind', 'w:firstLine'));
+    }
+
+    /**
      * Test text-align style
      */
     public function testParseTextAlign()


### PR DESCRIPTION
### Description
Add parsing of line-height and text-indent  CSS when reading HTML

Fixes #1204

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have update the documentation to describe the changes
