### PR TITLE
Improve robustness of HTML parsing on invalid html

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -65,7 +65,11 @@ class Html
         // Load DOM
         $dom = new \DOMDocument();
         $dom->preserveWhiteSpace = $preserveWhiteSpace;
-        $dom->loadXML($html);
+        try {
+            $dom->loadXML($html);
+        } catch (\Exception $e) {
+            $dom->loadXML(strip_tags($html, '<body>'));
+        }
         self::$xpath = new \DOMXpath($dom);
         $node = $dom->getElementsByTagName('body');
 

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -421,6 +421,21 @@ class HtmlTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Tests parsing of invalid HTML
+     */
+    public function testParseInvalidHtml()
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<p>This is some text with a paragraph</p><p>And another one that is not closed';
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $this->assertEquals('This is some text with a paragraphAnd another one that is not closed', $doc->getElement('/w:document/w:body/w:p/w:r[1]/w:t')->nodeValue);
+    }
+
+    /**
      * Test parsing of img
      */
     public function testParseImage()


### PR DESCRIPTION
### Description

When trying to create docx from invalid html markup docx creation crashes. I suppose it would be better if in this case all tags (aka formatting) is stripped but at least the text is kept and crash avoided as invalid markup might be produced by mysiwyg editors.
This PR addresses this. There is space for improvement e.g. in logging. Another glitch is that the strings are concatenated without space (see test).

Test testChartElements()  fails atm but it seems not to be related to my PR

Fixes # (issue)

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have update the documentation to describe the changes
