### PR TITLE
Adding a section with existing section

### DIFF
--- a/src/PhpWord/PhpWord.php
+++ b/src/PhpWord/PhpWord.php
@@ -240,7 +240,7 @@ class PhpWord
         return null;
     }
 
-    /**
+   /**
      * Create new section
      *
      * @param array $style
@@ -248,7 +248,16 @@ class PhpWord
      */
     public function addSection($style = null)
     {
-        $section = new Section(count($this->sections) + 1, $style);
+        return $this->addExistingSection(new Section(count($this->sections) + 1, $style));
+    }
+
+    /**
+     * Create a section with another existing section
+     * @param Section $section
+     * @return Section
+     */
+    public function addExistingSection(\PhpOffice\PhpWord\Element\Section $section)
+    {
         $section->setPhpWord($this);
         $this->sections[] = $section;
 


### PR DESCRIPTION
### Description

$phpWord = new \PhpOffice\PhpWord\PhpWord();
$section = $phpWord->addSection();
$section->addText('Lorem ipsum');

// Load another document
$phpWord2 = \PhpOffice\PhpWord\IOFactory::load('lorem.docx');
// Add sections to the first document
foreach ($phpWord2->getSections() as $section) {
   $phpWord->addExistingSection($section);
}



### Checklist:

- [x ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have update the documentation to describe the changes
