### PR TITLE
Adding setNumId method for ListItem style

### DIFF
--- a/src/PhpWord/Style/ListItem.php
+++ b/src/PhpWord/Style/ListItem.php
@@ -11,7 +11,7 @@
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
  *
  * @see         https://github.com/PHPOffice/PHPWord
- * @copyright   2010-2017 PHPWord contributors
+ * @copyright   2010-2018 PHPWord contributors
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 

--- a/src/PhpWord/Style/ListItem.php
+++ b/src/PhpWord/Style/ListItem.php
@@ -11,7 +11,7 @@
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
  *
  * @see         https://github.com/PHPOffice/PHPWord
- * @copyright   2010-2018 PHPWord contributors
+ * @copyright   2010-2017 PHPWord contributors
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
@@ -140,6 +140,16 @@ class ListItem extends AbstractStyle
     }
 
     /**
+     * Set numbering Id, to force list to restart counting. Same num id means same list
+     * @param int
+     */
+    public function setNumId($numInt)
+    {
+        $this->numId = $numInt;
+        $this->getListTypeStyle();
+    }
+
+    /**
      * Get legacy numbering definition
      *
      * @return array
@@ -148,7 +158,12 @@ class ListItem extends AbstractStyle
     private function getListTypeStyle()
     {
         // Check if legacy style already registered in global Style collection
-        $numStyle = "PHPWordList{$this->listType}";
+        $numStyle = "PHPWordList_" . $this->listType;
+        
+        if ($this->numId) {
+            $numStyle .= '_' . $this->numId;
+        }
+        
         if (Style::getStyle($numStyle) !== null) {
             $this->setNumStyle($numStyle);
 

--- a/src/PhpWord/Style/ListItem.php
+++ b/src/PhpWord/Style/ListItem.php
@@ -141,7 +141,7 @@ class ListItem extends AbstractStyle
 
     /**
      * Set numbering Id. Same numId means same list
-     * @param mixed
+     * @param mixed $numInt
      */
     public function setNumId($numInt)
     {
@@ -158,12 +158,12 @@ class ListItem extends AbstractStyle
     private function getListTypeStyle()
     {
         // Check if legacy style already registered in global Style collection
-        $numStyle = "PHPWordList_" . $this->listType;
-        
+        $numStyle = 'PHPWordListType' . $this->listType;
+
         if ($this->numId) {
-            $numStyle .= '_' . $this->numId;
+            $numStyle .= 'NumId' . $this->numId;
         }
-        
+
         if (Style::getStyle($numStyle) !== null) {
             $this->setNumStyle($numStyle);
 

--- a/src/PhpWord/Style/ListItem.php
+++ b/src/PhpWord/Style/ListItem.php
@@ -140,8 +140,8 @@ class ListItem extends AbstractStyle
     }
 
     /**
-     * Set numbering Id, to force list to restart counting. Same num id means same list
-     * @param int
+     * Set numbering Id. Same numId means same list
+     * @param mixed
      */
     public function setNumId($numInt)
     {


### PR DESCRIPTION
### Description

By allowing to set the numId in the ListItem style manually, you can separate lists. Every ListItem with the same numId belongs to one list. This allows you to restart list counting. For example:

addListItem("tem 1", 0, ['listType' => 7, 'numId' => 1]);
addListItem("tem 2", 0, ['listType' => 7, 'numId' => 1]);
addListItem("tem 3", 0, ['listType' => 7, 'numId' => 1]);

// restart list
addListItem("item 1", 0, ['listType' => 7, 'numId' => 2]);
addListItem("tem 2", 0, ['listType' => 7, 'numId' => 2]);
addListItem("tem 3", 0, ['listType' => 7, 'numId' => 2]);

Fixes # (issue)

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have update the documentation to describe the changes
