### PR TITLE
support internal link in addHtml method

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -664,6 +664,10 @@ class Html
         }
         self::parseInlineStyle($node, $styles['font']);
 
-        return $element->addLink($target, $node->textContent, $styles['font'], $styles['paragraph']);
+        if(strpos($target, '#') === 0) {
+          return $element->addLink(substr($target, 1), $node->textContent, $styles['font'], $styles['paragraph'], true);
+        } else {
+          return $element->addLink($target, $node->textContent, $styles['font'], $styles['paragraph']);
+        }
     }
 }

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -353,5 +353,17 @@ class HtmlTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:hyperlink'));
         $this->assertEquals('link text', $doc->getElement('/w:document/w:body/w:p/w:hyperlink/w:r/w:t')->nodeValue);
+        
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $section->addBookmark('bookmark');
+        $html = '<p><a href="#bookmark">internal link text</a></p>';
+        Html::addHtml($section, $html);
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:hyperlink'));
+        $this->assertTrue($doc->getElement('/w:document/w:body/w:p/w:hyperlink')->hasAttribute('w:anchor'));
+        $this->assertEquals('bookmark', $doc->getElement('/w:document/w:body/w:p/w:hyperlink')->getAttribute('w:anchor'));
+        
     }
 }


### PR DESCRIPTION
### Description

This add support for internal link on Html::addHTML method

Fixes # (issue)
should fix #1300

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have update the documentation to describe the changes
