### PR TITLE
Improve security-related documentation of addImage and addHtml

### DIFF
--- a/docs/elements.rst
+++ b/docs/elements.rst
@@ -234,7 +234,7 @@ To add an image, use the ``addImage`` method to sections, headers, footers, text
 
     $section->addImage($src, [$style]);
 
-- ``$src``. String path to a local image, URL of a remote image or the image data, as a string.
+- ``$src``. String path to a local image, URL of a remote image or the image data, as a string. Warning: Do not pass user-generated strings here, as that would allow an attacker to read arbitrary files or perform server-side request forgery by passing file paths or URLs instead of image data.
 - ``$style``. See :ref:`image-style`.
 
 Examples:

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -34,6 +34,8 @@ class Html
      * Add HTML parts.
      *
      * Note: $stylesheet parameter is removed to avoid PHPMD error for unused parameter
+     * Warning: Do not pass user-generated HTML here, as that would allow an attacker to read arbitrary
+     * files or perform server-side request forgery by passing local file paths or URLs in <img>.
      *
      * @param \PhpOffice\PhpWord\Element\AbstractContainer $element Where the parts need to be added
      * @param string $html The code to parse


### PR DESCRIPTION
### Description

The `addImage` API is not well designed from a security standpoint. Passing user data to `addImage` in the assumption that only an image is added fails when a malicious user uploads a file path instead of an image file and leads to arbitrary file reads. This commit adds a corresponding warning to the RST documentation.

Furthermore a similar warning to `Html::addHtml` is added, as `Html::parseImage` passes the `<img>` `value` attribute to the `Image` constructor, thus suffering from the same issue. As the `Html` class seems not to be covered by the documentation the documentation was not updated.

Note that "reading arbitrary files" might be limited to image files, however I did not look into this further.

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have update the documentation to describe the changes
