### PR TITLE
Wrong unit in image style documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ v0.15.0 (?? ??? 2018)
 
 ### Changed
 - Remove zend-stdlib dependency @Trainmaster #1284
+- The default unit for `\PhpOffice\PhpWord\Style\Image` changed from `px` to `pt`.
 
 
 v0.14.0 (29 Dec 2017)

--- a/docs/elements.rst
+++ b/docs/elements.rst
@@ -435,8 +435,8 @@ Available line style attributes:
 - ``dash``. Line types: dash, rounddot, squaredot, dashdot, longdash, longdashdot, longdashdotdot.
 - ``beginArrow``. Start type of arrow: block, open, classic, diamond, oval.
 - ``endArrow``. End type of arrow: block, open, classic, diamond, oval.
-- ``width``. Line-object width in pt.
-- ``height``. Line-object height in pt.
+- ``width``. Line-object width in *pt*.
+- ``height``. Line-object height in *pt*.
 - ``flip``. Flip the line element: true, false.
 
 Chart

--- a/docs/styles.rst
+++ b/docs/styles.rst
@@ -149,10 +149,10 @@ Image
 Available Image style options:
 
 - ``alignment``. See ``\PhpOffice\PhpWord\SimpleType\Jc`` class for the details.
-- ``height``. Height in pixels.
+- ``height``. Height in *pt*.
 - ``marginLeft``. Left margin in inches, can be negative.
 - ``marginTop``. Top margin in inches, can be negative.
-- ``width``. Width in pixels.
+- ``width``. Width in *pt*.
 - ``wrappingStyle``. Wrapping style, *inline*, *square*, *tight*, *behind*, or *infront*.
 - ``wrapDistanceTop``. Top text wrapping in pixels.
 - ``wrapDistanceBottom``. Bottom text wrapping in pixels.


### PR DESCRIPTION
### Description

According to the change in https://github.com/PHPOffice/PHPWord/pull/874 the unit now is `pt`.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have update the documentation to describe the changes
