### PR TITLE
Fix TemplateProcessor :: fixBrokenMacros;

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -444,7 +444,7 @@ class TemplateProcessor
         $fixedDocumentPart = $documentPart;
 
         $fixedDocumentPart = preg_replace_callback(
-            '|\$[^{]*\{[^}]*\}|U',
+            '|\$(?:<[^{]*)?\{[^}]*\}|U',
             function ($match) {
                 return strip_tags($match[0]);
             },


### PR DESCRIPTION
### Description
The current regex causes the loss of the original formatting of some documents after the variables have been overwritten.
Replaces the current regex with one that resolves this problem.
