### PR TITLE
Fix calls to the getEndingNotes method in the samples

### DIFF
--- a/samples/Sample_07_TemplateCloneRow.php
+++ b/samples/Sample_07_TemplateCloneRow.php
@@ -56,7 +56,7 @@ $templateProcessor->setValue('userPhone#3', '+1 428 889 775');
 echo date('H:i:s'), ' Saving the result document...', EOL;
 $templateProcessor->saveAs('results/Sample_07_TemplateCloneRow.docx');
 
-echo getEndingNotes(array('Word2007' => 'docx'));
+echo getEndingNotes(array('Word2007' => 'docx'), 'results/Sample_07_TemplateCloneRow.docx');
 if (!CLI) {
     include_once 'Sample_Footer.php';
 }

--- a/samples/Sample_23_TemplateBlock.php
+++ b/samples/Sample_23_TemplateBlock.php
@@ -14,7 +14,7 @@ $templateProcessor->deleteBlock('DELETEME');
 echo date('H:i:s'), ' Saving the result document...', EOL;
 $templateProcessor->saveAs('results/Sample_23_TemplateBlock.docx');
 
-echo getEndingNotes(array('Word2007' => 'docx'));
+echo getEndingNotes(array('Word2007' => 'docx'), 'results/Sample_23_TemplateBlock.docx');
 if (!CLI) {
     include_once 'Sample_Footer.php';
 }


### PR DESCRIPTION
### Description

This method call required both an array of writes and the filename, which was
missing in two method calls.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have update the documentation to describe the changes

---

I could not really check the last two items on the checklist since they are not really relevant.
