### PR TITLE
Update documentation for Style::add*Style methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
     - composer self-update
     - travis_wait composer install --prefer-source
     ## PHPDocumentor
-    - mkdir -p build/docs
+    ##- mkdir -p build/docs
     - mkdir -p build/coverage
 
 script:
@@ -52,7 +52,7 @@ script:
     ## PHPLOC
     - if [ -z "$COVERAGE" ]; then ./vendor/bin/phploc src/ ; fi
     ## PHPDocumentor
-    - if [ -z "$COVERAGE" ]; then ./vendor/bin/phpdoc -q -d ./src -t ./build/docs --ignore "*/src/PhpWord/Shared/*/*" --template="responsive-twig" ; fi
+    ##- if [ -z "$COVERAGE" ]; then ./vendor/bin/phpdoc -q -d ./src -t ./build/docs --ignore "*/src/PhpWord/Shared/*/*" --template="responsive-twig" ; fi
 
 after_success:
     ## Coveralls

--- a/composer.json
+++ b/composer.json
@@ -65,14 +65,13 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36 || ^5.0",
-        "phpdocumentor/phpdocumentor":"2.*",
-        "squizlabs/php_codesniffer": "^2.7",
-        "friendsofphp/php-cs-fixer": "^2.0",
+        "squizlabs/php_codesniffer": "^2.9",
+        "friendsofphp/php-cs-fixer": "^2.2",
         "phpmd/phpmd": "2.*",
         "phploc/phploc": "2.* || 3.* || 4.*",
         "dompdf/dompdf":"0.8.*",
         "tecnickcom/tcpdf": "6.*",
-        "mpdf/mpdf": "5.* || 6.* || 7.*",
+        "mpdf/mpdf": "5.7.4 || 6.* || 7.*",
         "php-coveralls/php-coveralls": "1.1.0 || ^2.0"
     },
     "suggest": {

--- a/src/PhpWord/Element/AbstractElement.php
+++ b/src/PhpWord/Element/AbstractElement.php
@@ -347,7 +347,7 @@ abstract class AbstractElement
      *
      * @param \PhpOffice\PhpWord\Element\AbstractElement $container
      */
-    public function setParentContainer(AbstractElement $container)
+    public function setParentContainer(self $container)
     {
         $this->parentContainer = substr(get_class($container), strrpos(get_class($container), '\\') + 1);
         $this->parent = $container;

--- a/src/PhpWord/PhpWord.php
+++ b/src/PhpWord/PhpWord.php
@@ -35,7 +35,7 @@ use PhpOffice\PhpWord\Exception\Exception;
  * @method int addChart(Element\Chart $chart)
  * @method int addComment(Element\Comment $comment)
  *
- * @method Style\Paragraph addParagraphStyle(string $styleName, array $styles)
+ * @method Style\Paragraph addParagraphStyle(string $styleName, mixed $styles)
  * @method Style\Font addFontStyle(string $styleName, mixed $fontStyle, mixed $paragraphStyle = null)
  * @method Style\Font addLinkStyle(string $styleName, mixed $styles)
  * @method Style\Font addTitleStyle(mixed $depth, mixed $fontStyle, mixed $paragraphStyle = null)

--- a/src/PhpWord/PhpWord.php
+++ b/src/PhpWord/PhpWord.php
@@ -38,7 +38,7 @@ use PhpOffice\PhpWord\Exception\Exception;
  * @method Style\Paragraph addParagraphStyle(string $styleName, array $styles)
  * @method Style\Font addFontStyle(string $styleName, mixed $fontStyle, mixed $paragraphStyle = null)
  * @method Style\Font addLinkStyle(string $styleName, mixed $styles)
- * @method Style\Font addTitleStyle(int $depth, mixed $fontStyle, mixed $paragraphStyle = null)
+ * @method Style\Font addTitleStyle(mixed $depth, mixed $fontStyle, mixed $paragraphStyle = null)
  * @method Style\Table addTableStyle(string $styleName, mixed $styleTable, mixed $styleFirstRow = null)
  * @method Style\Numbering addNumberingStyle(string $styleName, mixed $styles)
  */

--- a/src/PhpWord/Style.php
+++ b/src/PhpWord/Style.php
@@ -95,7 +95,7 @@ class Style
      */
     public static function addTitleStyle($depth, $fontStyle, $paragraphStyle = null)
     {
-        if ($depth === null || $depth === '' || $depth === 0) {
+        if (empty($depth)) {
             $styleName = 'Title';
         } else {
             $styleName = "Heading_{$depth}";

--- a/src/PhpWord/Style.php
+++ b/src/PhpWord/Style.php
@@ -95,7 +95,7 @@ class Style
      */
     public static function addTitleStyle($depth, $fontStyle, $paragraphStyle = null)
     {
-        if ($depth == null) {
+        if ($depth === null) {
             $styleName = 'Title';
         } else {
             $styleName = "Heading_{$depth}";

--- a/src/PhpWord/Style.php
+++ b/src/PhpWord/Style.php
@@ -39,7 +39,7 @@ class Style
      * Add paragraph style
      *
      * @param string $styleName
-     * @param array $styles
+     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $styles
      * @return \PhpOffice\PhpWord\Style\Paragraph
      */
     public static function addParagraphStyle($styleName, $styles)
@@ -51,8 +51,8 @@ class Style
      * Add font style
      *
      * @param string $styleName
-     * @param array $fontStyle
-     * @param array $paragraphStyle
+     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $fontStyle
+     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $paragraphStyle
      * @return \PhpOffice\PhpWord\Style\Font
      */
     public static function addFontStyle($styleName, $fontStyle, $paragraphStyle = null)
@@ -64,7 +64,7 @@ class Style
      * Add link style
      *
      * @param string $styleName
-     * @param array $styles
+     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $styles
      * @return \PhpOffice\PhpWord\Style\Font
      */
     public static function addLinkStyle($styleName, $styles)
@@ -76,7 +76,7 @@ class Style
      * Add numbering style
      *
      * @param string $styleName
-     * @param array $styleValues
+     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $styleValues
      * @return \PhpOffice\PhpWord\Style\Numbering
      * @since 0.10.0
      */
@@ -89,8 +89,8 @@ class Style
      * Add title style
      *
      * @param int $depth
-     * @param array $fontStyle
-     * @param array $paragraphStyle
+     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $fontStyle
+     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $paragraphStyle
      * @return \PhpOffice\PhpWord\Style\Font
      */
     public static function addTitleStyle($depth, $fontStyle, $paragraphStyle = null)
@@ -141,7 +141,7 @@ class Style
     /**
      * Set default paragraph style
      *
-     * @param array $styles Paragraph style definition
+     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $styles Paragraph style definition
      * @return \PhpOffice\PhpWord\Style\Paragraph
      */
     public static function setDefaultParagraphStyle($styles)

--- a/src/PhpWord/Style.php
+++ b/src/PhpWord/Style.php
@@ -95,7 +95,7 @@ class Style
      */
     public static function addTitleStyle($depth, $fontStyle, $paragraphStyle = null)
     {
-        if ($depth === null) {
+        if ($depth === null || $depth === '' || $depth === 0) {
             $styleName = 'Title';
         } else {
             $styleName = "Heading_{$depth}";

--- a/src/PhpWord/Style.php
+++ b/src/PhpWord/Style.php
@@ -88,7 +88,7 @@ class Style
     /**
      * Add title style
      *
-     * @param int $depth
+     * @param int|null $depth Provide null to set title font
      * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $fontStyle
      * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $paragraphStyle
      * @return \PhpOffice\PhpWord\Style\Font

--- a/src/PhpWord/Style/Font.php
+++ b/src/PhpWord/Style/Font.php
@@ -264,7 +264,7 @@ class Font extends AbstractStyle
      * Create new font style
      *
      * @param string $type Type of font
-     * @param array $paragraph Paragraph styles definition
+     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $paragraph Paragraph styles definition
      */
     public function __construct($type = 'text', $paragraph = null)
     {

--- a/src/PhpWord/Style/Font.php
+++ b/src/PhpWord/Style/Font.php
@@ -264,7 +264,7 @@ class Font extends AbstractStyle
      * Create new font style
      *
      * @param string $type Type of font
-     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $paragraph Paragraph styles definition
+     * @param array|string|\PhpOffice\PhpWord\Style\AbstractStyle $paragraph Paragraph styles definition
      */
     public function __construct($type = 'text', $paragraph = null)
     {


### PR DESCRIPTION
### Description

Methods `addFontStyle`, `addParagraphStyle`, `addLinkStyle`, `addNumberingStyle`, `addTitleStyle`, and `setDefaultParagraphStyle` does allow `\PhpOffice\PhpWord\Style\AbstractStyle` to be passed as `Style::setStyleValues` checks for this on line 193.

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have update the documentation to describe the changes
