### PR TITLE
Require `ext-zip` for development

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
     },
     "require-dev": {
         "ext-zip": "*",
+        "ext-gd": "*",
         "phpunit/phpunit": "^4.8.36 || ^5.0",
         "squizlabs/php_codesniffer": "^2.9",
         "friendsofphp/php-cs-fixer": "^2.2",

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
         "phpoffice/common": "^0.2"
     },
     "require-dev": {
+        "ext-zip": "*",
         "phpunit/phpunit": "^4.8.36 || ^5.0",
         "squizlabs/php_codesniffer": "^2.9",
         "friendsofphp/php-cs-fixer": "^2.2",


### PR DESCRIPTION
### Description

`ext-zip` seems to be required for development, but isn't specified in `composer.json`.

```
There were 2 failures:

1) PhpOffice\PhpWord\TemplateProcessorTest::testXslStyleSheetCanNotBeAppliedOnFailureOfSettingParameterValue
Failed asserting that exception of type "Error" matches expected exception "\PhpOffice\PhpWord\Exception\Exception". Message was: "Class 'ZipArchive' not found" at
/home/jonathan/Workspace/PHPWord/src/PhpWord/Shared/ZipArchive.php:134
/home/jonathan/Workspace/PHPWord/src/PhpWord/TemplateProcessor.php:88
/home/jonathan/Workspace/PHPWord/tests/PhpWord/TemplateProcessorTest.php:122
.

2) PhpOffice\PhpWord\TemplateProcessorTest::testXslStyleSheetCanNotBeAppliedOnFailureOfLoadingXmlFromTemplate
Failed asserting that exception of type "Error" matches expected exception "\PhpOffice\PhpWord\Exception\Exception". Message was: "Class 'ZipArchive' not found" at
/home/jonathan/Workspace/PHPWord/src/PhpWord/Shared/ZipArchive.php:134
/home/jonathan/Workspace/PHPWord/src/PhpWord/TemplateProcessor.php:88
/home/jonathan/Workspace/PHPWord/tests/PhpWord/TemplateProcessorTest.php:144
.

ERRORS!
Tests: 574, Assertions: 1413, Errors: 133, Failures: 2, Skipped: 1.
```