### PR TITLE
disable entity loader before parsing XML to avoid XXE injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ v0.15.0 (?? ??? 2018)
 - Fix parsing of Heading and Title formating @troosan @gthomas2 #465
 - Fix Dateformat typo, fix hours casing, add Month-Day-Year formats @ComputerTinker #591
 - Fix missing column width in ODText writer @potofcoffee #413
+- Disable entity loader before parsing XML to avoid XXE injection @Tom4t0 #1427
 
 ### Changed
 - Remove zend-stdlib dependency @Trainmaster #1284

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
     "require-dev": {
         "ext-zip": "*",
         "ext-gd": "*",
-        "phpunit/phpunit": "^4.8.36 || ^5.0",
+        "phpunit/phpunit": "^4.8.36 || ^7.0",
         "squizlabs/php_codesniffer": "^2.9",
         "friendsofphp/php-cs-fixer": "^2.2",
         "phpmd/phpmd": "2.*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,8 +6,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="PhpWord Test Suite">
             <directory>./tests/PhpWord</directory>
@@ -22,7 +21,7 @@
         </whitelist>
     </filter>
     <logging>
-        <log type="coverage-html" target="./build/coverage" charset="UTF-8" highlight="true" />
+        <log type="coverage-html" target="./build/coverage" />
         <log type="coverage-clover" target="./build/logs/clover.xml" />
     </logging>
 </phpunit>

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -71,6 +71,7 @@ class Html
         }
 
         // Load DOM
+        libxml_disable_entity_loader(true);
         $dom = new \DOMDocument();
         $dom->preserveWhiteSpace = $preserveWhiteSpace;
         $dom->loadXML($html);

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -113,6 +113,7 @@ class TemplateProcessor
      */
     protected function transformSingleXml($xml, $xsltProcessor)
     {
+        libxml_disable_entity_loader(true);
         $domDocument = new \DOMDocument();
         if (false === $domDocument->loadXML($xml)) {
             throw new Exception('Could not load the given XML document.');

--- a/tests/PhpWord/_includes/XmlDocument.php
+++ b/tests/PhpWord/_includes/XmlDocument.php
@@ -76,8 +76,10 @@ class XmlDocument
         $this->file = $file;
 
         $file = $this->path . '/' . $file;
+        libxml_disable_entity_loader(false);
         $this->dom = new \DOMDocument();
         $this->dom->load($file);
+        libxml_disable_entity_loader(true);
 
         return $this->dom;
     }


### PR DESCRIPTION
### Description
XXE injection possible when parsing XML

Fixes #1421 by @Tom4t0 

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
