### PR TITLE
allow to override TemplateProcessor#ensureUtf8Encoded

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -217,10 +217,10 @@ class TemplateProcessor
 
         if (is_array($replace)) {
             foreach ($replace as &$item) {
-                $item = self::ensureUtf8Encoded($item);
+                $item = static::ensureUtf8Encoded($item);
             }
         } else {
-            $replace = self::ensureUtf8Encoded($replace);
+            $replace = static::ensureUtf8Encoded($replace);
         }
 
         if (Settings::isOutputEscapingEnabled()) {


### PR DESCRIPTION
the method is `protected`,
but since it is called with `self` instead of `static`
it does not allow for subclasses to override it

(we have a special case of mostly ISO-8859-1 strings sometimes containing MS Word apostrophes,
and these appear as question marks in the document when `utf8_encode` is used,
but are displayed fine when we use `mb_convert_encoding($string, 'UTF-8', 'windows-1252')`)

An alternative would be to make the `ensureUtf8Encoded` non static,
since it only appears to be used in a non static method.
