### PR TITLE
* Improve Style parsing

### DIFF
--- a/src/PhpWord/Reader/Word2007/Styles.php
+++ b/src/PhpWord/Reader/Word2007/Styles.php
@@ -64,11 +64,11 @@ class Styles extends AbstractPart
         if ($nodes->length > 0) {
             foreach ($nodes as $node) {
                 $type = $xmlReader->getAttribute('w:type', $node);
-                $name = $xmlReader->getAttribute('w:styleId', $node);
+                $name = $xmlReader->getAttribute('w:val', $node, 'w:name');
                 if (is_null($name)) {
-                    $name = $xmlReader->getAttribute('w:val', $node, 'w:name');
+                    $name = $xmlReader->getAttribute('w:styleId', $node);
                 }
-                preg_match('/Heading(\d)/', $name, $headingMatches);
+                preg_match('/Heading\s*(\d)/i', $name, $headingMatches);
                 // $default = ($xmlReader->getAttribute('w:default', $node) == 1);
                 switch ($type) {
                     case 'paragraph':

--- a/tests/PhpWord/Reader/Word2007/StyleTest.php
+++ b/tests/PhpWord/Reader/Word2007/StyleTest.php
@@ -21,9 +21,7 @@ use PhpOffice\PhpWord\AbstractTestReader;
 use PhpOffice\PhpWord\SimpleType\TblWidth;
 use PhpOffice\PhpWord\Style\Table;
 use PhpOffice\PhpWord\Style\TablePosition;
-
 use PhpOffice\PhpWord\Style;
-
 
 /**
  * Test class for PhpOffice\PhpWord\Reader\Word2007\Styles

--- a/tests/PhpWord/Reader/Word2007/StyleTest.php
+++ b/tests/PhpWord/Reader/Word2007/StyleTest.php
@@ -22,6 +22,9 @@ use PhpOffice\PhpWord\SimpleType\TblWidth;
 use PhpOffice\PhpWord\Style\Table;
 use PhpOffice\PhpWord\Style\TablePosition;
 
+use PhpOffice\PhpWord\Style;
+
+
 /**
  * Test class for PhpOffice\PhpWord\Reader\Word2007\Styles
  */
@@ -144,5 +147,30 @@ class StyleTest extends AbstractTestReader
         $tableStyle = $elements[0]->getStyle();
         $this->assertSame(TblWidth::TWIP, $tableStyle->getIndent()->getType());
         $this->assertSame(2160, $tableStyle->getIndent()->getValue());
+    }
+
+    public function testReadHeading()
+    {
+        Style::resetStyles();
+
+        $documentXml = '<w:style w:type="paragraph" w:styleId="Ttulo1">
+            <w:name w:val="heading 1"/>
+            <w:basedOn w:val="Normal"/>
+            <w:uiPriority w:val="1"/>
+            <w:qFormat/>
+            <w:pPr>
+                <w:outlineLvl w:val="0"/>
+            </w:pPr>
+            <w:rPr>
+                <w:rFonts w:ascii="Times New Roman" w:eastAsia="Times New Roman" w:hAnsi="Times New Roman"/>
+                <w:b/>
+                <w:bCs/>
+            </w:rPr>
+        </w:style>';
+
+        $name = 'Heading_1';
+
+        $phpWord = $this->getDocumentFromString(array('styles' => $documentXml));
+        $this->assertInstanceOf("PhpOffice\\PhpWord\\Style\\Font", Style::getStyle($name));
     }
 }


### PR DESCRIPTION
### Description

MS Word uses a w:name tag to indicate Headings instead w:styleId. In Word Portuguese version, per example, the parameter w:styleId contains the class name in Portuguese (Titulo1) and Word infers if the paragraph is a title looking at <w:name /> tag (heading 1).

Fixes #1431
