### PR TITLE
Style Name Parsing fails if document generated by a non-english word version

### DIFF
--- a/src/PhpWord/Reader/Word2007/Styles.php
+++ b/src/PhpWord/Reader/Word2007/Styles.php
@@ -64,11 +64,11 @@ class Styles extends AbstractPart
         if ($nodes->length > 0) {
             foreach ($nodes as $node) {
                 $type = $xmlReader->getAttribute('w:type', $node);
-                $name = $xmlReader->getAttribute('w:styleId', $node);
+                $name = $xmlReader->getAttribute('w:val', $node, 'w:name');
                 if (is_null($name)) {
-                    $name = $xmlReader->getAttribute('w:val', $node, 'w:name');
+                    $name = $xmlReader->getAttribute('w:styleId', $node);
                 }
-                preg_match('/Heading(\d)/', $name, $headingMatches);
+                preg_match('/Heading\s*(\d)/i', $name, $headingMatches);
                 // $default = ($xmlReader->getAttribute('w:default', $node) == 1);
                 switch ($type) {
                     case 'paragraph':

--- a/tests/PhpWord/Reader/Word2007/StyleTest.php
+++ b/tests/PhpWord/Reader/Word2007/StyleTest.php
@@ -19,6 +19,7 @@ namespace PhpOffice\PhpWord\Reader\Word2007;
 
 use PhpOffice\PhpWord\AbstractTestReader;
 use PhpOffice\PhpWord\SimpleType\TblWidth;
+use PhpOffice\PhpWord\Style;
 use PhpOffice\PhpWord\Style\Table;
 use PhpOffice\PhpWord\Style\TablePosition;
 
@@ -144,5 +145,30 @@ class StyleTest extends AbstractTestReader
         $tableStyle = $elements[0]->getStyle();
         $this->assertSame(TblWidth::TWIP, $tableStyle->getIndent()->getType());
         $this->assertSame(2160, $tableStyle->getIndent()->getValue());
+    }
+
+    public function testReadHeading()
+    {
+        Style::resetStyles();
+
+        $documentXml = '<w:style w:type="paragraph" w:styleId="Ttulo1">
+            <w:name w:val="heading 1"/>
+            <w:basedOn w:val="Normal"/>
+            <w:uiPriority w:val="1"/>
+            <w:qFormat/>
+            <w:pPr>
+                <w:outlineLvl w:val="0"/>
+            </w:pPr>
+            <w:rPr>
+                <w:rFonts w:ascii="Times New Roman" w:eastAsia="Times New Roman" w:hAnsi="Times New Roman"/>
+                <w:b/>
+                <w:bCs/>
+            </w:rPr>
+        </w:style>';
+
+        $name = 'Heading_1';
+
+        $this->getDocumentFromString(array('styles' => $documentXml));
+        $this->assertInstanceOf('PhpOffice\\PhpWord\\Style\\Font', Style::getStyle($name));
     }
 }


### PR DESCRIPTION
### Description
Depending on the language of the word installation, the styleId is different.
e.g.
- en: Heading1
- fr: Titre1
- pt: Titulo1
- de: Übershrift1
- ...
Because of this the parser fails to parse the Styles
The solution is to use the `<w:name />` instead

Fixes #1431

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have update the documentation to describe the changes
