### PR TITLE
HTML Title Writer loses text when Title contains a TextRun instead a string.

### DIFF
--- a/src/PhpWord/Writer/HTML/Element/Title.php
+++ b/src/PhpWord/Writer/HTML/Element/Title.php
@@ -45,7 +45,7 @@ class Title extends AbstractElement
                 $text = $this->escaper->escapeHtml($text);
             }
         } elseif ($text instanceof \PhpOffice\PhpWord\Element\AbstractContainer) {
-            $writer = new Container($this->parentWriter, $this->element);
+            $writer = new Container($this->parentWriter, $text);
             $text = $writer->write();
         }
 

--- a/tests/PhpWord/Writer/HTML/ElementTest.php
+++ b/tests/PhpWord/Writer/HTML/ElementTest.php
@@ -18,6 +18,7 @@
 namespace PhpOffice\PhpWord\Writer\HTML;
 
 use PhpOffice\PhpWord\Element\Text as TextElement;
+use PhpOffice\PhpWord\Element\TextRun;
 use PhpOffice\PhpWord\Element\TrackChange;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Writer\HTML;
@@ -137,5 +138,23 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $dom->loadHTML($htmlWriter->getContent());
 
         return $dom;
+    }
+
+    public function testWriteTitleTextRun()
+    {
+        $expected = 'Title with TextRun';
+
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+
+        $textRun = new TextRun();
+        $textRun->addText($expected);
+
+        $section->addTitle($textRun);
+
+        $htmlWriter = new HTML($phpWord);
+        $content = $htmlWriter->getContent();
+
+        $this->assertTrue(strpos($content, $expected) !== false);
     }
 }


### PR DESCRIPTION
### Description

When the text content of a Title is a TextRun, the writer is losing the text, returning a empty `<h1>`.
Fixes #1435

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have update the documentation to describe the changes
