### PR TITLE
writer / word2007 / support valign and watermark without paragraph

### DIFF
--- a/src/PhpWord/Writer/Word2007/Element/Image.php
+++ b/src/PhpWord/Writer/Word2007/Element/Image.php
@@ -103,7 +103,9 @@ class Image extends AbstractElement
         $style->setPositioning('absolute');
         $styleWriter = new ImageStyleWriter($xmlWriter, $style);
 
-        $xmlWriter->startElement('w:p');
+        if (!$this->withoutP) {
+            $xmlWriter->startElement('w:p');
+        }
         $xmlWriter->startElement('w:r');
         $xmlWriter->startElement('w:pict');
         $xmlWriter->startElement('v:shape');
@@ -118,6 +120,8 @@ class Image extends AbstractElement
         $xmlWriter->endElement(); // v:shape
         $xmlWriter->endElement(); // w:pict
         $xmlWriter->endElement(); // w:r
-        $xmlWriter->endElement(); // w:p
+        if (!$this->withoutP) {
+            $xmlWriter->endElement(); // w:p
+        }
     }
 }

--- a/src/PhpWord/Writer/Word2007/Style/Frame.php
+++ b/src/PhpWord/Writer/Word2007/Style/Frame.php
@@ -61,6 +61,7 @@ class Frame extends AbstractStyle
             'hPos'      => 'mso-position-horizontal',
             'vPos'      => 'mso-position-vertical',
             'hPosRelTo' => 'mso-position-horizontal-relative',
+            'vPosRelTo' => 'mso-position-vertical-relative',
         );
         $posStyles = $this->getStyles($style, $properties);
 


### PR DESCRIPTION
### Description

Writer / Word2007 / Style / Frame / write(): now support vertical align (skipped property)
Writer / Word2007 / Element / Image / writeWatermark(): now support insert without paragraph, similar to writeImage()

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have update the documentation to describe the changes
