### PR TITLE
Round pageSizeH and pageSizeW

### DIFF
--- a/src/PhpWord/Style/Section.php
+++ b/src/PhpWord/Style/Section.php
@@ -281,7 +281,7 @@ class Section extends Border
      */
     public function getPageSizeW()
     {
-        return $this->pageSizeW;
+        return round($this->pageSizeW);
     }
 
     /**
@@ -307,7 +307,7 @@ class Section extends Border
      */
     public function getPageSizeH()
     {
-        return $this->pageSizeH;
+        return round($this->pageSizeH);
     }
 
     /**


### PR DESCRIPTION
When output as RTF the decimal places of pagesize are coming out at the start of the document. See https://stackoverflow.com/questions/48391201/numbers-show-at-beginning-of-phpword-document
