### PR TITLE
Escape HTML entities from incoming HTML.

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -267,7 +267,8 @@ class Html
         }
 
         if (is_callable(array($element, 'addText'))) {
-            $element->addText($node->nodeValue, $styles['font'], $styles['paragraph']);
+            $textContent = htmlspecialchars($node->nodeValue, ENT_QUOTES, 'UTF-8');
+            $element->addText($textContent, $styles['font'], $styles['paragraph']);
         }
     }
 


### PR DESCRIPTION
### Description

HTML entities (e.g. `&lt;`) within text in HTML documents being read get decoded (e.g. into `<`), which means they can end up output wrong. In the case of `&lt;...&gt;`, the text between the two can go missing altogether in the output, as it is considered a HTML tag, rather than plain text.

Just the equivalent change was needed for text coming from XML/docx files, which was added in https://github.com/PHPOffice/PHPWord/commit/d8387c1abad2e0e44af3f936cad0e6d5746ad271 , I believe it's the same for text coming HTML.