### PR TITLE
RTF writer: Round getPageSizeW and getPageSizeH to avoid decimals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,19 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
 
 matrix:
     include:
         - php: 7.0
           env: COVERAGE=1
+        - php: 5.3
+          env: COMPOSER_MEMORY_LIMIT=2G
+    exclude:
+        - php: 7.0
+        - php: 5.3
+    allow_failures:
+        - php: 7.3
 
 cache:
     directories:
@@ -32,7 +40,7 @@ before_install:
 
 before_script:
     ## Deactivate xdebug if we don't do code coverage
-    - if [ -z "$COVERAGE" ]; then phpenv config-rm xdebug.ini ; fi
+    - if [ -z "$COVERAGE" ]; then phpenv config-rm xdebug.ini || echo "xdebug not available" ; fi
     ## Composer
     - composer self-update
     - travis_wait composer install --prefer-source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v0.16.0 (xx xxx 2018)
 ### Fixed
 - Fix regex in `cloneBlock` function @nicoder #1269
 - HTML Title Writer loses text when Title contains a TextRun instead a string. @begnini #1436
+- RTF writer: Round getPageSizeW and getPageSizeH to avoid decimals @Patrick64 #1493
 
 v0.15.0 (14 Jul 2018)
 ----------------------

--- a/src/PhpWord/Writer/RTF/Style/Section.php
+++ b/src/PhpWord/Writer/RTF/Style/Section.php
@@ -43,8 +43,8 @@ class Section extends AbstractStyle
         $content .= '\sectd ';
 
         // Size & margin
-        $content .= $this->getValueIf($style->getPageSizeW() !== null, '\pgwsxn' . $style->getPageSizeW());
-        $content .= $this->getValueIf($style->getPageSizeH() !== null, '\pghsxn' . $style->getPageSizeH());
+        $content .= $this->getValueIf($style->getPageSizeW() !== null, '\pgwsxn' . round($style->getPageSizeW()));
+        $content .= $this->getValueIf($style->getPageSizeH() !== null, '\pghsxn' . round($style->getPageSizeH()));
         $content .= ' ';
         $content .= $this->getValueIf($style->getMarginTop() !== null, '\margtsxn' . $style->getMarginTop());
         $content .= $this->getValueIf($style->getMarginRight() !== null, '\margrsxn' . $style->getMarginRight());


### PR DESCRIPTION
When output as RTF the decimal places of pagesize are coming out at the start of the document. See https://stackoverflow.com/questions/48391201/numbers-show-at-beginning-of-phpword-document

This only changes it for RTF writer