### PR TITLE
Fix loading of Sharepoint document

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,19 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
 
 matrix:
     include:
         - php: 7.0
           env: COVERAGE=1
+        - php: 5.3
+          env: COMPOSER_MEMORY_LIMIT=2G
+    exclude:
+        - php: 7.0
+        - php: 5.3
+    allow_failures:
+        - php: 7.3
 
 cache:
     directories:
@@ -32,7 +40,7 @@ before_install:
 
 before_script:
     ## Deactivate xdebug if we don't do code coverage
-    - if [ -z "$COVERAGE" ]; then phpenv config-rm xdebug.ini ; fi
+    - if [ -z "$COVERAGE" ]; then phpenv config-rm xdebug.ini || echo "xdebug not available" ; fi
     ## Composer
     - composer self-update
     - travis_wait composer install --prefer-source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v0.16.0 (xx xxx 2018)
 ### Fixed
 - Fix regex in `cloneBlock` function @nicoder #1269
 - HTML Title Writer loses text when Title contains a TextRun instead a string. @begnini #1436
+- Fix loading of Sharepoint document @Garrcomm #1498
 
 v0.15.0 (14 Jul 2018)
 ----------------------

--- a/src/PhpWord/Reader/Word2007.php
+++ b/src/PhpWord/Reader/Word2007.php
@@ -62,6 +62,9 @@ class Word2007 extends AbstractReader implements ReaderInterface
         foreach ($steps as $step) {
             $stepPart = $step['stepPart'];
             $stepItems = $step['stepItems'];
+            if (!isset($relationships[$stepPart])) {
+                continue;
+            }
             foreach ($relationships[$stepPart] as $relItem) {
                 $relType = $relItem['type'];
                 if (isset($stepItems[$relType])) {


### PR DESCRIPTION
### Description

When loading some documents from Sharepoint, I got notices and warnings about non-existent keys. By skipping those keys, the problem seems to be resolved.

Fixes these messages:
```
PHP Notice:  Undefined index: document in /home/stefan/Projects/garrcomm/PHPWord/src/PhpWord/Reader/Word2007.php on line 65
PHP Warning:  Invalid argument supplied for foreach() in /home/stefan/Projects/garrcomm/PHPWord/src/PhpWord/Reader/Word2007.php on line 65
```

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [n/a] The new code is covered by unit tests (check build/coverage for coverage report)
- [n/a] I have update the documentation to describe the changes
