### PR TITLE
Fix ampersand corrupting document

### DIFF
--- a/src/PhpWord/Element/Text.php
+++ b/src/PhpWord/Element/Text.php
@@ -56,6 +56,8 @@ class Text extends AbstractElement
      */
     public function __construct($text = null, $fontStyle = null, $paragraphStyle = null)
     {
+        // escape ampersand. It could be here because $domElement->nodeValue returns as a simple ampersand (& instead of &amp;), or a user could have added ampersands with the addText method
+        $text = preg_replace('/(&)(?![0-9a-z]+;)/i', '&amp;', $text);
         $this->setText($text);
         $paragraphStyle = $this->setParagraphStyle($paragraphStyle);
         $this->setFontStyle($fontStyle, $paragraphStyle);


### PR DESCRIPTION
see: https://github.com/PHPOffice/PHPWord/issues/1500

### Description

This will replace any ampersand that is not already followed by a semi-colon (making it an HTML character) with `&amp;`. This is because without converting it, the document cannot be opened.

Fixes # (issue)
https://github.com/PHPOffice/PHPWord/issues/1500

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have update the documentation to describe the changes **n/a**
