### PR TITLE
Use dedicated PHPUnit assertions

### DIFF
--- a/tests/PhpWord/Writer/HTML/ElementTest.php
+++ b/tests/PhpWord/Writer/HTML/ElementTest.php
@@ -73,8 +73,8 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $dom = $this->getAsHTML($phpWord);
         $xpath = new \DOMXPath($dom);
 
-        $this->assertTrue($xpath->query('/html/body/p[1]/ins')->length == 1);
-        $this->assertTrue($xpath->query('/html/body/p[2]/del')->length == 1);
+        $this->assertEquals(1, $xpath->query('/html/body/p[1]/ins')->length);
+        $this->assertEquals(1, $xpath->query('/html/body/p[2]/del')->length);
     }
 
     /**
@@ -97,9 +97,9 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $dom = $this->getAsHTML($phpWord);
         $xpath = new \DOMXPath($dom);
 
-        $this->assertTrue($xpath->query('/html/body/table/tr[1]/td')->length == 1);
+        $this->assertEquals(1, $xpath->query('/html/body/table/tr[1]/td')->length);
         $this->assertEquals('2', $xpath->query('/html/body/table/tr/td[1]')->item(0)->attributes->getNamedItem('colspan')->textContent);
-        $this->assertTrue($xpath->query('/html/body/table/tr[2]/td')->length == 2);
+        $this->assertEquals(2, $xpath->query('/html/body/table/tr[2]/td')->length);
     }
 
     /**
@@ -126,9 +126,9 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $dom = $this->getAsHTML($phpWord);
         $xpath = new \DOMXPath($dom);
 
-        $this->assertTrue($xpath->query('/html/body/table/tr[1]/td')->length == 2);
+        $this->assertEquals(2, $xpath->query('/html/body/table/tr[1]/td')->length);
         $this->assertEquals('3', $xpath->query('/html/body/table/tr[1]/td[1]')->item(0)->attributes->getNamedItem('rowspan')->textContent);
-        $this->assertTrue($xpath->query('/html/body/table/tr[2]/td')->length == 1);
+        $this->assertEquals(1, $xpath->query('/html/body/table/tr[2]/td')->length);
     }
 
     private function getAsHTML(PhpWord $phpWord)
@@ -155,6 +155,6 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $htmlWriter = new HTML($phpWord);
         $content = $htmlWriter->getContent();
 
-        $this->assertTrue(strpos($content, $expected) !== false);
+        $this->assertContains($expected, $content);
     }
 }


### PR DESCRIPTION
### Description

Using dedicated PHPUnit assertions, we can get better error messages when debugging errors, for example:
```diff
-$this->assertTrue($xpath->query('/html/body/p[1]/ins')->length == 1); // Failing asserting that true is false
+$this->assertEquals(1, $xpath->query('/html/body/p[1]/ins')->length); // Failing asserting that variables is equal to 1
```

Fixes: -

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
