### PR TITLE
For RTF writers, sizes should should never have decimals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ v0.16.0 (xx dec 2018)
 - Fix loading of Sharepoint document @Garrcomm #1498
 - RTF writer: Round getPageSizeW and getPageSizeH to avoid decimals @Patrick64 #1493
 - Fix parsing of Office 365 documents @Timanx #1485
+- For RTF writers, sizes should should never have decimals @Samuel-BF #1536
 
 v0.15.0 (14 Jul 2018)
 ----------------------

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -92,7 +92,7 @@ class Border extends AbstractStyle
 
         $content .= '\pgbrdr' . substr($side, 0, 1);
         $content .= '\brdrs'; // Single-thickness border; @todo Get other type of border
-        $content .= '\brdrw' . $width; // Width
+        $content .= '\brdrw' . round($width); // Width
         $content .= '\brdrcf' . $colorIndex; // Color
         $content .= '\brsp480'; // Space in twips between borders and the paragraph (24pt, following OOXML)
         $content .= ' ';

--- a/src/PhpWord/Writer/RTF/Style/Font.php
+++ b/src/PhpWord/Writer/RTF/Style/Font.php
@@ -53,7 +53,7 @@ class Font extends AbstractStyle
         $content .= '\f' . $this->nameIndex;
 
         $size = $style->getSize();
-        $content .= $this->getValueIf(is_numeric($size), '\fs' . ($size * 2));
+        $content .= $this->getValueIf(is_numeric($size), '\fs' . round($size * 2));
 
         $content .= $this->getValueIf($style->isBold(), '\b');
         $content .= $this->getValueIf($style->isItalic(), '\i');

--- a/src/PhpWord/Writer/RTF/Style/Indentation.php
+++ b/src/PhpWord/Writer/RTF/Style/Indentation.php
@@ -36,9 +36,9 @@ class Indentation extends AbstractStyle
             return '';
         }
 
-        $content = '\fi' . $style->getFirstLine();
-        $content .= '\li' . $style->getLeft();
-        $content .= '\ri' . $style->getRight();
+        $content = '\fi' . round($style->getFirstLine());
+        $content .= '\li' . round($style->getLeft());
+        $content .= '\ri' . round($style->getRight());
 
         return $content . ' ';
     }

--- a/src/PhpWord/Writer/RTF/Style/Paragraph.php
+++ b/src/PhpWord/Writer/RTF/Style/Paragraph.php
@@ -65,8 +65,8 @@ class Paragraph extends AbstractStyle
             $content .= $alignments[$style->getAlignment()];
         }
         $content .= $this->writeIndentation($style->getIndentation());
-        $content .= $this->getValueIf($spaceBefore !== null, '\sb' . $spaceBefore);
-        $content .= $this->getValueIf($spaceAfter !== null, '\sa' . $spaceAfter);
+        $content .= $this->getValueIf($spaceBefore !== null, '\sb' . round($spaceBefore));
+        $content .= $this->getValueIf($spaceAfter !== null, '\sa' . round($spaceAfter));
 
         $styles = $style->getStyleValues();
         $content .= $this->writeTabs($styles['tabs']);

--- a/src/PhpWord/Writer/RTF/Style/Section.php
+++ b/src/PhpWord/Writer/RTF/Style/Section.php
@@ -46,13 +46,13 @@ class Section extends AbstractStyle
         $content .= $this->getValueIf($style->getPageSizeW() !== null, '\pgwsxn' . round($style->getPageSizeW()));
         $content .= $this->getValueIf($style->getPageSizeH() !== null, '\pghsxn' . round($style->getPageSizeH()));
         $content .= ' ';
-        $content .= $this->getValueIf($style->getMarginTop() !== null, '\margtsxn' . $style->getMarginTop());
-        $content .= $this->getValueIf($style->getMarginRight() !== null, '\margrsxn' . $style->getMarginRight());
-        $content .= $this->getValueIf($style->getMarginBottom() !== null, '\margbsxn' . $style->getMarginBottom());
-        $content .= $this->getValueIf($style->getMarginLeft() !== null, '\marglsxn' . $style->getMarginLeft());
-        $content .= $this->getValueIf($style->getHeaderHeight() !== null, '\headery' . $style->getHeaderHeight());
-        $content .= $this->getValueIf($style->getFooterHeight() !== null, '\footery' . $style->getFooterHeight());
-        $content .= $this->getValueIf($style->getGutter() !== null, '\guttersxn' . $style->getGutter());
+        $content .= $this->getValueIf($style->getMarginTop() !== null, '\margtsxn' . round($style->getMarginTop()));
+        $content .= $this->getValueIf($style->getMarginRight() !== null, '\margrsxn' . round($style->getMarginRight()));
+        $content .= $this->getValueIf($style->getMarginBottom() !== null, '\margbsxn' . round($style->getMarginBottom()));
+        $content .= $this->getValueIf($style->getMarginLeft() !== null, '\marglsxn' . round($style->getMarginLeft()));
+        $content .= $this->getValueIf($style->getHeaderHeight() !== null, '\headery' . round($style->getHeaderHeight()));
+        $content .= $this->getValueIf($style->getFooterHeight() !== null, '\footery' . round($style->getFooterHeight()));
+        $content .= $this->getValueIf($style->getGutter() !== null, '\guttersxn' . round($style->getGutter()));
         $content .= ' ';
 
         // Borders

--- a/src/PhpWord/Writer/RTF/Style/Tab.php
+++ b/src/PhpWord/Writer/RTF/Style/Tab.php
@@ -42,7 +42,7 @@ class Tab extends AbstractStyle
         if (isset($tabs[$style->getType()])) {
             $content .= $tabs[$style->getType()];
         }
-        $content .= '\tx' . $style->getPosition();
+        $content .= '\tx' . round($style->getPosition());
 
         return $content;
     }


### PR DESCRIPTION

### Description

In #1493 fix, only page dimensions where rounded for RTF writers. But every numerical value should be rounded, as per the spec([v1.5](http://www.biblioscape.com/rtf15_spec.htm#Heading2), more recent versions say the same) :
> The delimiter marks the end of an RTF control word, and can be one of the following : [...]
> * A digit or a hyphen (-), which indicates that a numeric parameter follows. The subsequent digital sequence is then delimited by a space or any character other than a letter or a digit.

This PR fixes that by rounding every numerical values used in formatting RTF documents (I hope i did not forget any value ...).

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [-] The new code is covered by unit tests (check build/coverage for coverage report) (no new code)
- [-] I have updated the documentation to describe the changes (not relevant)
