### PR TITLE
[WIP] Still add text if link missing

### DIFF
--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -297,6 +297,8 @@ abstract class AbstractPart
                 $target = $this->getMediaTarget($docPart, $rId);
                 if (!is_null($target)) {
                     $parent->addLink($target, $textContent, $fontStyle, $paragraphStyle);
+                } else {
+                    $parent->addText($textContent, $fontStyle, $paragraphStyle);
                 }
             } else {
                 /** @var AbstractElement $element */


### PR DESCRIPTION
### Description

If link target doesn't exist, still add the text anyway. 

This has fixed issues for me with broken anchors. If the anchor is broken it just doesn't even create an element in the list and so text is lost. Even if the anchor is broken the content should still be there. 

I can write, or attempt to write a unit test for this if this change makes sense. 

Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
