### PR TITLE
Add "Plain Text" type to SDT (Structured Document Tags)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ v0.16.0 (xx dec 2018)
 - Add ability to pass a Style object in Section constructor @ndench #1416
 - Add support for hidden text @Alexmg86 #1527
 - Add support for setting images in TemplateProcessor @SailorMax #1170
+- Add "Plain Text" type to SDT (Structured Document Tags) @morrisdj #1541
 
 ### Fixed
 - Fix regex in `cloneBlock` function @nicoder #1269

--- a/src/PhpWord/Element/SDT.php
+++ b/src/PhpWord/Element/SDT.php
@@ -90,7 +90,7 @@ class SDT extends Text
      */
     public function setType($value)
     {
-        $enum = array('comboBox', 'dropDownList', 'date');
+        $enum = array('plainText', 'comboBox', 'dropDownList', 'date');
         $this->type = $this->setEnumVal($value, $enum, 'comboBox');
 
         return $this;

--- a/src/PhpWord/Writer/Word2007/Element/SDT.php
+++ b/src/PhpWord/Writer/Word2007/Element/SDT.php
@@ -78,13 +78,13 @@ class SDT extends Text
      *
      * @see  http://www.datypic.com/sc/ooxml/t-w_CT_SdtText.html
      * @param \PhpOffice\Common\XMLWriter $xmlWriter
-     * @param \PhpOffice\PhpWord\Element\SDT $element
      */
-    private function writePlainText(XMLWriter $xmlWriter, SDTElement $element)
+    private function writePlainText(XMLWriter $xmlWriter)
     {
-        $xmlWriter->startElement("w:text");
-        $xmlWriter->endElement(); // w:{$type}
+        $xmlWriter->startElement('w:text');
+        $xmlWriter->endElement(); // w:text
     }
+
     /**
      * Write combo box.
      *

--- a/src/PhpWord/Writer/Word2007/Element/SDT.php
+++ b/src/PhpWord/Writer/Word2007/Element/SDT.php
@@ -74,6 +74,18 @@ class SDT extends Text
     }
 
     /**
+     * Write text.
+     *
+     * @see  http://www.datypic.com/sc/ooxml/t-w_CT_SdtText.html
+     * @param \PhpOffice\Common\XMLWriter $xmlWriter
+     * @param \PhpOffice\PhpWord\Element\SDT $element
+     */
+    private function writePlainText(XMLWriter $xmlWriter, SDTElement $element)
+    {
+        $xmlWriter->startElement("w:text");
+        $xmlWriter->endElement(); // w:{$type}
+    }
+    /**
      * Write combo box.
      *
      * @see  http://www.datypic.com/sc/ooxml/t-w_CT_SdtComboBox.html

--- a/tests/PhpWord/Element/SDTTest.php
+++ b/tests/PhpWord/Element/SDTTest.php
@@ -29,8 +29,8 @@ class SDTTest extends \PHPUnit\Framework\TestCase
      */
     public function testConstruct()
     {
-        $types = array('comboBox', 'dropDownList', 'date');
-        $type = $types[rand(0, 2)];
+        $types = array('plainText', 'comboBox', 'dropDownList', 'date');
+        $type = $types[rand(0, 3)];
         $value = rand(0, 100);
         $alias = 'alias';
         $tag = 'my_tag';

--- a/tests/PhpWord/Writer/Word2007/ElementTest.php
+++ b/tests/PhpWord/Writer/Word2007/ElementTest.php
@@ -387,6 +387,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $section->addSDT('comboBox')->setListItems(array('1' => 'Choice 1', '2' => 'Choice 2'))->setValue('select value');
         $section->addSDT('dropDownList');
         $section->addSDT('date')->setAlias('date_alias')->setTag('my_tag');
+        $section->addSDT('plainText');
 
         $doc = TestHelperDOCX::getDocument($phpWord);
 
@@ -405,6 +406,8 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($doc->elementExists($path . '[3]/w:sdt/w:sdtPr/w:date'));
         $this->assertTrue($doc->elementExists($path . '[3]/w:sdt/w:sdtPr/w:alias'));
         $this->assertTrue($doc->elementExists($path . '[3]/w:sdt/w:sdtPr/w:tag'));
+
+        $this->assertTrue($doc->elementExists($path . '[4]/w:sdt/w:sdtPr/w:text'));
     }
 
     /**


### PR DESCRIPTION
### Description

The specification for SDTs (Structured Document Tags) allows for these types:
- plain text
- rich text
- date picker
- combo box
- drop-down list
- image

Only date, combo box and drop-down list were previously implemented.

I have added the **plain text** type.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
