### PR TITLE
Update minimum req, stop running travis builds for php 5.3, 5.4, 5.5 and 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "0.17-dev"
+            "dev-develop": "0.17-dev",
+            "develop_v1.0": "1.0-dev"
         }
     }
 }


### PR DESCRIPTION
### Description
Now that all php 5 versions are EOL, it's time to move on.
http://php.net/supported-versions.php
https://blog.packagist.com/php-versions-stats-2018-2-edition/

### Checklist:
- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
