### PR TITLE
Language::validateLocale should pass with locale 'zxx'.

### DIFF
--- a/src/PhpWord/Style/Language.php
+++ b/src/PhpWord/Style/Language.php
@@ -229,7 +229,7 @@ final class Language extends AbstractStyle
             return strtolower($locale) . '-' . strtoupper($locale);
         }
 
-        if ($locale !== null && strstr($locale, '-') === false) {
+        if ($locale !== null && $locale !== 'zxx' && strstr($locale, '-') === false) {
             throw new \InvalidArgumentException($locale . ' is not a valid language code');
         }
 


### PR DESCRIPTION
### Description

libreoffice uses zxx as default language code. This PR updates the language code validation to accept this code.

Fixes #1298

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
