### PR TITLE
fix parsing of border-color and add test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ v0.17.0 (?? ??? 2019)
 ----------------------
 ### Added
 - Add RightToLeft table presentation. @troosan #1550
+- Set complex type in template @troosan #1565
 - Add support for page vertical alignment. @troosan #672 #1569
 
 ### Fixed
+- Fix HTML border-color parsing. @troosan #1551 #1570
 
 ### Miscelaneous
 - Use embedded http server to test loading of remote images @troosan #

--- a/samples/Sample_26_Html.php
+++ b/samples/Sample_26_Html.php
@@ -74,7 +74,7 @@ $html .= '<table align="center" style="width: 50%; border: 6px #0000FF double;">
                     </tr>
                 </thead>
                 <tbody>
-                    <tr><td style="border-style: dotted;">1</td><td colspan="2">2</td></tr>
+                    <tr><td style="border-style: dotted; border-color: #FF0000">1</td><td colspan="2">2</td></tr>
                     <tr><td>This is <b>bold</b> text</td><td></td><td>6</td></tr>
                 </tbody>
             </table>';

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -516,7 +516,7 @@ class Html
                     $styles['alignment'] = self::mapAlign($cValue);
                     break;
                 case 'display':
-                    $styles['hidden'] = $cValue === 'none';
+                    $styles['hidden'] = $cValue === 'none' || $cValue === 'hidden';
                     break;
                 case 'direction':
                     $styles['rtl'] = $cValue === 'rtl';
@@ -747,7 +747,7 @@ class Html
             $colors = explode(' ', $cssBorderColor);
             $borders = array('borderTopColor', 'borderRightColor', 'borderBottomColor', 'borderLeftColor');
             for ($i = 0; $i < min(4, $numColors, count($colors)); $i++) {
-                $styles[$borders[$i]] = $colors[$i];
+                $styles[$borders[$i]] = trim($colors[$i], '#');
             }
         }
     }

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -581,7 +581,7 @@ class Html
                     $styles['spaceAfter'] = Converter::cssToPoint($cValue);
                     break;
                 case 'border-color':
-                    $styles['color'] = trim($cValue, '#');
+                    self::mapBorderColor($styles, $cValue);
                     break;
                 case 'border-width':
                     $styles['borderSize'] = Converter::cssToPoint($cValue);
@@ -735,6 +735,20 @@ class Html
                 return $cssBorderStyle;
             default:
                 return 'single';
+        }
+    }
+
+    private static function mapBorderColor(&$styles, $cssBorderColor)
+    {
+        $numColors = substr_count($cssBorderColor, '#');
+        if ($numColors === 1) {
+            $styles['borderColor'] = trim($cssBorderColor, '#');
+        } elseif ($numColors > 1) {
+            $colors = explode(' ', $cssBorderColor);
+            $borders = array('borderTopColor', 'borderRightColor', 'borderBottomColor', 'borderLeftColor');
+            for ($i = 0; $i < min(4, $numColors, count($colors)); $i++) {
+                $styles[$borders[$i]] = $colors[$i];
+            }
         }
     }
 

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -297,7 +297,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
                 <thead>
                     <tr style="background-color: #FF0000; text-align: center; color: #FFFFFF; font-weight: bold; ">
                         <th style="width: 50pt">header a</th>
-                        <th style="width: 50">header b</th>
+                        <th style="width: 50; border-color: #00EE00">header b</th>
                         <th style="border-color: #00AA00 #00BB00 #00CC00 #00DD00; border-width: 3px">header c</th>
                     </tr>
                 </thead>
@@ -313,11 +313,17 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
         $this->assertTrue($doc->elementExists('/w:document/w:body/w:tbl/w:tr/w:tc'));
         $this->assertTrue($doc->elementExists('/w:document/w:body/w:tbl/w:tblPr/w:jc'));
         $this->assertEquals(Jc::START, $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tblPr/w:jc', 'w:val'));
+
         //check border colors
-        $this->assertEquals('#00AA00', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr[1]/w:tc[3]/w:tcPr/w:tcBorders/w:top', 'w:color'));
-        $this->assertEquals('#00BB00', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr[1]/w:tc[3]/w:tcPr/w:tcBorders/w:right', 'w:color'));
-        $this->assertEquals('#00CC00', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr[1]/w:tc[3]/w:tcPr/w:tcBorders/w:bottom', 'w:color'));
-        $this->assertEquals('#00DD00', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr[1]/w:tc[3]/w:tcPr/w:tcBorders/w:left', 'w:color'));
+        $this->assertEquals('00EE00', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr[1]/w:tc[2]/w:tcPr/w:tcBorders/w:top', 'w:color'));
+        $this->assertEquals('00EE00', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr[1]/w:tc[2]/w:tcPr/w:tcBorders/w:right', 'w:color'));
+        $this->assertEquals('00EE00', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr[1]/w:tc[2]/w:tcPr/w:tcBorders/w:bottom', 'w:color'));
+        $this->assertEquals('00EE00', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr[1]/w:tc[2]/w:tcPr/w:tcBorders/w:left', 'w:color'));
+
+        $this->assertEquals('00AA00', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr[1]/w:tc[3]/w:tcPr/w:tcBorders/w:top', 'w:color'));
+        $this->assertEquals('00BB00', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr[1]/w:tc[3]/w:tcPr/w:tcBorders/w:right', 'w:color'));
+        $this->assertEquals('00CC00', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr[1]/w:tc[3]/w:tcPr/w:tcBorders/w:bottom', 'w:color'));
+        $this->assertEquals('00DD00', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr[1]/w:tc[3]/w:tcPr/w:tcBorders/w:left', 'w:color'));
     }
 
     /**
@@ -594,5 +600,36 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
         Html::addHtml($section, $html);
         $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
         $this->assertFalse($doc->elementExists('/w:document/w:body/w:p[1]/w:pPr/w:jc'));
+    }
+
+    /**
+     * Tests parsing hidden text
+     */
+    public function testParseHiddenText()
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<p style="display: hidden">This is some hidden text.</p>';
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:rPr/w:vanish'));
+    }
+
+    /**
+     * Tests parsing letter spacing
+     */
+    public function testParseLetterSpacing()
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<p style="letter-spacing: 150px">This is some text with letter spacing.</p>';
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:rPr/w:spacing'));
+        $this->assertEquals(150 * 15, $doc->getElement('/w:document/w:body/w:p/w:r/w:rPr/w:spacing')->getAttribute('w:val'));
     }
 }

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -298,7 +298,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
                     <tr style="background-color: #FF0000; text-align: center; color: #FFFFFF; font-weight: bold; ">
                         <th style="width: 50pt">header a</th>
                         <th style="width: 50">header b</th>
-                        <th style="border-color: #00FF00; border-width: 3px">header c</th>
+                        <th style="border-color: #00AA00 #00BB00 #00CC00 #00DD00; border-width: 3px">header c</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -313,6 +313,11 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
         $this->assertTrue($doc->elementExists('/w:document/w:body/w:tbl/w:tr/w:tc'));
         $this->assertTrue($doc->elementExists('/w:document/w:body/w:tbl/w:tblPr/w:jc'));
         $this->assertEquals(Jc::START, $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tblPr/w:jc', 'w:val'));
+        //check border colors
+        $this->assertEquals('#00AA00', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr[1]/w:tc[3]/w:tcPr/w:tcBorders/w:top', 'w:color'));
+        $this->assertEquals('#00BB00', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr[1]/w:tc[3]/w:tcPr/w:tcBorders/w:right', 'w:color'));
+        $this->assertEquals('#00CC00', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr[1]/w:tc[3]/w:tcPr/w:tcBorders/w:bottom', 'w:color'));
+        $this->assertEquals('#00DD00', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr[1]/w:tc[3]/w:tcPr/w:tcBorders/w:left', 'w:color'));
     }
 
     /**


### PR DESCRIPTION
### Description
Parsing of CSS border-style

Fixes #1551

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
