### PR TITLE
TrackChange doesn't handle all return types of \DateTime::createFromFormat(...)

### DIFF
--- a/src/PhpWord/Element/TrackChange.php
+++ b/src/PhpWord/Element/TrackChange.php
@@ -58,13 +58,13 @@ class TrackChange extends AbstractContainer
      *
      * @param string $changeType
      * @param string $author
-     * @param null|int|\DateTime $date
+     * @param null|int|bool|\DateTime $date
      */
     public function __construct($changeType = null, $author = null, $date = null)
     {
         $this->changeType = $changeType;
         $this->author = $author;
-        if ($date !== null) {
+        if ($date !== null && $date !== false) {
             $this->date = ($date instanceof \DateTime) ? $date : new \DateTime('@' . $date);
         }
     }

--- a/tests/PhpWord/Element/TrackChangeTest.php
+++ b/tests/PhpWord/Element/TrackChangeTest.php
@@ -41,7 +41,7 @@ class TrackChangeTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($date, $oTrackChange->getDate());
         $this->assertEquals(TrackChange::INSERTED, $oTrackChange->getChangeType());
     }
-    
+
     /**
      * New instance with invalid \DateTime (produced by \DateTime::createFromFormat(...))
      */

--- a/tests/PhpWord/Element/TrackChangeTest.php
+++ b/tests/PhpWord/Element/TrackChangeTest.php
@@ -41,4 +41,22 @@ class TrackChangeTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($date, $oTrackChange->getDate());
         $this->assertEquals(TrackChange::INSERTED, $oTrackChange->getChangeType());
     }
+    
+    /**
+     * New instance with invalid \DateTime (produced by \DateTime::createFromFormat(...))
+     */
+    public function testConstructDefaultWithInvalidDate()
+    {
+        $author = 'Test User';
+        $date = false;
+        $oTrackChange = new TrackChange(TrackChange::INSERTED, $author, $date);
+
+        $oText = new Text('dummy text');
+        $oText->setTrackChange($oTrackChange);
+
+        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\TrackChange', $oTrackChange);
+        $this->assertEquals($author, $oTrackChange->getAuthor());
+        $this->assertEquals($date, null);
+        $this->assertEquals(TrackChange::INSERTED, $oTrackChange->getChangeType());
+    }
 }


### PR DESCRIPTION
### Description

DateTime::createFromFormat(...) returns either a \DateTime instance or FALSE, not NULL.  Working on the basis that there might be legitimate TrackChange constructor calls containing a NULL date parameter, line 67 has been expanded to check not only for NOT NULL but also NOT FALSE.

Without this additional check, a document with "Track Changes" enabled could cause an Exception to be raised when loaded into a reader.

"Exception: DateTime::__construct(): Failed to parse time string (@) at position 0 (@): Unexpected character"

I couldn't see any relevant documentation that would benefit from being updated with details of this change, hence the incomplete checklist.

Fixes # N/A

### Checklist:

- [X] I have run `composer run-script check --timeout=0` and no errors were reported
- [X] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
