### PR TITLE
Ensure that entity_loader disable variable is re-set back to the orig…

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -72,7 +72,7 @@ class Html
         }
 
         // Load DOM
-        libxml_disable_entity_loader(true);
+        $orignalLibEntityLoader = libxml_disable_entity_loader(true);
         $dom = new \DOMDocument();
         $dom->preserveWhiteSpace = $preserveWhiteSpace;
         $dom->loadXML($html);
@@ -80,6 +80,7 @@ class Html
         $node = $dom->getElementsByTagName('body');
 
         self::parseNode($node->item(0), $element);
+        libxml_disable_entity_loader($orignalLibEntityLoader);
     }
 
     /**

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -170,7 +170,7 @@ class TemplateProcessor
      */
     protected function transformSingleXml($xml, $xsltProcessor)
     {
-        libxml_disable_entity_loader(true);
+        $orignalLibEntityLoader = libxml_disable_entity_loader(true);
         $domDocument = new \DOMDocument();
         if (false === $domDocument->loadXML($xml)) {
             throw new Exception('Could not load the given XML document.');
@@ -180,6 +180,7 @@ class TemplateProcessor
         if (false === $transformedXml) {
             throw new Exception('Could not transform the given XML document.');
         }
+        libxml_disable_entity_loader($orignalLibEntityLoader);
 
         return $transformedXml;
     }

--- a/tests/PhpWord/_includes/XmlDocument.php
+++ b/tests/PhpWord/_includes/XmlDocument.php
@@ -76,10 +76,10 @@ class XmlDocument
         $this->file = $file;
 
         $file = $this->path . '/' . $file;
-        libxml_disable_entity_loader(false);
+        $orignalLibEntityLoader = libxml_disable_entity_loader(false);
         $this->dom = new \DOMDocument();
         $this->dom->load($file);
-        libxml_disable_entity_loader(true);
+        libxml_disable_entity_loader($orignalLibEntityLoader);
 
         return $this->dom;
     }


### PR DESCRIPTION
…inal setting

### Description

I work for a project that implements PHPWord that being CiviCRM, we have found that the changes here have sometimes disrupted our test suite because we have used XML to define our menu structure and like. This is because the changes override the global value of the loading of external entites and doesn't re-set afterwards. 

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [n/a] I have updated the documentation to describe the changes
