### PR TITLE
Set proper default heading styles during HTML parsing

### DIFF
--- a/samples/Sample_26_Html.php
+++ b/samples/Sample_26_Html.php
@@ -4,7 +4,6 @@ include_once 'Sample_Header.php';
 // New Word Document
 echo date('H:i:s') , ' Create new PhpWord object' , EOL;
 $phpWord = new \PhpOffice\PhpWord\PhpWord();
-$phpWord->addParagraphStyle('Heading2', array('alignment' => 'center'));
 
 $section = $phpWord->addSection();
 $html = '<h1>Adding element via HTML</h1>';
@@ -21,7 +20,7 @@ $html .= '<ul><li>Item 1</li><li>Item 2</li><ul><li>Item 2.1</li><li>Item 2.1</l
 $html .= '<p style="margin-top: 240pt;">1.5 line height with first line text indent:</p>';
 $html .= '<p style="text-align: justify; text-indent: 70.9pt; line-height: 150%;">Lorem ipsum dolor sit amet, <strong>consectetur adipiscing elit</strong>, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>';
 
-$html .= '<h2 style="align: center">centered title</h2>';
+$html .= '<h2 style="text-align: center">centered title</h2>';
 
 $html .= '<p style="margin-top: 240pt;">Ordered (numbered) list:</p>';
 $html .= '<ol>

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -135,12 +135,12 @@ class Html
         $nodes = array(
                               // $method        $node   $element    $styles     $data   $argument1      $argument2
             'p'         => array('Paragraph',   $node,  $element,   $styles,    null,   null,           null),
-            'h1'        => array('Heading',     null,   $element,   $styles,    null,   'Heading1',     1),
-            'h2'        => array('Heading',     null,   $element,   $styles,    null,   'Heading2',     2),
-            'h3'        => array('Heading',     null,   $element,   $styles,    null,   'Heading3',     3),
-            'h4'        => array('Heading',     null,   $element,   $styles,    null,   'Heading4',     4),
-            'h5'        => array('Heading',     null,   $element,   $styles,    null,   'Heading5',     5),
-            'h6'        => array('Heading',     null,   $element,   $styles,    null,   'Heading6',     6),
+            'h1'        => array('Heading',     $node,  $element,   $styles,    null,   1,              null),
+            'h2'        => array('Heading',     $node,  $element,   $styles,    null,   2,              null),
+            'h3'        => array('Heading',     $node,  $element,   $styles,    null,   3,              null),
+            'h4'        => array('Heading',     $node,  $element,   $styles,    null,   4,              null),
+            'h5'        => array('Heading',     $node,  $element,   $styles,    null,   5,              null),
+            'h6'        => array('Heading',     $node,  $element,   $styles,    null,   6,              null),
             '#text'     => array('Text',        $node,  $element,   $styles,    null,   null,           null),
             'strong'    => array('Property',    null,   null,       $styles,    null,   'bold',         true),
             'b'         => array('Property',    null,   null,       $styles,    null,   'bold',         true),
@@ -236,6 +236,7 @@ class Html
     /**
      * Parse heading node
      *
+     * @param \DOMNode $node
      * @param \PhpOffice\PhpWord\Element\AbstractContainer $element
      * @param array &$styles
      * @param string $argument1 Name of heading style
@@ -244,13 +245,14 @@ class Html
      * @todo Think of a clever way of defining header styles, now it is only based on the assumption, that
      * Heading1 - Heading6 are already defined somewhere
      */
-    private static function parseHeading($element, &$styles, $argument1, $argument2)
+    private static function parseHeading($node, $element, &$styles, $argument1)
     {
-        $styles['paragraph'] = $argument1;
-        $newElement = $element->addTextRun($styles['paragraph']);
+        $styles['styleName'] = "Heading{$argument1}";
+        $styles = self::parseInlineStyle($node, $styles);
+        $newElement = $element->addTextRun($styles);
 
-        if ( empty(\PhpOffice\PhpWord\Style::getStyle("Heading_{$argument2}")) ) {
-            \PhpOffice\PhpWord\Style::setDefaultTitleStyle($argument2);
+        if (empty(\PhpOffice\PhpWord\Style::getStyle("Heading_{$argument1}"))) {
+            \PhpOffice\PhpWord\Style::setDefaultTitleStyle($argument1);
         }
 
         return $newElement;

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -135,12 +135,12 @@ class Html
         $nodes = array(
                               // $method        $node   $element    $styles     $data   $argument1      $argument2
             'p'         => array('Paragraph',   $node,  $element,   $styles,    null,   null,           null),
-            'h1'        => array('Heading',     null,   $element,   $styles,    null,   'Heading1',     null),
-            'h2'        => array('Heading',     null,   $element,   $styles,    null,   'Heading2',     null),
-            'h3'        => array('Heading',     null,   $element,   $styles,    null,   'Heading3',     null),
-            'h4'        => array('Heading',     null,   $element,   $styles,    null,   'Heading4',     null),
-            'h5'        => array('Heading',     null,   $element,   $styles,    null,   'Heading5',     null),
-            'h6'        => array('Heading',     null,   $element,   $styles,    null,   'Heading6',     null),
+            'h1'        => array('Heading',     null,   $element,   $styles,    null,   'Heading1',     1),
+            'h2'        => array('Heading',     null,   $element,   $styles,    null,   'Heading2',     2),
+            'h3'        => array('Heading',     null,   $element,   $styles,    null,   'Heading3',     3),
+            'h4'        => array('Heading',     null,   $element,   $styles,    null,   'Heading4',     4),
+            'h5'        => array('Heading',     null,   $element,   $styles,    null,   'Heading5',     5),
+            'h6'        => array('Heading',     null,   $element,   $styles,    null,   'Heading6',     6),
             '#text'     => array('Text',        $node,  $element,   $styles,    null,   null,           null),
             'strong'    => array('Property',    null,   null,       $styles,    null,   'bold',         true),
             'b'         => array('Property',    null,   null,       $styles,    null,   'bold',         true),
@@ -244,10 +244,14 @@ class Html
      * @todo Think of a clever way of defining header styles, now it is only based on the assumption, that
      * Heading1 - Heading6 are already defined somewhere
      */
-    private static function parseHeading($element, &$styles, $argument1)
+    private static function parseHeading($element, &$styles, $argument1, $argument2)
     {
         $styles['paragraph'] = $argument1;
         $newElement = $element->addTextRun($styles['paragraph']);
+
+        if ( empty(\PhpOffice\PhpWord\Style::getStyle("Heading_{$argument2}")) ) {
+            \PhpOffice\PhpWord\Style::setDefaultTitleStyle($argument2);
+        }
 
         return $newElement;
     }

--- a/src/PhpWord/Style.php
+++ b/src/PhpWord/Style.php
@@ -152,6 +152,7 @@ class Style
     /**
      * Set default title style
      *
+     * @param int $depth
      * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $styles Title style definition
      * @return \PhpOffice\PhpWord\Style\Title
      */
@@ -163,7 +164,7 @@ class Style
             3 => array('size' => 12, 'color' => '1F4D78'),
             4 => array('size' => 12, 'color' => '2E74B5', 'italic' => true),
             5 => array('size' => 12, 'color' => '2E74B5'),
-            6 => array('size' => 12, 'color' => '1F4D78')
+            6 => array('size' => 12, 'color' => '1F4D78'),
         );
 
         return self::addTitleStyle($depth, $titleFontStyles[$depth]);

--- a/src/PhpWord/Style.php
+++ b/src/PhpWord/Style.php
@@ -150,6 +150,26 @@ class Style
     }
 
     /**
+     * Set default title style
+     *
+     * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $styles Title style definition
+     * @return \PhpOffice\PhpWord\Style\Title
+     */
+    public static function setDefaultTitleStyle($depth)
+    {
+        $titleFontStyles = array(
+            1 => array('size' => 16, 'color' => '2E74B5'),
+            2 => array('size' => 13, 'color' => '2E74B5'),
+            3 => array('size' => 12, 'color' => '1F4D78'),
+            4 => array('size' => 12, 'color' => '2E74B5', 'italic' => true),
+            5 => array('size' => 12, 'color' => '2E74B5'),
+            6 => array('size' => 12, 'color' => '1F4D78')
+        );
+
+        return self::addTitleStyle($depth, $titleFontStyles[$depth]);
+    }
+
+    /**
      * Get all styles
      *
      * @return \PhpOffice\PhpWord\Style\AbstractStyle[]


### PR DESCRIPTION
### Description

In the past, only heading style names (e.g. Heading1, Heading2, Heading3, ...etc) were added to heading text during HTML parsing. But there is no actual heading style were created correspondingly. That is the root cuase of #334.

This PR is going to set proper default heading styles during HTML parsing. The default style values are same as I observed from Microsoft Word Online.

Fixes #334

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
