### PR TITLE
call static instead of self on protected method

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -192,7 +192,7 @@ class Html
             $newElement = $element;
         }
 
-        self::parseChildNodes($node, $newElement, $styles, $data);
+        static::parseChildNodes($node, $newElement, $styles, $data);
     }
 
     /**


### PR DESCRIPTION
### Description

No linked issue.
When you want to extends PhpOffice\PhpWord\Shared\Html class, the protected method **parseNode**,  will call "self::parseChildNodes" making the call parseNode useless in the new class. And prevent parseChildNodes from being customized in the new class.

The change made allows the **parseNode** method to look for **parseChildNodes** first in the newly created class

More concretely, you can now customize **parseChildNodes** by extending the Html class

Maybe we can do same thing with all static methods (replacing calls _self::_ by _static::_)

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
