### PR TITLE
No nested w:pPr elements in ListItemRun.

### DIFF
--- a/src/PhpWord/Writer/Word2007/Element/ListItemRun.php
+++ b/src/PhpWord/Writer/Word2007/Element/ListItemRun.php
@@ -17,6 +17,7 @@
 
 namespace PhpOffice\PhpWord\Writer\Word2007\Element;
 
+use PhpOffice\PhpWord\Element\ListItemRun as ListItemRunElement;
 use PhpOffice\PhpWord\Writer\Word2007\Style\Paragraph as ParagraphStyleWriter;
 
 /**
@@ -31,34 +32,56 @@ class ListItemRun extends AbstractElement
      */
     public function write()
     {
-        $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\ListItemRun) {
+
+        if (!$element instanceof ListItemRunElement) {
             return;
         }
 
+        $this->writeParagraph($element);
+    }
+
+    private function writeParagraph(ListItemRunElement $element)
+    {
+        $xmlWriter = $this->getXmlWriter();
         $xmlWriter->startElement('w:p');
 
-        $xmlWriter->startElement('w:pPr');
-        $paragraphStyle = $element->getParagraphStyle();
-        $styleWriter = new ParagraphStyleWriter($xmlWriter, $paragraphStyle);
-        $styleWriter->setIsInline(true);
-        $styleWriter->write();
-
-        $xmlWriter->startElement('w:numPr');
-        $xmlWriter->startElement('w:ilvl');
-        $xmlWriter->writeAttribute('w:val', $element->getDepth());
-        $xmlWriter->endElement(); // w:ilvl
-        $xmlWriter->startElement('w:numId');
-        $xmlWriter->writeAttribute('w:val', $element->getStyle()->getNumId());
-        $xmlWriter->endElement(); // w:numId
-        $xmlWriter->endElement(); // w:numPr
-
-        $xmlWriter->endElement(); // w:pPr
+        $this->writeParagraphProperties($element);
 
         $containerWriter = new Container($xmlWriter, $element);
         $containerWriter->write();
 
         $xmlWriter->endElement(); // w:p
+    }
+
+    private function writeParagraphProperties(ListItemRunElement $element)
+    {
+        $xmlWriter = $this->getXmlWriter();
+        $xmlWriter->startElement('w:pPr');
+
+        $styleWriter = new ParagraphStyleWriter($xmlWriter, $element->getParagraphStyle());
+        $styleWriter->setIsInline(true);
+        $styleWriter->setWithoutPPR(true);
+        $styleWriter->write();
+
+        $this->writeParagraphPropertiesNumbering($element);
+
+        $xmlWriter->endElement(); // w:pPr
+    }
+
+    private function writeParagraphPropertiesNumbering(ListItemRunElement $element)
+    {
+        $xmlWriter = $this->getXmlWriter();
+        $xmlWriter->startElement('w:numPr');
+
+        $xmlWriter->writeElementBlock('w:ilvl', array(
+            'w:val' => $element->getDepth(),
+        ));
+
+        $xmlWriter->writeElementBlock('w:numId', array(
+            'w:val' => $element->getStyle()->getNumId(),
+        ));
+
+        $xmlWriter->endElement(); // w:numPr
     }
 }

--- a/tests/PhpWord/Writer/Word2007/ElementTest.php
+++ b/tests/PhpWord/Writer/Word2007/ElementTest.php
@@ -510,4 +510,25 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:t'));
         $this->assertEquals('this text contains an & (ampersant)', $doc->getElement('/w:document/w:body/w:p/w:r/w:t')->nodeValue);
     }
+
+    /**
+     * Test ListItemRun paragraph style writing
+     */
+    public function testListItemRunStyleWriting()
+    {
+        $phpWord = new PhpWord();
+        $phpWord->addParagraphStyle('MyParagraphStyle', array('spaceBefore' => 400));
+
+        $section = $phpWord->addSection();
+        $listItemRun = $section->addListItemRun(0, null, 'MyParagraphStyle');
+        $listItemRun->addText('List item');
+        $listItemRun->addText(' in bold', array('bold' => true));
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+        $this->assertFalse($doc->elementExists('/w:document/w:body/w:p/w:pPr/w:pPr'));
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:pPr/w:pStyle'));
+        $this->assertEquals('List item', $doc->getElement('/w:document/w:body/w:p/w:r[1]/w:t')->nodeValue);
+        $this->assertEquals(' in bold', $doc->getElement('/w:document/w:body/w:p/w:r[2]/w:t')->nodeValue);
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r[2]/w:rPr/w:b'));
+    }
 }


### PR DESCRIPTION
### Description

This commit fixes issue #1529

This commit prevents nested w:pPr elements when using a ListItemRun with
a paragraph style. The different between a ListItem and a ListItem run
is that the setWithoutPPR method is called on the ParagraphStyleWriter
(PhpOffice\PhpWord\Writer\Word2007\Style\Paragraph).

According to the specs it's not allowed to have nested w:pPr elements.
See http://www.datypic.com/sc/ooxml/e-w_pPr-2.html

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
