### PR TITLE
To support PreserveText inside sub container

### DIFF
--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -254,7 +254,7 @@ abstract class AbstractContainer extends AbstractElement
         // Special condition, e.g. preservetext can only exists in cell when
         // the cell is located in header or footer
         $validSubcontainers = array(
-            'PreserveText'  => array(array('Cell'), array('Header', 'Footer')),
+            'PreserveText'  => array(array('Cell'), array('Header', 'Footer', 'Section')),
             'Footnote'      => array(array('Cell', 'TextRun'), array('Section')),
             'Endnote'       => array(array('Cell', 'TextRun'), array('Section')),
         );

--- a/tests/PhpWord/Element/CellTest.php
+++ b/tests/PhpWord/Element/CellTest.php
@@ -231,7 +231,7 @@ class CellTest extends \PHPUnit\Framework\TestCase
     public function testAddPreserveTextException()
     {
         $oCell = new Cell();
-        $oCell->setDocPart('Section', 1);
+        $oCell->setDocPart('TextRun', 1);
         $oCell->addPreserveText('text');
     }
 


### PR DESCRIPTION


### Description

if we use PreserveText inside table or special characters, issue fixed
Relavent
https://stackoverflow.com/questions/33070424/phpword-cannot-add-preservetext-in-section

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
