### PR TITLE
allow user to set custom config for pdf rendering library (specially mpdf)

### DIFF
--- a/src/PhpWord/Settings.php
+++ b/src/PhpWord/Settings.php
@@ -100,6 +100,13 @@ class Settings
     private static $pdfRendererPath = null;
 
     /**
+     * Config to the external Library used for rendering PDF files
+     *
+     * @var string
+     */
+    private static $pdfRendererConfig = null;
+
+    /**
      * Measurement unit
      *
      * @var int|float
@@ -231,6 +238,19 @@ class Settings
     }
 
     /**
+     * Set the config to use for the PDF Rendering Library.
+     *
+     * @param array $libraryConfig
+     * @return string
+     */
+    public static function setPdfRendererConfig($libraryConfig)
+    {
+        self::$pdfRendererConfig = $libraryConfig;
+
+        return true;
+    }
+
+    /**
      * Return the directory path to the PDF Rendering Library.
      *
      * @return string
@@ -238,6 +258,16 @@ class Settings
     public static function getPdfRendererPath()
     {
         return self::$pdfRendererPath;
+    }
+
+    /**
+     * Return the config to instantiate PDF Rendering Library.
+     *
+     * @return array
+     */
+    public static function getPdfRendererConfig()
+    {
+        return self::$pdfRendererConfig;
     }
 
     /**

--- a/src/PhpWord/Writer/PDF/MPDF.php
+++ b/src/PhpWord/Writer/PDF/MPDF.php
@@ -29,6 +29,9 @@ use PhpOffice\PhpWord\Writer\WriterInterface;
  */
 class MPDF extends AbstractRenderer implements WriterInterface
 {
+    const MPDF_5 = '\mpdf';
+    const MPDF_6 = '\Mpdf\Mpdf';
+
     /**
      * Overridden to set the correct includefile, only needed for MPDF 5
      *
@@ -59,7 +62,12 @@ class MPDF extends AbstractRenderer implements WriterInterface
 
         //  Create PDF
         $mPdfClass = $this->getMPdfClassName();
-        $pdf = new $mPdfClass();
+        if (self::MPDF_5 === $mPdfClass) {
+            $pdf = new $mPdfClass();
+        } else {
+            $mPdfConfig = Settings::getPdfRendererConfig() ?: array();
+            $pdf = new $mPdfClass($mPdfConfig);
+        }
         $pdf->_setPageSize($paperSize, $orientation);
         $pdf->addPage($orientation);
 
@@ -90,10 +98,10 @@ class MPDF extends AbstractRenderer implements WriterInterface
     {
         if ($this->includeFile != null) {
             // MPDF version 5.*
-            return '\mpdf';
+            return self::MPDF_5;
         }
 
         // MPDF version > 6.*
-        return '\Mpdf\Mpdf';
+        return self::MPDF_6;
     }
 }


### PR DESCRIPTION
Issue on mpdf library : https://github.com/mpdf/mpdf/issues/701#issuecomment-502382803

Rejected PR on mpdf library : https://github.com/mpdf/mpdf/pull/1047

### Description

Allow user to set pdf rendering library configuration. Please refer to the issue referenced in commit message.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
-- I'll do it. But wait for PR reviewing before.
- [ ] I have updated the documentation to describe the changes
-- Not described in documentation
