### PR TITLE
Add page numbers in TOC

### DIFF
--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -31,7 +31,7 @@ namespace PhpOffice\PhpWord\Element;
  * @method Footnote addFootnote(mixed $pStyle = null)
  * @method Endnote addEndnote(mixed $pStyle = null)
  * @method CheckBox addCheckBox(string $name, $text, mixed $fStyle = null, mixed $pStyle = null)
- * @method Title addTitle(mixed $text, int $depth = 1)
+ * @method Title addTitle(mixed $text, int $depth = 1, $pageNum = null)
  * @method TOC addTOC(mixed $fontStyle = null, mixed $tocStyle = null, int $minDepth = 1, int $maxDepth = 9)
  * @method PageBreak addPageBreak()
  * @method Table addTable(mixed $style = null)
@@ -41,7 +41,7 @@ namespace PhpOffice\PhpWord\Element;
  * @method Field addField(string $type = null, array $properties = array(), array $options = array(), mixed $text = null)
  * @method Line addLine(mixed $lineStyle = null)
  * @method Shape addShape(string $type, mixed $style = null)
- * @method Chart addChart(string $type, array $categories, array $values, array $style = null)
+ * @method Chart addChart(string $type, array $categories, array $values, array $style = null, $seriesName = null)
  * @method FormField addFormField(string $type, mixed $fStyle = null, mixed $pStyle = null)
  * @method SDT addSDT(string $type)
  *

--- a/src/PhpWord/Element/Title.php
+++ b/src/PhpWord/Element/Title.php
@@ -54,12 +54,20 @@ class Title extends AbstractElement
     protected $collectionRelation = true;
 
     /**
+     * Bookmark page number
+     *
+     * @var int
+     */
+    private $pageNum;
+
+    /**
      * Create a new Title Element
      *
      * @param string|TextRun $text
      * @param int $depth
+     * @param int|null $pageNum
      */
-    public function __construct($text, $depth = 1)
+    public function __construct($text, $depth = 1, $pageNum = null)
     {
         if (is_string($text)) {
             $this->text = CommonText::toUTF8($text);
@@ -73,6 +81,10 @@ class Title extends AbstractElement
         $styleName = $depth === 0 ? 'Title' : "Heading_{$this->depth}";
         if (array_key_exists($styleName, Style::getStyles())) {
             $this->style = str_replace('_', '', $styleName);
+        }
+
+        if($pageNum !== null) {
+            $this->pageNum = $pageNum;
         }
     }
 
@@ -104,5 +116,15 @@ class Title extends AbstractElement
     public function getStyle()
     {
         return $this->style;
+    }
+
+    /**
+     * Get page number
+     *
+     * @return int
+     */
+    public function getPageNum()
+    {
+        return $this->pageNum;
     }
 }

--- a/src/PhpWord/Writer/Word2007/Element/TOC.php
+++ b/src/PhpWord/Writer/Word2007/Element/TOC.php
@@ -118,6 +118,20 @@ class TOC extends AbstractElement
         $xmlWriter->endElement();
         $xmlWriter->endElement();
 
+        if($title->getPageNum() !== null) {
+            $xmlWriter->startElement('w:r');
+            $xmlWriter->startElement('w:fldChar');
+            $xmlWriter->writeAttribute('w:fldCharType', 'separate');
+            $xmlWriter->endElement();
+            $xmlWriter->endElement();
+
+            $xmlWriter->startElement('w:r');
+            $xmlWriter->startElement('w:t');
+            $xmlWriter->text($title->getPageNum());
+            $xmlWriter->endElement();
+            $xmlWriter->endElement();
+        }
+
         $xmlWriter->startElement('w:r');
         $xmlWriter->startElement('w:fldChar');
         $xmlWriter->writeAttribute('w:fldCharType', 'end');


### PR DESCRIPTION
Update Wrong definition

### Description

There was no page numbers of TOC If open result Word document in libreoffice because MS Word getting this numbers of bookmarks by native method, but libreoffice can't do it. it just shows strings, but in PHPWord is not inserting pagenumbers. My pull-request is fixes this bug.
so you need to use  

```
$section = $this->getCurrentSection();
$section->addTitle($text, $depth, $pageNum);
```
if you want to open it in libreoffice