### PR TITLE
Use relative links in README to ensure they go to the correct branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Develop:
 
 PHPWord is a library written in pure PHP that provides a set of classes to write to and read from different document file formats. The current version of PHPWord supports Microsoft [Office Open XML](http://en.wikipedia.org/wiki/Office_Open_XML) (OOXML or OpenXML), OASIS [Open Document Format for Office Applications](http://en.wikipedia.org/wiki/OpenDocument) (OpenDocument or ODF), [Rich Text Format](http://en.wikipedia.org/wiki/Rich_Text_Format) (RTF), HTML, and PDF.
 
-PHPWord is an open source project licensed under the terms of [LGPL version 3](https://github.com/PHPOffice/PHPWord/blob/develop/COPYING.LESSER). PHPWord is aimed to be a high quality software product by incorporating [continuous integration](https://travis-ci.org/PHPOffice/PHPWord) and [unit testing](http://phpoffice.github.io/PHPWord/coverage/develop/). You can learn more about PHPWord by reading the [Developers' Documentation](http://phpword.readthedocs.org/).
+PHPWord is an open source project licensed under the terms of [LGPL version 3](COPYING.LESSER). PHPWord is aimed to be a high quality software product by incorporating [continuous integration](https://travis-ci.org/PHPOffice/PHPWord) and [unit testing](http://phpoffice.github.io/PHPWord/coverage/develop/). You can learn more about PHPWord by reading the [Developers' Documentation](http://phpword.readthedocs.org/).
 
 If you have any questions, please ask on [StackOverFlow](https://stackoverflow.com/questions/tagged/phpword)
 
@@ -174,7 +174,7 @@ You can also read the [Developers' Documentation](http://phpword.readthedocs.org
 
 We welcome everyone to contribute to PHPWord. Below are some of the things that you can do to contribute.
 
-- Read [our contributing guide](https://github.com/PHPOffice/PHPWord/blob/master/CONTRIBUTING.md).
+- Read [our contributing guide](CONTRIBUTING.md).
 - [Fork us](https://github.com/PHPOffice/PHPWord/fork) and [request a pull](https://github.com/PHPOffice/PHPWord/pulls) to the [develop](https://github.com/PHPOffice/PHPWord/tree/develop) branch.
 - Submit [bug reports or feature requests](https://github.com/PHPOffice/PHPWord/issues) to GitHub.
 - Follow [@PHPWord](https://twitter.com/PHPWord) and [@PHPOffice](https://twitter.com/PHPOffice) on Twitter.


### PR DESCRIPTION
### Description

I went in to check the updated CONTRIBUTING file and noticed the link in the README directs users to CONTRIBUTING.md on the master branch. I've updated that link and one other to use relative links so they'll always link to the current branch (and will be more portable).

Fixes # (issue)

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
