### PR TITLE
Remove urldecode to handle filenames with spaces

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -686,7 +686,6 @@ class Html
                 fclose($ifp);
             }
         }
-        $src = urldecode($src);
 
         if (!is_file($src)
             && !is_null(self::$options)


### PR DESCRIPTION
### Description

Converting an HTML file to Word fails when the HTML contains an `<img>` tag whose `<src>` is a) a URL, and b) contains a space.  

I'm not sure if there's a reliable way to test this, since it requires loading a file from a URL; the bug isn't present when a space exists in a file path.  However, I confirm that this passes all existing tests.

Fixes # (none)

### Checklist:

- [X] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
