### PR TITLE
add support wordwrap for paragraph

### DIFF
--- a/src/PhpWord/SimpleType/WordWrap.php
+++ b/src/PhpWord/SimpleType/WordWrap.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ * @copyright   2010-2018 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\SimpleType;
+
+use PhpOffice\PhpWord\Shared\AbstractEnum;
+
+/**
+ * Horizontal Alignment Type.
+ *
+ * Introduced in 1st Edition of ECMA-376. Initially it was intended to align paragraphs and tables.
+ * Since ISO/IEC-29500:2008 the type must not be used for table alignment.
+ *
+ * @since 0.13.0
+ *
+ * @see \PhpOffice\PhpWord\SimpleType\JcTable For table alignment modes available since ISO/IEC-29500:2008.
+ * @see  http://www.datypic.com/sc/ooxml/t-w_ST_Jc.html
+ */
+final class WordWrap extends AbstractEnum
+{
+    const ON = 'on';
+    const OFF = 'off';
+
+}

--- a/src/PhpWord/Style/Paragraph.php
+++ b/src/PhpWord/Style/Paragraph.php
@@ -20,6 +20,7 @@ namespace PhpOffice\PhpWord\Style;
 use PhpOffice\Common\Text;
 use PhpOffice\PhpWord\Exception\InvalidStyleException;
 use PhpOffice\PhpWord\SimpleType\Jc;
+use PhpOffice\PhpWord\SimpleType\WordWrap;
 use PhpOffice\PhpWord\SimpleType\TextAlignment;
 
 /**
@@ -39,6 +40,7 @@ use PhpOffice\PhpWord\SimpleType\TextAlignment;
  * OpenOffice:
  * - Indents & spacing
  * - Alignment
+ * - WordWrap
  * - Text flow
  * - Outline & numbering
  * - Tabs
@@ -81,6 +83,11 @@ class Paragraph extends Border
      * @var string
      */
     private $alignment = '';
+
+    /**
+     * @var string
+     */
+    private $wordWrap = '';
 
     /**
      * Indentation
@@ -221,6 +228,7 @@ class Paragraph extends Border
             'basedOn'             => $this->getBasedOn(),
             'next'                => $this->getNext(),
             'alignment'           => $this->getAlignment(),
+            'wordWrap'           => $this->getWordWrap(),
             'indentation'         => $this->getIndentation(),
             'spacing'             => $this->getSpace(),
             'pagination'          => array(
@@ -265,6 +273,33 @@ class Paragraph extends Border
     {
         if (Jc::isValid($value)) {
             $this->alignment = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @since 0.17.0
+     *
+     * @return string
+     */
+    public function getWordWrap()
+    {
+        return $this->wordWrap;
+    }
+
+
+    /**
+     * @since 0.17.0
+     *
+     * @param string $value
+     *
+     * @return self
+     */
+    public function setWordWrap($value)
+    {
+        if (WordWrap::isValid($value)) {
+            $this->wordWrap = $value;
         }
 
         return $this;

--- a/src/PhpWord/Writer/Word2007/Element/ParagraphWordWrap.php
+++ b/src/PhpWord/Writer/Word2007/Element/ParagraphWordWrap.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ * @copyright   2010-2018 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+
+/**
+ * @since 0.17.0
+ */
+class ParagraphWordWrap
+{
+    private $name = 'w:wordWrap';
+
+    private $attributes = array();
+
+    /**
+     * @since 0.17.0
+     *
+     * @param string $value Any value provided by WordWrap simple type
+     *
+     * @see \PhpOffice\PhpWord\SimpleType\WordWrap For the allowed values of $value parameter.
+     */
+    final public function __construct($value)
+    {
+        $this->attributes['w:val'] = $value;
+    }
+
+    /**
+     * @since 0.17.0
+     *
+     * @return string
+     */
+    final public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @since 0.17.0
+     *
+     * @return string[]
+     */
+    final public function getAttributes()
+    {
+        return $this->attributes;
+    }
+}

--- a/src/PhpWord/Writer/Word2007/Style/Paragraph.php
+++ b/src/PhpWord/Writer/Word2007/Style/Paragraph.php
@@ -21,6 +21,7 @@ use PhpOffice\Common\XMLWriter;
 use PhpOffice\PhpWord\Style;
 use PhpOffice\PhpWord\Style\Paragraph as ParagraphStyle;
 use PhpOffice\PhpWord\Writer\Word2007\Element\ParagraphAlignment;
+use PhpOffice\PhpWord\Writer\Word2007\Element\ParagraphWordWrap;
 
 /**
  * Paragraph style writer
@@ -98,6 +99,16 @@ class Paragraph extends AbstractStyle
             $paragraphAlignment = new ParagraphAlignment($styles['alignment']);
             $xmlWriter->startElement($paragraphAlignment->getName());
             foreach ($paragraphAlignment->getAttributes() as $attributeName => $attributeValue) {
+                $xmlWriter->writeAttribute($attributeName, $attributeValue);
+            }
+            $xmlWriter->endElement();
+        }
+
+        // Paragraph wordWrap
+        if ('' !== $styles['wordWrap']) {
+            $paragraphWordWrap = new ParagraphWordWrap($styles['wordWrap']);
+            $xmlWriter->startElement($paragraphWordWrap->getName());
+            foreach ($paragraphWordWrap->getAttributes() as $attributeName => $attributeValue) {
                 $xmlWriter->writeAttribute($attributeName, $attributeValue);
             }
             $xmlWriter->endElement();


### PR DESCRIPTION
### Description
add support wordwrap for paragraph to fixes
https://github.com/PHPOffice/PHPWord/issues/1687



### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
