### PR TITLE
Add support for whole-document FootnoteProperties

### DIFF
--- a/docs/elements.rst
+++ b/docs/elements.rst
@@ -359,17 +359,21 @@ The footnote numbering can be controlled by setting the FootnoteProperties on th
 
 .. code-block:: php
 
-    $fp = new PhpWord\SimpleType\FootnoteProperties();
+    $fp = new \PhpOffice\PhpWord\ComplexType\FootnoteProperties();
     //sets the position of the footnote (pageBottom (default), beneathText, sectEnd, docEnd)
-    $fp->setPos(FootnoteProperties::POSITION_DOC_END);
+    $fp->setPos(\PhpOffice\PhpWord\ComplexType\FootnoteProperties::POSITION_BENEATH_TEXT);
     //set the number format to use (decimal (default), upperRoman, upperLetter, ...)
-    $fp->setNumFmt(FootnoteProperties::NUMBER_FORMAT_LOWER_ROMAN);
+    $fp->setNumFmt(\PhpOffice\PhpWord\SimpleType\NumberFormat::LOWER_ROMAN);
     //force starting at other than 1
     $fp->setNumStart(2);
     //when to restart counting (continuous (default), eachSect, eachPage)
-    $fp->setNumRestart(FootnoteProperties::RESTART_NUMBER_EACH_PAGE);
+    $fp->setNumRestart(\PhpOffice\PhpWord\ComplexType\FootnoteProperties::RESTART_NUMBER_EACH_PAGE);
     //And finaly, set it on the Section
-    $section->setFootnoteProperties($properties);
+    $section->setFootnoteProperties($fp);
+
+To set endnote properties, use the ``setEndnoteProperties`` method instead.
+You can also use ``$phpWord->setDefaultFootnoteProperties()`` and ``$phpWord->setDefaultEndnoteProperties()``
+to set the properties for all the footnotes/endnotes in the document.
 
 Checkboxes
 ----------

--- a/docs/general.rst
+++ b/docs/general.rst
@@ -141,6 +141,24 @@ default font by using the following two functions:
     $phpWord->setDefaultFontName('Times New Roman');
     $phpWord->setDefaultFontSize(12);
 
+Default footnote and endnote properties
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, footnotes are displayed at the bottom of the page, numbered continuously from 1.
+Endnotes are displayed at the end of the document, numbered continuously in lower roman numerals starting from 1.
+
+Default properties will apply to all footnotes and endnotes in the document, unless overriden at the section level.
+
+You can change the default properties using ``$phpWord->setDefaultFootnoteProperties()`` and ``$phpWord->setDefaultEndnoteProperties()``:
+
+.. code-block:: php
+
+    $defaultProperties = new \PhpOffice\PhpWord\ComplexType\FootnoteProperties();
+    $defaultProperties->setPos(\PhpOffice\PhpWord\ComplexType\FootnoteProperties::POSITION_SECTION_END);
+    $defaultProperties->setNumFmt(\PhpOffice\PhpWord\SimpleType\NumberFormat::ORDINAL);
+    $defaultProperties->setNumStart(4);
+    $phpWord->setDefaultEndnoteProperties($defaultProperties);
+
 Document settings
 -----------------
 Settings for the generated document can be set using ``$phpWord->getSettings()``

--- a/samples/Sample_41_FootnoteProperties.php
+++ b/samples/Sample_41_FootnoteProperties.php
@@ -1,0 +1,100 @@
+<?php
+use PhpOffice\PhpWord\ComplexType\FootnoteProperties;
+use PhpOffice\PhpWord\SimpleType\NumberFormat;
+
+include_once 'Sample_Header.php';
+
+// New Word Document
+echo date('H:i:s'), ' Create new PhpWord object', EOL;
+$phpWord = new \PhpOffice\PhpWord\PhpWord();
+\PhpOffice\PhpWord\Settings::setCompatibility(false);
+
+$defaultFp = new FootnoteProperties();
+$defaultFp->setPos(FootnoteProperties::POSITION_BENEATH_TEXT);
+$defaultFp->setNumFmt(NumberFormat::DECIMAL);
+$defaultFp->setNumStart(3);
+$defaultFp->setNumRestart(FootnoteProperties::RESTART_NUMBER_CONTINUOUS);
+
+$phpWord->setDefaultFootnoteProperties($defaultFp);
+
+$defaultEp = new FootnoteProperties();
+$defaultEp->setPos(FootnoteProperties::POSITION_SECTION_END);
+$defaultEp->setNumFmt(NumberFormat::DECIMAL_ENCLOSED_CIRCLE);
+$defaultEp->setNumStart(8);
+$defaultEp->setNumRestart(FootnoteProperties::RESTART_NUMBER_CONTINUOUS);
+
+$phpWord->setDefaultEndnoteProperties($defaultEp);
+
+// First portrait section
+$section = $phpWord->addSection();
+
+$textrun = $section->addTextrun();
+$textrun->addText('This is some lead text in a paragraph with a following endnote and footnote. ');
+
+// First endnote, follows default properties.
+$endnote = $textrun->addEndnote();
+$endnote->addText('First endnote, should be on the second page, prefixed by a "8" enclosed in a circle.');
+
+// First footnote, follows default properties.
+$footnote = $textrun->addFootnote();
+$footnote->addText('First footnote, should be on the first page beneath the text, prefixed by a "3".');
+
+// Create a blank page before the next section
+$section->addPageBreak();
+$section->addPageBreak();
+
+// Second portrait section
+$section = $phpWord->addSection();
+
+// Custom endnote properties for this section
+$ep = new FootnoteProperties();
+$ep->setPos(FootnoteProperties::POSITION_DOC_END);
+$ep->setNumFmt(NumberFormat::DECIMAL_ZERO);
+$ep->setNumStart(2);
+$ep->setNumRestart(FootnoteProperties::RESTART_NUMBER_EACH_SECTION);
+
+// Custom footnote properties for this section
+$fp = new FootnoteProperties();
+$fp->setPos(FootnoteProperties::POSITION_PAGE_BOTTOM);
+$fp->setNumFmt(NumberFormat::ORDINAL_TEXT);
+$fp->setNumStart(6);
+$fp->setNumRestart(FootnoteProperties::RESTART_NUMBER_EACH_PAGE);
+
+$section->setEndnoteProperties($ep);
+$section->setFootnoteProperties($fp);
+
+$textrun = $section->addTextrun();
+$textrun->addText('Second section on a new page with some text followed by an endnote and a footnote. ');
+
+// Second endnote, follows custom properties
+$endnote = $textrun->addEndnote();
+$endnote->addText('Second endnote, should be on the third page at the end of the section
+– even though we told it to be at the end of the document, endnotes only obey default positioning –,
+prefixed by "01" – even though we told it to start at 2, the NumRestart value (each section) resets it to 1.');
+
+// Second footnote, follows custom properties
+$footnote = $textrun->addFootnote();
+$footnote->addText('Second footnote, should be at the bottom of the third page, prefixed by "First"
+– even though we told it to start at 6, the NumRestart value (each page), resets it to 1.');
+
+// Third portrait section
+$section = $phpWord->addSection();
+
+$textrun = $section->addTextrun();
+$textrun->addText('Third and last section, with an endnote and a footnote. ');
+
+// Third endnote, follows default properties
+$endnote = $textrun->addEndnote();
+$endnote->addText('Third endnote, should be at the bottom of the last section, prefixed by a "10" enclosed in a circle
+– note that the previous endnote was counted as part of the continuation, so "10" is displayed, not "9".');
+
+// Third footnote, follows default properties
+$footnote = $textrun->addFootnote();
+$footnote->addText('Third footnote, should be beneath the text on the last page, prefixed by a "5"
+– note that the previous endnote was counted as part of the continuation, so "5" is displayed, not "4".');
+
+// Save file
+echo write($phpWord, basename(__FILE__, '.php'), $writers);
+if (!CLI) {
+    include_once 'Sample_Footer.php';
+}

--- a/src/PhpWord/Element/Section.php
+++ b/src/PhpWord/Element/Section.php
@@ -56,6 +56,13 @@ class Section extends AbstractContainer
     private $footnoteProperties;
 
     /**
+     * The properties for the endnote of this section
+     *
+     * @var FootnoteProperties
+     */
+    private $endnoteProperties;
+
+    /**
      * Create new instance
      *
      * @param int $sectionCount
@@ -146,6 +153,18 @@ class Section extends AbstractContainer
      *
      * @return FootnoteProperties
      */
+    public function getFootnoteProperties()
+    {
+        return $this->footnoteProperties;
+    }
+
+    /**
+     * Get the footnote properties
+     *
+     * @deprecated Use the `getFootnoteProperties` method instead
+     *
+     * @return FootnoteProperties
+     */
     public function getFootnotePropoperties()
     {
         return $this->footnoteProperties;
@@ -159,6 +178,26 @@ class Section extends AbstractContainer
     public function setFootnoteProperties(FootnoteProperties $footnoteProperties = null)
     {
         $this->footnoteProperties = $footnoteProperties;
+    }
+
+    /**
+     * Get the endnote properties
+     *
+     * @return FootnoteProperties
+     */
+    public function getEndnoteProperties()
+    {
+        return $this->endnoteProperties;
+    }
+
+    /**
+     * Set the endnote properties
+     *
+     * @param FootnoteProperties $endnoteProperties
+     */
+    public function setEndnoteProperties(FootnoteProperties $endnoteProperties = null)
+    {
+        $this->endnoteProperties = $endnoteProperties;
     }
 
     /**

--- a/src/PhpWord/PhpWord.php
+++ b/src/PhpWord/PhpWord.php
@@ -17,6 +17,7 @@
 
 namespace PhpOffice\PhpWord;
 
+use PhpOffice\PhpWord\ComplexType\FootnoteProperties;
 use PhpOffice\PhpWord\Element\Section;
 use PhpOffice\PhpWord\Exception\Exception;
 
@@ -315,6 +316,46 @@ class PhpWord
     public function setDefaultParagraphStyle($styles)
     {
         return Style::setDefaultParagraphStyle($styles);
+    }
+
+    /**
+     * Set default Footnote properties to settings.xml
+     *
+     * @param FootnoteProperties $properties
+     */
+    public function setDefaultFootnoteProperties(FootnoteProperties $properties)
+    {
+        Settings::setDefaultFootnoteProperties($properties);
+    }
+
+    /**
+     * Get default Footnote properties
+     *
+     * @return FootnoteProperties
+     */
+    public function getDefaultFootnoteProperties()
+    {
+        return Settings::getDefaultFootnoteProperties();
+    }
+
+    /**
+     * Set default Endnote properties to settings.xml
+     *
+     * @param FootnoteProperties $properties
+     */
+    public function setDefaultEndnoteProperties(FootnoteProperties $properties)
+    {
+        Settings::setDefaultEndnoteProperties($properties);
+    }
+
+    /**
+     * Get default Endnote properties
+     *
+     * @return FootnoteProperties
+     */
+    public function getDefaultEndnoteProperties()
+    {
+        return Settings::getDefaultEndnoteProperties();
     }
 
     /**

--- a/src/PhpWord/Settings.php
+++ b/src/PhpWord/Settings.php
@@ -17,6 +17,8 @@
 
 namespace PhpOffice\PhpWord;
 
+use PhpOffice\PhpWord\ComplexType\FootnoteProperties;
+
 /**
  * PHPWord settings class
  *
@@ -133,6 +135,20 @@ class Settings
      * @var bool
      */
     private static $outputEscapingEnabled = false;
+
+    /**
+     * Default properties for the Footnotes
+     *
+     * @var FootnoteProperties
+     */
+    private static $defaultFootnoteProperties = null;
+
+    /**
+     * Default properties for the Endnotes
+     *
+     * @var FootnoteProperties
+     */
+    private static $defaultEndnoteProperties = null;
 
     /**
      * Return the compatibility option used by the XMLWriter
@@ -442,5 +458,45 @@ class Settings
     public static function getCompatibility()
     {
         return self::hasCompatibility();
+    }
+
+    /**
+     * Set default Footnote properties.
+     *
+     * @param FootnoteProperties $properties
+     */
+    public static function setDefaultFootnoteProperties(FootnoteProperties $properties)
+    {
+        self::$defaultFootnoteProperties = $properties;
+    }
+
+    /**
+     * Get default Footnote properties
+     *
+     * @return FootnoteProperties
+     */
+    public static function getDefaultFootnoteProperties()
+    {
+        return self::$defaultFootnoteProperties;
+    }
+
+    /**
+     * Set default Endnote properties.
+     *
+     * @param FootnoteProperties $properties
+     */
+    public static function setDefaultEndnoteProperties(FootnoteProperties $properties)
+    {
+        self::$defaultEndnoteProperties = $properties;
+    }
+
+    /**
+     * Get default Endnote properties
+     *
+     * @return FootnoteProperties
+     */
+    public static function getDefaultEndnoteProperties()
+    {
+        return self::$defaultEndnoteProperties;
     }
 }

--- a/tests/PhpWord/Element/SectionTest.php
+++ b/tests/PhpWord/Element/SectionTest.php
@@ -81,6 +81,7 @@ class SectionTest extends \PHPUnit\Framework\TestCase
         $section->addTitle(utf8_decode('ä'), 1);
         $section->addTextRun();
         $section->addFootnote();
+        $section->addEndnote();
         $section->addCheckBox(utf8_decode('chkä'), utf8_decode('Contentä'));
         $section->addTOC();
 
@@ -97,6 +98,7 @@ class SectionTest extends \PHPUnit\Framework\TestCase
             'Title',
             'TextRun',
             'Footnote',
+            'Endnote',
             'CheckBox',
             'TOC',
         );
@@ -214,5 +216,35 @@ class SectionTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(1, $section->countElements());
         $this->assertEquals($secondText->getElementId(), $section->getElement(1)->getElementId());
+    }
+
+    public function testGetSetFootnoteProperties()
+    {
+        $object = new Section(1);
+
+        $properties = new \PhpOffice\PhpWord\ComplexType\FootnoteProperties();
+        $properties->setPos(\PhpOffice\PhpWord\ComplexType\FootnoteProperties::POSITION_BENEATH_TEXT);
+        $properties->setNumFmt(\PhpOffice\PhpWord\SimpleType\NumberFormat::LOWER_ROMAN);
+        $properties->setNumStart(2);
+        $properties->setNumRestart(\PhpOffice\PhpWord\ComplexType\FootnoteProperties::RESTART_NUMBER_EACH_PAGE);
+
+        $object->setFootnoteProperties($properties);
+
+        $this->assertInstanceOf('PhpOffice\\PhpWord\\ComplexType\\FootnoteProperties', $object->getFootnoteProperties());
+    }
+
+    public function testGetSetEndnoteProperties()
+    {
+        $object = new Section(1);
+
+        $properties = new \PhpOffice\PhpWord\ComplexType\FootnoteProperties();
+        $properties->setPos(\PhpOffice\PhpWord\ComplexType\FootnoteProperties::POSITION_SECTION_END);
+        $properties->setNumFmt(\PhpOffice\PhpWord\SimpleType\NumberFormat::LOWER_ROMAN);
+        $properties->setNumStart(2);
+        $properties->setNumRestart(\PhpOffice\PhpWord\ComplexType\FootnoteProperties::RESTART_NUMBER_EACH_SECTION);
+
+        $object->setEndnoteProperties($properties);
+
+        $this->assertInstanceOf('PhpOffice\\PhpWord\\ComplexType\\FootnoteProperties', $object->getEndnoteProperties());
     }
 }

--- a/tests/PhpWord/Writer/Word2007/Part/DocumentTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/DocumentTest.php
@@ -119,6 +119,36 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Write section endnote properties
+     */
+    public function testSectionEndnoteProperties()
+    {
+        $properties = new FootnoteProperties();
+        $properties->setPos(FootnoteProperties::POSITION_DOC_END);
+        $properties->setNumFmt(NumberFormat::LOWER_ROMAN);
+        $properties->setNumStart(1);
+        $properties->setNumRestart(FootnoteProperties::RESTART_NUMBER_EACH_PAGE);
+
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $section->setEndnoteProperties($properties);
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $element = $doc->getElement('/w:document/w:body/w:sectPr/w:endnotePr/w:pos');
+        $this->assertEquals(FootnoteProperties::POSITION_DOC_END, $element->getAttribute('w:val'));
+
+        $element = $doc->getElement('/w:document/w:body/w:sectPr/w:endnotePr/w:numFmt');
+        $this->assertEquals(NumberFormat::LOWER_ROMAN, $element->getAttribute('w:val'));
+
+        $element = $doc->getElement('/w:document/w:body/w:sectPr/w:endnotePr/w:numStart');
+        $this->assertEquals(1, $element->getAttribute('w:val'));
+
+        $element = $doc->getElement('/w:document/w:body/w:sectPr/w:endnotePr/w:numRestart');
+        $this->assertEquals(FootnoteProperties::RESTART_NUMBER_EACH_PAGE, $element->getAttribute('w:val'));
+    }
+
+    /**
      * Write elements
      */
     public function testElements()

--- a/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
@@ -18,9 +18,11 @@
 namespace PhpOffice\PhpWord\Writer\Word2007\Part;
 
 use PhpOffice\Common\Microsoft\PasswordEncoder;
+use PhpOffice\PhpWord\ComplexType\FootnoteProperties;
 use PhpOffice\PhpWord\ComplexType\ProofState;
 use PhpOffice\PhpWord\ComplexType\TrackChangesView;
 use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\SimpleType\NumberFormat;
 use PhpOffice\PhpWord\SimpleType\Zoom;
 use PhpOffice\PhpWord\Style\Language;
 use PhpOffice\PhpWord\TestHelperDOCX;
@@ -440,5 +442,85 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
 
         $element = $doc->getElement($path, $file);
         $this->assertSame('true', $element->getAttribute('w:val'));
+    }
+
+    public function testDefaultFootnoteProperties()
+    {
+        $properties = new FootnoteProperties();
+        $properties->setPos(FootnoteProperties::POSITION_BENEATH_TEXT);
+        $properties->setNumFmt(NumberFormat::LOWER_ROMAN);
+        $properties->setNumStart(1);
+        $properties->setNumRestart(FootnoteProperties::RESTART_NUMBER_EACH_PAGE);
+
+        $phpWord = new PhpWord();
+        $phpWord->setDefaultFootnoteProperties($properties);
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $file = 'word/settings.xml';
+
+        $path = '/w:settings/w:footnotePr';
+
+        $this->assertFalse($doc->elementExists($path, $file));
+
+        $section = $phpWord->addSection();
+        $footnote = $section->addFootnote();
+        $footnote->addText('There has to be at least one footnote for the default properties to be written to the settings.xml file.');
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $this->assertTrue($doc->elementExists($path, $file));
+
+        $element = $doc->getElement('/w:settings/w:footnotePr/w:pos', $file);
+        $this->assertEquals(FootnoteProperties::POSITION_BENEATH_TEXT, $element->getAttribute('w:val'));
+
+        $element = $doc->getElement('/w:settings/w:footnotePr/w:numFmt', $file);
+        $this->assertEquals(NumberFormat::LOWER_ROMAN, $element->getAttribute('w:val'));
+
+        $element = $doc->getElement('/w:settings/w:footnotePr/w:numStart', $file);
+        $this->assertEquals(1, $element->getAttribute('w:val'));
+
+        $element = $doc->getElement('/w:settings/w:footnotePr/w:numRestart', $file);
+        $this->assertEquals(FootnoteProperties::RESTART_NUMBER_EACH_PAGE, $element->getAttribute('w:val'));
+    }
+
+    public function testDefaultEndnoteProperties()
+    {
+        $properties = new FootnoteProperties();
+        $properties->setPos(FootnoteProperties::POSITION_SECTION_END);
+        $properties->setNumFmt(NumberFormat::CHICAGO);
+        $properties->setNumStart(2);
+        $properties->setNumRestart(FootnoteProperties::RESTART_NUMBER_EACH_SECTION);
+
+        $phpWord = new PhpWord();
+        $phpWord->setDefaultEndnoteProperties($properties);
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $file = 'word/settings.xml';
+
+        $path = '/w:settings/w:endnotePr';
+
+        $this->assertFalse($doc->elementExists($path, $file));
+
+        $section = $phpWord->addSection();
+        $footnote = $section->addEndnote();
+        $footnote->addText('There has to be at least one endnote for the default properties to be written to the settings.xml file.');
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $this->assertTrue($doc->elementExists($path, $file));
+
+        $element = $doc->getElement('/w:settings/w:endnotePr/w:pos', $file);
+        $this->assertEquals(FootnoteProperties::POSITION_SECTION_END, $element->getAttribute('w:val'));
+
+        $element = $doc->getElement('/w:settings/w:endnotePr/w:numFmt', $file);
+        $this->assertEquals(NumberFormat::CHICAGO, $element->getAttribute('w:val'));
+
+        $element = $doc->getElement('/w:settings/w:endnotePr/w:numStart', $file);
+        $this->assertEquals(2, $element->getAttribute('w:val'));
+
+        $element = $doc->getElement('/w:settings/w:endnotePr/w:numRestart', $file);
+        $this->assertEquals(FootnoteProperties::RESTART_NUMBER_EACH_SECTION, $element->getAttribute('w:val'));
     }
 }

--- a/tests/PhpWord/Writer/Word2007Test.php
+++ b/tests/PhpWord/Writer/Word2007Test.php
@@ -56,7 +56,7 @@ class Word2007Test extends AbstractWebServerEmbeddedTest
             'Header'       => 'Header',
             'Footer'       => 'Footer',
             'Footnotes'    => 'Footnotes',
-            'Endnotes'     => 'Footnotes',
+            'Endnotes'     => 'Endnotes',
         );
         foreach ($writerParts as $part => $type) {
             $this->assertInstanceOf(


### PR DESCRIPTION
Also improves support of these properties for Endnotes.

### Description

It is now possible to set FootnoteProperties for Endnotes at the section level. Previously it only worked for footnotes.

However, since positioning endnotes (for example at the end of the section instead of the end of the document) only works at the document level, I added a way to set default properties for footnotes and endnotes.

Some further work was needed to have both document-level and section-level properties working correctly, as in redeclaring the document-level properties at the section level if need be (this is what Word itself is doing BTW), and omitting to output default properties if the document doesn't have any footnote or endnote.

Fixes #1703 

### Checklist:

- [X] I have run `composer run-script check --timeout=0` and no errors were reported
- [X] The new code is covered by unit tests (check build/coverage for coverage report)
- [X] I have updated the documentation to describe the changes
