### PR TITLE
Fix apt-get crash in Travis CI for PHP 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - php: 7.0
           env: COVERAGE=1
         - php: 5.3
-          env: COMPOSER_MEMORY_LIMIT=2G
+          env: COMPOSER_MEMORY_LIMIT=3G
         - php: 7.3
           env: DEPENDENCIES="--ignore-platform-reqs"
     exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ env:
 
 before_install:
     ## Packages
+    - sudo rm -f /etc/apt/sources.list.d/mongodb.list  # Makes apt crash on Precise, and we don't need MongoDB
     - sudo apt-get update -qq
     - sudo apt-get install -y graphviz
 


### PR DESCRIPTION
### Description

Fixes the crash when calling `apt-get update` in PHP 5.3 environment in Travis CI. Since the culprit is a 3rd party repo for MongoDB and that we don't need MongoDB, I just remove the repo definition so `apt-get` doesn't try to connect to it.

Fixes #1706

### Checklist:

- [X] I have run `composer run-script check --timeout=0` and no errors were reported
- [X] The new code is covered by unit tests (check build/coverage for coverage report)
- [X] I have updated the documentation to describe the changes
