### PR TITLE
Added return type

### DIFF
--- a/src/PhpWord/Element/AbstractElement.php
+++ b/src/PhpWord/Element/AbstractElement.php
@@ -96,7 +96,7 @@ abstract class AbstractElement
     /**
      * A reference to the parent
      *
-     * @var \PhpOffice\PhpWord\Element\AbstractElement
+     * @var AbstractElement|null
      */
     private $parent;
 
@@ -335,6 +335,11 @@ abstract class AbstractElement
         $this->commentRangeEnd->setEndElement($this);
     }
 
+    /**
+     * Get parent element
+     *
+     * @return AbstractElement|null
+     */
     public function getParent()
     {
         return $this->parent;


### PR DESCRIPTION
### Description

There was return type currently missing. Also property type was wrong as `$parent` can be null (i.e. for `Section`)

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
