### PR TITLE
Allow a closure to be passed with image replacement tags

### DIFF
--- a/docs/templates-processing.rst
+++ b/docs/templates-processing.rst
@@ -63,6 +63,11 @@ Example:
 
     $templateProcessor->setImageValue('CompanyLogo', 'path/to/company/logo.png');
     $templateProcessor->setImageValue('UserLogo', array('path' => 'path/to/logo.png', 'width' => 100, 'height' => 100, 'ratio' => false));
+    $templateProcessor->setImageValue('FeatureImage', function () {
+        // Closure will only be executed if the replacement tag is found in the template
+
+        return array('path' => SlowFeatureImageGenerator::make(), 'width' => 100, 'height' => 100, 'ratio' => false);
+    });
 
 cloneBlock
 """"""""""

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -447,6 +447,13 @@ class TemplateProcessor
         $width = null;
         $height = null;
         $ratio = null;
+
+        // a closure can be passed as replacement value which after resolving, can contain the replacement info for the image
+        // use case: only when a image if found, the replacement tags can be generated
+        if (is_callable($replaceImage)) {
+            $replaceImage = $replaceImage();
+        }
+
         if (is_array($replaceImage) && isset($replaceImage['path'])) {
             $imgPath = $replaceImage['path'];
             if (isset($replaceImage['width'])) {

--- a/tests/PhpWord/TemplateProcessorTest.php
+++ b/tests/PhpWord/TemplateProcessorTest.php
@@ -392,9 +392,11 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
         $imagePath = __DIR__ . '/_files/images/earth.jpg';
 
         $variablesReplace = array(
-                                'headerValue'       => $imagePath,
-                                'documentContent'   => array('path' => $imagePath, 'width' => 500, 'height' => 500),
-                                'footerValue'       => array('path' => $imagePath, 'width' => 100, 'height' => 50, 'ratio' => false),
+                                'headerValue' => function () use ($imagePath) {
+                                    return $imagePath;
+                                },
+                                'documentContent' => array('path' => $imagePath, 'width' => 500, 'height' => 500),
+                                'footerValue' => array('path' => $imagePath, 'width' => 100, 'height' => 50, 'ratio' => false),
         );
         $templateProcessor->setImageValue(array_keys($variablesReplace), $variablesReplace);
 


### PR DESCRIPTION
### Description

This PR adds support to supply a closure to the `setImageValue` call on the `TemplateProcessor` class. 

Usage case: we generate serveral documents based from templates and supply a set of replacement tags. One of these tags contains a image that's generated on the fly which results in a performance impact. We must generate this image on every document as we aren't sure if the template contains the replacement tag in question. 

This ensures the generation only happens when the tag is found and the `TemplateProcesser` want's to inject the image.

Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
_Ran the test suite but was unable to run the php-cs script due to what i think are filemode issues on Bash on Windows (the CS script wanted to change all files)._
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
