### PR TITLE
Add support for basic fields in RTF writer.

### DIFF
--- a/src/PhpWord/Writer/RTF/Element/Field.php
+++ b/src/PhpWord/Writer/RTF/Element/Field.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ * @copyright   2019 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\RTF\Element;
+
+/**
+ * Field element writer
+ *
+ * Note: for now, only date, page and numpages fields are implemented for RTF.
+ */
+class Field extends Text
+{
+    /**
+     * Write field element.
+     */
+    public function write()
+    {
+        $element = $this->element;
+        if (!$element instanceof \PhpOffice\PhpWord\Element\Field) {
+            return;
+        }
+
+        $this->getStyles();
+
+        $content = '';
+        $content .= $this->writeOpening();
+        $content .= '{';
+        $content .= $this->writeFontStyle();
+
+        $methodName = 'write' . ucfirst(strtolower($element->getType()));
+        if (!method_exists($this, $methodName)) {
+            // Unsupported field
+            $content .= '';
+        } else {
+            $content .= '\\field{\\*\\fldinst ';
+            $content .= $this->$methodName($element);
+            $content .= '}{\\fldrslt}';
+        }
+        $content .= '}';
+        $content .= $this->writeClosing();
+
+        return $content;
+    }
+
+    protected function writePage()
+    {
+        return 'PAGE';
+    }
+
+    protected function writeNumpages()
+    {
+        return 'NUMPAGES';
+    }
+
+    protected function writeDate(\PhpOffice\PhpWord\Element\Field $element)
+    {
+        $content = '';
+        $content .= 'DATE';
+        $properties = $element->getProperties();
+        if (isset($properties['dateformat'])) {
+            $content .= ' \\\\@ "' . $properties['dateformat'] . '"';
+        }
+
+        return $content;
+    }
+}

--- a/tests/PhpWord/Writer/RTF/ElementTest.php
+++ b/tests/PhpWord/Writer/RTF/ElementTest.php
@@ -29,7 +29,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
      */
     public function testUnmatchedElements()
     {
-        $elements = array('Container', 'Text', 'Title', 'Link', 'Image', 'Table');
+        $elements = array('Container', 'Text', 'Title', 'Link', 'Image', 'Table', 'Field');
         foreach ($elements as $element) {
             $objectClass = 'PhpOffice\\PhpWord\\Writer\\RTF\\Element\\' . $element;
             $parentWriter = new RTF();
@@ -38,5 +38,41 @@ class ElementTest extends \PHPUnit\Framework\TestCase
 
             $this->assertEquals('', $object->write());
         }
+    }
+
+    public function testPageField()
+    {
+        $parentWriter = new RTF();
+        $element = new \PhpOffice\PhpWord\Element\Field('PAGE');
+        $field = new \PhpOffice\PhpWord\Writer\RTF\Element\Field($parentWriter, $element);
+
+        $this->assertEquals("{\\field{\\*\\fldinst PAGE}{\\fldrslt}}\\par\n", $field->write());
+    }
+
+    public function testNumpageField()
+    {
+        $parentWriter = new RTF();
+        $element = new \PhpOffice\PhpWord\Element\Field('NUMPAGES');
+        $field = new \PhpOffice\PhpWord\Writer\RTF\Element\Field($parentWriter, $element);
+
+        $this->assertEquals("{\\field{\\*\\fldinst NUMPAGES}{\\fldrslt}}\\par\n", $field->write());
+    }
+
+    public function testDateField()
+    {
+        $parentWriter = new RTF();
+        $element = new \PhpOffice\PhpWord\Element\Field('DATE', array('dateformat' => 'd MM yyyy H:mm:ss'));
+        $field = new \PhpOffice\PhpWord\Writer\RTF\Element\Field($parentWriter, $element);
+
+        $this->assertEquals("{\\field{\\*\\fldinst DATE \\\\@ \"d MM yyyy H:mm:ss\"}{\\fldrslt}}\\par\n", $field->write());
+    }
+
+    public function testIndexField()
+    {
+        $parentWriter = new RTF();
+        $element = new \PhpOffice\PhpWord\Element\Field('INDEX');
+        $field = new \PhpOffice\PhpWord\Writer\RTF\Element\Field($parentWriter, $element);
+
+        $this->assertEquals("{}\\par\n", $field->write());
     }
 }


### PR DESCRIPTION
### Description

Add support for PAGE, NUMPAGES and DATE fields in RTF documents.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- (pointless) I have updated the documentation to describe the changes
