### PR TITLE
Update documentation from templates processing

### DIFF
--- a/docs/templates-processing.rst
+++ b/docs/templates-processing.rst
@@ -244,3 +244,20 @@ See ``Sample_40_TemplateSetComplexValue.php`` for examples.
     $table->addCell(150)->addText('Cell B2');
     $table->addCell(150)->addText('Cell B3');
     $templateProcessor->setComplexBlock('table', $table);
+    
+save
+"""""""""
+Saves the loaded template within the current directory. Returns the file path.
+
+.. code-block:: php
+
+    $filepath = $templateProcessor->save();
+    
+saveAs
+"""""""""
+Saves a copy of the loaded template in the indicated path. Returns the file path.
+
+.. code-block:: php
+    
+    $pathToSave = 'path/to/save/file.ext';
+    $filepath = $templateProcessor->saveAs($pathToSave);


### PR DESCRIPTION
Add save() and saveAs() methods documentations

### Description

The docs from save() and saveAs() are nonexistent. Adding them to the docs.

Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
