### PR TITLE
Improvements in RTF writer

### DIFF
--- a/src/PhpWord/Escaper/Rtf.php
+++ b/src/PhpWord/Escaper/Rtf.php
@@ -26,8 +26,14 @@ class Rtf extends AbstractEscaper
 {
     protected function escapeAsciiCharacter($code)
     {
-        if (20 > $code || $code >= 80) {
-            return '{\u' . $code . '}';
+        if ($code == 9) {
+            return '{\\tab}';
+        }
+        if (0x20 > $code || $code >= 0x80) {
+            return '{\\u' . $code . '}';
+        }
+        if ($code == 123 || $code == 125 || $code == 92) { // open or close brace or backslash
+            return '\\' . chr($code);
         }
 
         return chr($code);
@@ -35,7 +41,7 @@ class Rtf extends AbstractEscaper
 
     protected function escapeMultibyteCharacter($code)
     {
-        return '\uc0{\u' . $code . '}';
+        return '\\uc0{\\u' . $code . '}';
     }
 
     /**

--- a/tests/PhpWord/Escaper/RtfEscaper2Test.php
+++ b/tests/PhpWord/Escaper/RtfEscaper2Test.php
@@ -15,8 +15,10 @@
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
+namespace PhpOffice\PhpWord\Escaper;
+
 /**
- * Test class for PhpOffice\PhpWord\Writer\RTF\Style subnamespace
+ * Test class for PhpOffice\PhpWord\Escaper\RTF
  */
 class RtfEscaperTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PhpWord/Escaper/RtfEscaper2Test.php
+++ b/tests/PhpWord/Escaper/RtfEscaper2Test.php
@@ -20,7 +20,7 @@ namespace PhpOffice\PhpWord\Escaper;
 /**
  * Test class for PhpOffice\PhpWord\Escaper\RTF
  */
-class RtfEscaperTest extends \PHPUnit\Framework\TestCase
+class RtfEscaper2Test extends \PHPUnit\Framework\TestCase
 {
     const HEADER = '\\pard\\nowidctlpar {\\cf0\\f0 ';
     const TRAILER = '}\\par';

--- a/tests/PhpWord/Escaper/RtfEscaper2Test.php
+++ b/tests/PhpWord/Escaper/RtfEscaper2Test.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ * @copyright   2010-2018 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+/**
+ * Test class for PhpOffice\PhpWord\Writer\RTF\Style subnamespace
+ */
+class RtfEscaperTest extends \PHPUnit\Framework\TestCase
+{
+    const HEADER = '\\pard\\nowidctlpar {\\cf0\\f0 ';
+    const TRAILER = '}\\par';
+
+    public function escapestring($str)
+    {
+        \PhpOffice\PhpWord\Settings::setOutputEscapingEnabled(true);
+        $parentWriter = new \PhpOffice\PhpWord\Writer\RTF();
+        $element = new \PhpOffice\PhpWord\Element\Text($str);
+        $txt = new \PhpOffice\PhpWord\Writer\RTF\Element\Text($parentWriter, $element);
+        $txt2 = trim($txt->write());
+
+        return $txt2;
+    }
+
+    public function expect($str)
+    {
+        return self::HEADER . $str . self::TRAILER;
+    }
+
+    /**
+     * Test special characters which require escaping
+     */
+    public function testSpecial()
+    {
+        $str = 'Special characters { open brace } close brace \\ backslash';
+        $expect = $this->expect('Special characters \\{ open brace \\} close brace \\\\ backslash');
+        $this->assertEquals($expect, $this->escapestring($str));
+    }
+
+    /**
+     * Test accented character
+     */
+    public function testAccent()
+    {
+        $str = 'Voilà - string with accented char';
+        $expect = $this->expect('Voil\\uc0{\\u224} - string with accented char');
+        $this->assertEquals($expect, $this->escapestring($str));
+    }
+
+    /**
+     * Test Hebrew
+     */
+    public function testHebrew()
+    {
+        $str = 'Hebrew - שלום';
+        $expect = $this->expect('Hebrew - \\uc0{\\u1513}\\uc0{\\u1500}\\uc0{\\u1493}\\uc0{\\u1501}');
+        $this->assertEquals($expect, $this->escapestring($str));
+    }
+
+    /**
+     * Test tab
+     */
+    public function testTab()
+    {
+        $str = "Here's a tab\tfollowed by more characters.";
+        $expect = $this->expect("Here's a tab{\\tab}followed by more characters.");
+        $this->assertEquals($expect, $this->escapestring($str));
+    }
+}

--- a/tests/PhpWord/Writer/RTF/ElementTest.php
+++ b/tests/PhpWord/Writer/RTF/ElementTest.php
@@ -24,6 +24,9 @@ use PhpOffice\PhpWord\Writer\RTF;
  */
 class ElementTest extends \PHPUnit\Framework\TestCase
 {
+    public function removeCr($field) {
+        return str_replace("\r\n", "\n", $field->write());
+    }
     /**
      * Test unmatched elements
      */
@@ -46,7 +49,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $element = new \PhpOffice\PhpWord\Element\Field('PAGE');
         $field = new \PhpOffice\PhpWord\Writer\RTF\Element\Field($parentWriter, $element);
 
-        $this->assertEquals("{\\field{\\*\\fldinst PAGE}{\\fldrslt}}\\par\n", $field->write());
+        $this->assertEquals("{\\field{\\*\\fldinst PAGE}{\\fldrslt}}\\par\n", $this->removeCr($field));
     }
 
     public function testNumpageField()
@@ -55,7 +58,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $element = new \PhpOffice\PhpWord\Element\Field('NUMPAGES');
         $field = new \PhpOffice\PhpWord\Writer\RTF\Element\Field($parentWriter, $element);
 
-        $this->assertEquals("{\\field{\\*\\fldinst NUMPAGES}{\\fldrslt}}\\par\n", $field->write());
+        $this->assertEquals("{\\field{\\*\\fldinst NUMPAGES}{\\fldrslt}}\\par\n", $this->removeCr($field));
     }
 
     public function testDateField()
@@ -64,7 +67,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $element = new \PhpOffice\PhpWord\Element\Field('DATE', array('dateformat' => 'd MM yyyy H:mm:ss'));
         $field = new \PhpOffice\PhpWord\Writer\RTF\Element\Field($parentWriter, $element);
 
-        $this->assertEquals("{\\field{\\*\\fldinst DATE \\\\@ \"d MM yyyy H:mm:ss\"}{\\fldrslt}}\\par\n", $field->write());
+        $this->assertEquals("{\\field{\\*\\fldinst DATE \\\\@ \"d MM yyyy H:mm:ss\"}{\\fldrslt}}\\par\n", $this->removeCr($field));
     }
 
     public function testIndexField()
@@ -73,6 +76,6 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $element = new \PhpOffice\PhpWord\Element\Field('INDEX');
         $field = new \PhpOffice\PhpWord\Writer\RTF\Element\Field($parentWriter, $element);
 
-        $this->assertEquals("{}\\par\n", $field->write());
+        $this->assertEquals("{}\\par\n", $this->removeCr($field));
     }
 }

--- a/tests/PhpWord/Writer/RTF/ElementTest.php
+++ b/tests/PhpWord/Writer/RTF/ElementTest.php
@@ -28,6 +28,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
     {
         return str_replace("\r\n", "\n", $field->write());
     }
+
     /**
      * Test unmatched elements
      */

--- a/tests/PhpWord/Writer/RTF/ElementTest.php
+++ b/tests/PhpWord/Writer/RTF/ElementTest.php
@@ -24,7 +24,8 @@ use PhpOffice\PhpWord\Writer\RTF;
  */
 class ElementTest extends \PHPUnit\Framework\TestCase
 {
-    public function removeCr($field) {
+    public function removeCr($field)
+    {
         return str_replace("\r\n", "\n", $field->write());
     }
     /**


### PR DESCRIPTION
1. Codes meant to be in hex are specified in decimal.
   Consequently characters which don't need escaping are escaped.
2. Special handling (prepend backslash) needed for {, }, and \.
   RTF docs generated with those characters cannot be opened in Word.
3. Tab character needs to be escaped as \tab.
   RTF docs drop these characters.
While running test suite, found that Writer/RTF/ElementTest was coded
only for Unix line endings, and fails on Windows. Changed so that it
would work on either.

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
