### PR TITLE
TemplateProcessor cloneBlock wrongly clones images

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -1085,7 +1085,7 @@ class TemplateProcessor
     {
         $results = array();
         for ($i = 1; $i <= $count; $i++) {
-            $results[] = preg_replace('/\$\{(.*?)(:.*)?\}/', '\${\1#' . $i . '\2}', $xmlBlock);
+            $results[] = preg_replace('/\$\{([^:]*?)(:.*?)?\}/', '\${\1#' . $i . '\2}', $xmlBlock);
         }
 
         return $results;

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -1085,7 +1085,7 @@ class TemplateProcessor
     {
         $results = array();
         for ($i = 1; $i <= $count; $i++) {
-            $results[] = preg_replace('/\$\{(.*?)\}/', '\${\\1#' . $i . '}', $xmlBlock);
+            $results[] = preg_replace('/\$\{(.*?)(:.*)?\}/', '\${\1#' . $i . '\2}', $xmlBlock);
         }
 
         return $results;

--- a/tests/PhpWord/_includes/AbstractWebServerEmbeddedTest.php
+++ b/tests/PhpWord/_includes/AbstractWebServerEmbeddedTest.php
@@ -26,7 +26,7 @@ abstract class AbstractWebServerEmbeddedTest extends \PHPUnit\Framework\TestCase
     public static function setUpBeforeClass()
     {
         if (self::isBuiltinServerSupported()) {
-            self::$httpServer = new Process('php -S localhost:8080 -t tests/PhpWord/_files');
+            self::$httpServer = new Process(array('php', '-S', 'localhost:8080', '-t', 'tests/PhpWord/_files'));
             self::$httpServer->start();
             while (!self::$httpServer->isRunning()) {
                 usleep(1000);


### PR DESCRIPTION
### Description

I was met with the issue reported in #1750 and fixed it. 
The problem was that the regexp to clone and add number did include the size attributes in the tag before the number. So I added a second capture group so that image attributes are properly placed after the tag with it's added number.

I also fixed the call to Process to use an array as it otherwise cause hundred of errors as it now expects an array instead of a string.

All tests are passed and code coverage is unchanged.

Fixes #1750 #1624

### Checklist:

- [X] I have run `composer run-script check --timeout=0` and no errors were reported
- [X] The new code is covered by unit tests (check build/coverage for coverage report)
- [X] I have updated the documentation to describe the changes
