### PR TITLE
fix: documentation about paragraph indentation

### DIFF
--- a/docs/styles.rst
+++ b/docs/styles.rst
@@ -75,8 +75,10 @@ Available Paragraph style options:
 - ``alignment``. Supports all alignment modes since 1st Edition of ECMA-376 standard up till ISO/IEC 29500:2012.
    See ``\PhpOffice\PhpWord\SimpleType\Jc`` class constants for possible values.
 - ``basedOn``. Parent style.
-- ``hanging``. Hanging in *twip*.
-- ``indent``. Indent in *twip*.
+- ``hanging``. Hanging indentation in *half inches*.
+- ``indent``. Indent (left indentation) in *half inches*.
+- ``indentation``. An array of indentation key => value pairs in *twip*. Supports *left*, *right*, *firstLine* and *hanging* indentation.
+   See ``\PhpOffice\PhpWord\Style\Indentation`` for possible identation types.
 - ``keepLines``. Keep all lines on one page, *true* or *false*.
 - ``keepNext``. Keep paragraph with next paragraph, *true* or *false*.
 - ``lineHeight``. Text line height, e.g. *1.0*, *1.5*, etc.

--- a/src/PhpWord/Style/Paragraph.php
+++ b/src/PhpWord/Style/Paragraph.php
@@ -198,7 +198,7 @@ class Paragraph extends Border
     {
         $key = Text::removeUnderscorePrefix($key);
         if ('indent' == $key || 'hanging' == $key) {
-            $value = $value * 720;
+            $value = $value * 720;  // 720 twips is 0.5 inch
         }
 
         return parent::setStyleValue($key, $value);


### PR DESCRIPTION
### Description

As stated in #358, the documentation about `indent` and `hanging` styling for the Paragraph element is wrong:

- It states that the values for ``indent`` and ``hanging`` are in twips while they are in half-inches
- It does not mention the ``indentation`` property which allows setting values in twips and the ``firstLine`` and ``right`` indentations as well.

Fixes #358

### Checklist:

- [X] I have run `composer run-script check --timeout=0` and no errors were reported
- [X] ~~The new code is covered by unit tests (check build/coverage for coverage report)~~ **Documentation change only, no new code**
- [X] I have updated the documentation to describe the changes
