### PR TITLE
Add support for ListItemRun in HTML writer

### DIFF
--- a/src/PhpWord/Writer/HTML/Element/ListItemRun.php
+++ b/src/PhpWord/Writer/HTML/Element/ListItemRun.php
@@ -17,14 +17,12 @@
 
 namespace PhpOffice\PhpWord\Writer\HTML\Element;
 
-use PhpOffice\PhpWord\Settings;
-
 /**
  * ListItem element HTML writer
  *
  * @since 0.10.0
  */
-class ListItemRun extends ListItem
+class ListItemRun extends TextRun
 {
     /**
      * Write list item
@@ -38,12 +36,7 @@ class ListItemRun extends ListItem
         }
 
         $writer = new Container($this->parentWriter, $this->element);
-
-        if (Settings::isOutputEscapingEnabled()) {
-            $content = '<p>' . $this->escaper->escapeHtml($writer->write()) . '</p>' . PHP_EOL;
-        } else {
-            $content = '<p>' . $writer->write() . '</p>' . PHP_EOL;
-        }
+        $content = $writer->write() . PHP_EOL;
 
         return $content;
     }

--- a/src/PhpWord/Writer/HTML/Element/ListItemRun.php
+++ b/src/PhpWord/Writer/HTML/Element/ListItemRun.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ * @copyright   2010-2018 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\HTML\Element;
+
+use PhpOffice\PhpWord\Settings;
+
+/**
+ * ListItem element HTML writer
+ *
+ * @since 0.10.0
+ */
+class ListItemRun extends ListItem
+{
+    /**
+     * Write list item
+     *
+     * @return string
+     */
+    public function write()
+    {
+        if (!$this->element instanceof \PhpOffice\PhpWord\Element\ListItemRun) {
+            return '';
+        }
+
+        $writer = new Container($this->parentWriter, $this->element);
+
+        if (Settings::isOutputEscapingEnabled()) {
+            $content = '<p>' . $this->escaper->escapeHtml($writer->write()) . '</p>' . PHP_EOL;
+        } else {
+            $content = '<p>' . $writer->write() . '</p>' . PHP_EOL;
+        }
+
+        return $content;
+    }
+}

--- a/tests/PhpWord/Writer/HTML/ElementTest.php
+++ b/tests/PhpWord/Writer/HTML/ElementTest.php
@@ -34,7 +34,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
      */
     public function testUnmatchedElements()
     {
-        $elements = array('Container', 'Footnote', 'Image', 'Link', 'ListItem', 'Table', 'Title', 'Bookmark');
+        $elements = array('Container', 'Footnote', 'Image', 'Link', 'ListItem', 'ListItemRun', 'Table', 'Title', 'Bookmark');
         foreach ($elements as $element) {
             $objectClass = 'PhpOffice\\PhpWord\\Writer\\HTML\\Element\\' . $element;
             $parentWriter = new HTML();

--- a/tests/PhpWord/Writer/HTML/ElementTest.php
+++ b/tests/PhpWord/Writer/HTML/ElementTest.php
@@ -164,6 +164,31 @@ class ElementTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test write element ListItemRun
+     */
+    public function testListItemRun()
+    {
+        $expected1 = 'List item run 1';
+        $expected2 = 'List item run 1 in bold';
+
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+
+        $listItemRun = $section->addListItemRun(0, null, 'MyParagraphStyle');
+        $listItemRun->addText($expected1);
+        $listItemRun->addText($expected2, array('bold' => true));
+
+        $htmlWriter = new HTML($phpWord);
+        $content = $htmlWriter->getContent();
+
+        $dom = new \DOMDocument();
+        $dom->loadHTML($content);
+
+        $this->assertEquals($expected1, $dom->getElementsByTagName('p')->item(0)->textContent);
+        $this->assertEquals($expected2, $dom->getElementsByTagName('p')->item(1)->textContent);
+    }
+
+    /**
      * Tests writing table with layout
      */
     public function testWriteTableLayout()


### PR DESCRIPTION
### Description

Add List for docx to html. Implemented ListItemRun for HTML in Writer.

Fixes List item fail #1717 (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
