### PR TITLE
Fix PHPUnit tests on develop branch

### DIFF
--- a/tests/PhpWord/_includes/AbstractWebServerEmbeddedTest.php
+++ b/tests/PhpWord/_includes/AbstractWebServerEmbeddedTest.php
@@ -26,7 +26,26 @@ abstract class AbstractWebServerEmbeddedTest extends \PHPUnit\Framework\TestCase
     public static function setUpBeforeClass()
     {
         if (self::isBuiltinServerSupported()) {
-            self::$httpServer = new Process('php -S localhost:8080 -t tests/PhpWord/_files');
+            $commandLine = 'php -S localhost:8080 -t tests/PhpWord/_files';
+
+            /*
+             * Make sure to invoke \Symfony\Component\Process\Process correctly
+             * regardless of PHP version used.
+             *
+             * In Process version >= 5 / PHP >= 7.2.5, the constructor requires
+             * an array, while in version < 3.3 / PHP < 5.5.9 it requires a string.
+             * In between, it can accept both.
+             *
+             * Process::fromShellCommandLine() was introduced in version 4.2.0,
+             * to enable recent versions of Process to parse a command string,
+             * so if it is not available it means it is still possible to pass
+             * a string to the constructor.
+             */
+            if (method_exists('Symfony\Component\Process\Process', 'fromShellCommandLine')) {
+                self::$httpServer = Process::fromShellCommandline($commandLine);
+            } else {
+                self::$httpServer = new Process($commandLine);
+            }
             self::$httpServer->start();
             while (!self::$httpServer->isRunning()) {
                 usleep(1000);


### PR DESCRIPTION
When tests are run with a recent version of PHP, `\Symfony\Component\Process\Process` called in `AbstractWebServerEmbeddedTest` needs to be passed an array. When tests are run in an old PHP version (like 5.4), it needs to be passed a string.

Tests should pass regardless of the supported PHP version is running them.

### Description

Make sure that we use `\Symfony\Component\Process\Process::fromShellCommandLine()` if available. If it's not available, it means we are running an older version of `Process` where it's safe to pass a string to the constructor.

Fixes #1770

### Checklist:

- [X] I have run `composer run-script check --timeout=0` and no errors were reported
- [X] The new code is covered by unit tests (check build/coverage for coverage report)
- [X] I have updated the documentation to describe the changes
