### PR TITLE
Fix documentation and method name for FootnoteProperties

### DIFF
--- a/docs/elements.rst
+++ b/docs/elements.rst
@@ -359,17 +359,17 @@ The footnote numbering can be controlled by setting the FootnoteProperties on th
 
 .. code-block:: php
 
-    $fp = new PhpWord\SimpleType\FootnoteProperties();
+    $fp = new \PhpOffice\PhpWord\ComplexType\FootnoteProperties();
     //sets the position of the footnote (pageBottom (default), beneathText, sectEnd, docEnd)
-    $fp->setPos(FootnoteProperties::POSITION_DOC_END);
+    $fp->setPos(\PhpOffice\PhpWord\ComplexType\FootnoteProperties::POSITION_BENEATH_TEXT);
     //set the number format to use (decimal (default), upperRoman, upperLetter, ...)
-    $fp->setNumFmt(FootnoteProperties::NUMBER_FORMAT_LOWER_ROMAN);
+    $fp->setNumFmt(\PhpOffice\PhpWord\SimpleType\NumberFormat::LOWER_ROMAN);
     //force starting at other than 1
     $fp->setNumStart(2);
     //when to restart counting (continuous (default), eachSect, eachPage)
-    $fp->setNumRestart(FootnoteProperties::RESTART_NUMBER_EACH_PAGE);
+    $fp->setNumRestart(\PhpOffice\PhpWord\ComplexType\FootnoteProperties::RESTART_NUMBER_EACH_PAGE);
     //And finaly, set it on the Section
-    $section->setFootnoteProperties($properties);
+    $section->setFootnoteProperties($fp);
 
 Checkboxes
 ----------

--- a/src/PhpWord/Element/Section.php
+++ b/src/PhpWord/Element/Section.php
@@ -146,6 +146,18 @@ class Section extends AbstractContainer
      *
      * @return FootnoteProperties
      */
+    public function getFootnoteProperties()
+    {
+        return $this->footnoteProperties;
+    }
+
+    /**
+     * Get the footnote properties
+     *
+     * @deprecated Use the `getFootnoteProperties` method instead
+     *
+     * @return FootnoteProperties
+     */
     public function getFootnotePropoperties()
     {
         return $this->footnoteProperties;

--- a/src/PhpWord/Writer/Word2007/Part/Document.php
+++ b/src/PhpWord/Writer/Word2007/Part/Document.php
@@ -126,27 +126,27 @@ class Document extends AbstractPart
             $xmlWriter->endElement();
         }
 
-        //footnote properties
-        if ($section->getFootnotePropoperties() !== null) {
+        // Footnote properties
+        if ($section->getFootnoteProperties() !== null) {
             $xmlWriter->startElement('w:footnotePr');
-            if ($section->getFootnotePropoperties()->getPos() != null) {
+            if ($section->getFootnoteProperties()->getPos() != null) {
                 $xmlWriter->startElement('w:pos');
-                $xmlWriter->writeAttribute('w:val', $section->getFootnotePropoperties()->getPos());
+                $xmlWriter->writeAttribute('w:val', $section->getFootnoteProperties()->getPos());
                 $xmlWriter->endElement();
             }
-            if ($section->getFootnotePropoperties()->getNumFmt() != null) {
+            if ($section->getFootnoteProperties()->getNumFmt() != null) {
                 $xmlWriter->startElement('w:numFmt');
-                $xmlWriter->writeAttribute('w:val', $section->getFootnotePropoperties()->getNumFmt());
+                $xmlWriter->writeAttribute('w:val', $section->getFootnoteProperties()->getNumFmt());
                 $xmlWriter->endElement();
             }
-            if ($section->getFootnotePropoperties()->getNumStart() != null) {
+            if ($section->getFootnoteProperties()->getNumStart() != null) {
                 $xmlWriter->startElement('w:numStart');
-                $xmlWriter->writeAttribute('w:val', $section->getFootnotePropoperties()->getNumStart());
+                $xmlWriter->writeAttribute('w:val', $section->getFootnoteProperties()->getNumStart());
                 $xmlWriter->endElement();
             }
-            if ($section->getFootnotePropoperties()->getNumRestart() != null) {
+            if ($section->getFootnoteProperties()->getNumRestart() != null) {
                 $xmlWriter->startElement('w:numRestart');
-                $xmlWriter->writeAttribute('w:val', $section->getFootnotePropoperties()->getNumRestart());
+                $xmlWriter->writeAttribute('w:val', $section->getFootnoteProperties()->getNumRestart());
                 $xmlWriter->endElement();
             }
             $xmlWriter->endElement();


### PR DESCRIPTION
### Description

- Fixed documentation about FootnoteProperties which contained an invalid code snippet, so that people can actually use the code:
  - it now uses the correct class names
  - no more typo in variable name usage
  - now uses a Footnote position parameter that works when outputting Word (`POSITION_BENEATH_TEXT`). `POSITION_DOC_END` only works for Endnotes.
- Fixed bogus method name `$section->addFootnotePropoperties()`:
  - added a method with the correct spelling `$section->addFootnoteProperties()`
  - former method still works but is marked as deprecated
  - migrated code to use the correct method name

### Checklist:

- [X] I have run `composer run-script check --timeout=0` and no errors were reported
- [X] The new code is covered by unit tests (check build/coverage for coverage report)
- [X] I have updated the documentation to describe the changes
