### PR TITLE
FormField support (name and value available for textinput)

### DIFF
--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -112,7 +112,7 @@ abstract class AbstractPart
             $headingDepth = $this->getHeadingDepth($paragraphStyle);
         }
 
-        // PreserveText
+        // PreserveText with Field support (name and value available for FORMTEXT)
         if ($xmlReader->elementExists('w:r/w:instrText', $domNode)) {
             $ignoreText = false;
             $textContent = '';
@@ -124,12 +124,19 @@ abstract class AbstractPart
                     $fldCharType = $xmlReader->getAttribute('w:fldCharType', $node, 'w:fldChar');
                     if ('begin' == $fldCharType) {
                         $ignoreText = true;
-                    } elseif ('end' == $fldCharType) {
+                        if ($xmlReader->elementExists('w:fldChar/w:ffData', $node)) {
+                            $ffData=$xmlReader->getElement('w:fldChar/w:ffData',$node);
+                            $fldName = $xmlReader->getAttribute('w:val', $ffData, 'w:name');
+                        }
+                    } elseif ('separate' == $fldCharType) {
                         $ignoreText = false;
                     }
                 }
                 if (!is_null($instrText)) {
-                    $textContent .= '{' . $instrText . '}';
+                    $textContent .= '{' . $instrText .'}';
+                    if($instrText== "FORMTEXT") {        
+                        $textContent .=$fldName.'=';
+                    }
                 } else {
                     if (false === $ignoreText) {
                         $textContent .= $xmlReader->getValue('w:t', $node);


### PR DESCRIPTION
Textbox fields name and value can be retrieved using this code:
 $phpWord = \PhpOffice\PhpWord\IOFactory::load($docfile);
      
        $fields[];
        $sections = $phpWord->getSections();
        foreach ($sections as $key => $value) {
            $sectionElement = $value->getElements();
            $first=true;
            foreach ($sectionElement as $elementKey => $elementValue) {
   
                
                 if($elementValue instanceof \PhpOffice\PhpWord\Element\PreserveText) {
                     
                            $fieldDef=$elementValue->getText();
                            if(count($fieldDef)==2) {
                                array_unshift($fieldDef,"");
                            }
                            /**
                             * array (size=3)
                                0 => string '[1=Falun Dafa is Good]' 
                                1 => string '{FORMTEXT}' 
                                2 => string 'SayToTheWorldField=Falun Dafa est Bon'
                             */
                           list($sos_orig_text,$DATATYPE,$sos_trad_text)=  $fieldDef;
                           if($DATATYPE== '{FORMTEXT}') {
                                $field=explode('=',$sos_trad_text."=".trim($sos_orig_text,'[]'));
                                $fields[]=$field;
                           }else {
                               var_dump($elementValue->getText());
                               var_dump("Unsupported field Type $DATATYPE :");
                               die("stop");
                           }
                 }
echo "<pre>";
echo(htmlentities(implode("\n",$fields)));
echo "</pre>";

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
