### PR TITLE
add default state to checkbox inside textRun

### DIFF
--- a/src/PhpWord/Element/CheckBox.php
+++ b/src/PhpWord/Element/CheckBox.php
@@ -35,6 +35,13 @@ class CheckBox extends Text
     private $name;
 
     /**
+     * Default state.
+     *
+     * @var bool
+     */
+    private $defaultChecked;
+
+    /**
      * Create new instance.
      *
      * @param string $name
@@ -70,5 +77,27 @@ class CheckBox extends Text
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * Set default state.
+     *
+     * @return self
+     */
+    public function setDefaultChecked(bool $default = true)
+    {
+        $this->defaultChecked = $default;
+
+        return $this;
+    }
+
+    /**
+     * Is default state checked?
+     *
+     * @return bool
+     */
+    public function isDefaultChecked(): bool
+    {
+        return $this->defaultChecked;
     }
 }

--- a/src/PhpWord/Element/CheckBox.php
+++ b/src/PhpWord/Element/CheckBox.php
@@ -81,10 +81,8 @@ class CheckBox extends Text
 
     /**
      * Set default state.
-     *
-     * @return self
      */
-    public function setDefaultChecked(bool $default = true)
+    public function setDefaultChecked(bool $default = true): self
     {
         $this->defaultChecked = $default;
 
@@ -93,11 +91,9 @@ class CheckBox extends Text
 
     /**
      * Is default state checked?
-     *
-     * @return bool
      */
     public function isDefaultChecked(): bool
     {
-        return $this->defaultChecked;
+        return (bool) $this->defaultChecked;
     }
 }

--- a/src/PhpWord/Element/CheckBox.php
+++ b/src/PhpWord/Element/CheckBox.php
@@ -39,7 +39,7 @@ class CheckBox extends Text
      *
      * @var bool
      */
-    private $defaultChecked;
+    private $defaultChecked = false;
 
     /**
      * Create new instance.

--- a/src/PhpWord/Writer/Word2007/Element/CheckBox.php
+++ b/src/PhpWord/Writer/Word2007/Element/CheckBox.php
@@ -52,7 +52,7 @@ class CheckBox extends Text
         $xmlWriter->startElement('w:checkBox');
         $xmlWriter->writeAttribute('w:sizeAuto', '');
         $xmlWriter->startElement('w:default');
-        $xmlWriter->writeAttribute('w:val', 0);
+        $xmlWriter->writeAttribute('w:val', $element->isDefaultChecked() ? 1 : 0);
         $xmlWriter->endElement(); //w:default
         $xmlWriter->endElement(); //w:checkBox
         $xmlWriter->endElement(); // w:ffData

--- a/tests/PhpWordTests/Element/CheckBoxTest.php
+++ b/tests/PhpWordTests/Element/CheckBoxTest.php
@@ -85,4 +85,16 @@ class CheckBoxTest extends \PHPUnit\Framework\TestCase
         $oCheckBox->setParagraphStyle(['alignment' => Jc::CENTER, 'spaceAfter' => 100]);
         self::assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $oCheckBox->getParagraphStyle());
     }
+
+    /**
+     * Set and get default value.
+     */
+    public function testDefault(): void
+    {
+        $oCheckBox = new CheckBox('chkBox', 'CheckBox');
+        self::assertFalse($oCheckBox->isDefaultChecked());
+
+        $oCheckBox->setDefaultChecked(true);
+        self::assertTrue($oCheckBox->isDefaultChecked());
+    }
 }

--- a/tests/PhpWordTests/Writer/Word2007/Element/CheckBoxTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/Element/CheckBoxTest.php
@@ -15,12 +15,15 @@ class CheckBoxTest extends TestCase
      * @dataProvider checkBoxCheckedProvider
      */
     public function testCheckBoxGeneratesCorrectXml(
+        bool $checked,
         string $expectedCheckedAttribute
     ): void {
         // Arrange
         $xmlWriter = new XMLWriter();
 
         $checkBoxElement = new CheckBoxElement('test', 'test');
+        $checkBoxElement->setDefaultChecked($checked);
+
         $checkBox = new CheckBox($xmlWriter, $checkBoxElement);
 
         // Act
@@ -38,9 +41,11 @@ class CheckBoxTest extends TestCase
     {
         return [
             'Default checked' => [
+                'checked' => true,
                 'w:default w:val="1"',
             ],
             'Default unchecked' => [
+                'checked' => false,
                 'w:default w:val="0"',
             ],
         ];

--- a/tests/PhpWordTests/Writer/Word2007/Element/CheckBoxTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/Element/CheckBoxTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 class CheckBoxTest extends TestCase
 {
     /**
-     * @dataProvider checkBoxColorProvider
+     * @dataProvider checkBoxCheckedProvider
      */
     public function testCheckBoxGeneratesCorrectXml(
         string $expectedCheckedAttribute
@@ -32,16 +32,16 @@ class CheckBoxTest extends TestCase
     }
 
     /**
-     * Data provider for testing different combinations of background and border colors.
+     * Data provider for testing checked state.
      */
-    public static function checkBoxColorProvider(): array
+    public static function checkBoxCheckedProvider(): array
     {
         return [
             'Default checked' => [
-                'w:val="1"',
+                'w:default w:val="1"',
             ],
             'Default unchecked' => [
-                'w:val="0"',
+                'w:default w:val="0"',
             ],
         ];
     }

--- a/tests/PhpWordTests/Writer/Word2007/Element/CheckBoxTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/Element/CheckBoxTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpWordTests\Writer\Word2007\Element;
+
+use PhpOffice\PhpWord\Element\CheckBox as CheckBoxElement;
+use PhpOffice\PhpWord\Shared\XMLWriter;
+use PhpOffice\PhpWord\Writer\Word2007\Element\CheckBox;
+use PHPUnit\Framework\TestCase;
+
+class CheckBoxTest extends TestCase
+{
+    /**
+     * @dataProvider checkBoxColorProvider
+     */
+    public function testCheckBoxGeneratesCorrectXml(
+        string $expectedCheckedAttribute
+    ): void {
+        // Arrange
+        $xmlWriter = new XMLWriter();
+
+        $checkBoxElement = new CheckBoxElement('test', 'test');
+        $checkBox = new CheckBox($xmlWriter, $checkBoxElement);
+
+        // Act
+        $checkBox->write();
+        $output = $xmlWriter->getData();
+
+        // Assert
+        self::assertStringContainsString($expectedCheckedAttribute, $output, 'Default checked should be applied.');
+    }
+
+    /**
+     * Data provider for testing different combinations of background and border colors.
+     */
+    public static function checkBoxColorProvider(): array
+    {
+        return [
+            'Default checked' => [
+                'w:val="1"',
+            ],
+            'Default unchecked' => [
+                'w:val="0"',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
### Description

When using textRun with templates, there is no possibility to set default checkbox state. This commit adds the possibility as shown below.

```php
$templateProcessor = new \PhpOffice\PhpWord\TemplateProcessor("template.docx");
$textRun = new \PhpOffice\PhpWord\Element\TextRun();
$cb = $textRun->addCheckBox("test", "  Test Checkbox");
$cb->setDefaultChecked(true);
$templateProcessor->setComplexValue("my_template_parameter", $textRun);
```

Fixes #1187 #696 

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
