### PR TITLE
move from "zendframework/zend-escaper" to  "laminas/laminas-escaper" 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
-    - 7.4snapshot
+    - 7.4
 
 matrix:
     include:
@@ -33,7 +33,7 @@ matrix:
         - php: 7.0
         - php: 7.3
     allow_failures:
-        - php: 7.4snapshot
+        - php: 7.4
 
 cache:
     directories:

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -14,7 +14,6 @@
  * @copyright   2010-2018 PHPWord contributors
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
-
 $vendorDirPath = realpath(__DIR__ . '/vendor');
 if (file_exists($vendorDirPath . '/autoload.php')) {
     require $vendorDirPath . '/autoload.php';

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     "require": {
         "php": "^5.3.3 || ^7.0",
         "ext-xml": "*",
-        "zendframework/zend-escaper": "^2.2",
+        "laminas/laminas-escaper": "^2.2",
         "phpoffice/common": "^0.2.9"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -67,13 +67,13 @@
         "ext-zip": "*",
         "ext-gd": "*",
         "phpunit/phpunit": "^4.8.36 || ^7.0",
-        "squizlabs/php_codesniffer": "^2.9",
+        "squizlabs/php_codesniffer": "^2.9 || ^3.5",
         "friendsofphp/php-cs-fixer": "^2.2",
         "phpmd/phpmd": "2.*",
-        "phploc/phploc": "2.* || 3.* || 4.*",
+        "phploc/phploc": "2.* || 3.* || 4.* || 5.*",
         "dompdf/dompdf":"0.8.*",
         "tecnickcom/tcpdf": "6.*",
-        "mpdf/mpdf": "5.7.4 || 6.* || 7.*",
+        "mpdf/mpdf": "5.7.4 || 6.* || 7.* || 8.*",
         "php-coveralls/php-coveralls": "1.1.0 || ^2.0"
     },
     "suggest": {

--- a/src/PhpWord/Shared/OLERead.php
+++ b/src/PhpWord/Shared/OLERead.php
@@ -14,6 +14,7 @@
  * @copyright   2010-2018 PHPWord contributors
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
+
 namespace PhpOffice\PhpWord\Shared;
 
 use PhpOffice\PhpWord\Exception\Exception;
@@ -29,40 +30,37 @@ class OLERead
     const IDENTIFIER_OLE = IDENTIFIER_OLE;
 
     // Size of a sector = 512 bytes
-    const BIG_BLOCK_SIZE                    = 0x200;
+    const BIG_BLOCK_SIZE = 0x200;
 
     // Size of a short sector = 64 bytes
-    const SMALL_BLOCK_SIZE                  = 0x40;
+    const SMALL_BLOCK_SIZE = 0x40;
 
     // Size of a directory entry always = 128 bytes
-    const PROPERTY_STORAGE_BLOCK_SIZE       = 0x80;
+    const PROPERTY_STORAGE_BLOCK_SIZE = 0x80;
 
     // Minimum size of a standard stream = 4096 bytes, streams smaller than this are stored as short streams
-    const SMALL_BLOCK_THRESHOLD             = 0x1000;
+    const SMALL_BLOCK_THRESHOLD = 0x1000;
 
     // header offsets
-    const NUM_BIG_BLOCK_DEPOT_BLOCKS_POS    = 0x2c;
-    const ROOT_START_BLOCK_POS              = 0x30;
-    const SMALL_BLOCK_DEPOT_BLOCK_POS       = 0x3c;
-    const EXTENSION_BLOCK_POS               = 0x44;
-    const NUM_EXTENSION_BLOCK_POS           = 0x48;
-    const BIG_BLOCK_DEPOT_BLOCKS_POS        = 0x4c;
+    const NUM_BIG_BLOCK_DEPOT_BLOCKS_POS = 0x2c;
+    const ROOT_START_BLOCK_POS = 0x30;
+    const SMALL_BLOCK_DEPOT_BLOCK_POS = 0x3c;
+    const EXTENSION_BLOCK_POS = 0x44;
+    const NUM_EXTENSION_BLOCK_POS = 0x48;
+    const BIG_BLOCK_DEPOT_BLOCKS_POS = 0x4c;
 
     // property storage offsets (directory offsets)
-    const SIZE_OF_NAME_POS                  = 0x40;
-    const TYPE_POS                          = 0x42;
-    const START_BLOCK_POS                   = 0x74;
-    const SIZE_POS                          = 0x78;
+    const SIZE_OF_NAME_POS = 0x40;
+    const TYPE_POS = 0x42;
+    const START_BLOCK_POS = 0x74;
+    const SIZE_POS = 0x78;
 
-
-
-    public $wrkdocument                     = null;
-    public $wrk1Table                       = null;
-    public $wrkData                         = null;
-    public $wrkObjectPool                   = null;
-    public $summaryInformation              = null;
-    public $docSummaryInfos                 = null;
-
+    public $wrkdocument = null;
+    public $wrk1Table = null;
+    public $wrkData = null;
+    public $wrkObjectPool = null;
+    public $summaryInformation = null;
+    public $docSummaryInfos = null;
 
     /**
      * Read the file
@@ -75,7 +73,7 @@ class OLERead
     {
         // Check if file exists and is readable
         if (!is_readable($sFileName)) {
-            throw new Exception("Could not open " . $sFileName . " for reading! File does not exist, or it is not readable.");
+            throw new Exception('Could not open ' . $sFileName . ' for reading! File does not exist, or it is not readable.');
         }
 
         // Get the file identifier
@@ -112,7 +110,7 @@ class OLERead
 
         // @codeCoverageIgnoreStart
         if ($this->numExtensionBlocks != 0) {
-            $bbdBlocks = (self::BIG_BLOCK_SIZE - self::BIG_BLOCK_DEPOT_BLOCKS_POS)/4;
+            $bbdBlocks = (self::BIG_BLOCK_SIZE - self::BIG_BLOCK_DEPOT_BLOCKS_POS) / 4;
         }
         // @codeCoverageIgnoreEnd
 
@@ -144,8 +142,8 @@ class OLERead
         for ($i = 0; $i < $this->numBigBlockDepotBlocks; ++$i) {
             $pos = ($bigBlockDepotBlocks[$i] + 1) * self::BIG_BLOCK_SIZE;
 
-            $this->bigBlockChain .= substr($this->data, $pos, 4*$bbs);
-            $pos += 4*$bbs;
+            $this->bigBlockChain .= substr($this->data, $pos, 4 * $bbs);
+            $pos += 4 * $bbs;
         }
 
         $pos = 0;
@@ -154,10 +152,10 @@ class OLERead
         while ($sbdBlock != -2) {
             $pos = ($sbdBlock + 1) * self::BIG_BLOCK_SIZE;
 
-            $this->smallBlockChain .= substr($this->data, $pos, 4*$bbs);
-            $pos += 4*$bbs;
+            $this->smallBlockChain .= substr($this->data, $pos, 4 * $bbs);
+            $pos += 4 * $bbs;
 
-            $sbdBlock = self::getInt4d($this->bigBlockChain, $sbdBlock*4);
+            $sbdBlock = self::getInt4d($this->bigBlockChain, $sbdBlock * 4);
         }
 
         // read the directory stream
@@ -170,6 +168,7 @@ class OLERead
     /**
      * Extract binary stream data
      *
+     * @param mixed $stream
      * @return string
      */
     public function getStream($stream)
@@ -189,7 +188,7 @@ class OLERead
                 $pos = $block * self::SMALL_BLOCK_SIZE;
                 $streamData .= substr($rootdata, $pos, self::SMALL_BLOCK_SIZE);
 
-                $block = self::getInt4d($this->smallBlockChain, $block*4);
+                $block = self::getInt4d($this->smallBlockChain, $block * 4);
             }
 
             return $streamData;
@@ -201,7 +200,7 @@ class OLERead
         }
 
         if ($numBlocks == 0) {
-            return '';// @codeCoverageIgnore
+            return ''; // @codeCoverageIgnore
         }
 
         $block = $this->props[$stream]['startBlock'];
@@ -209,7 +208,7 @@ class OLERead
         while ($block != -2) {
             $pos = ($block + 1) * self::BIG_BLOCK_SIZE;
             $streamData .= substr($this->data, $pos, self::BIG_BLOCK_SIZE);
-            $block = self::getInt4d($this->bigBlockChain, $block*4);
+            $block = self::getInt4d($this->bigBlockChain, $block * 4);
         }
 
         return $streamData;
@@ -229,8 +228,9 @@ class OLERead
         while ($block != -2) {
             $pos = ($block + 1) * self::BIG_BLOCK_SIZE;
             $data .= substr($this->data, $pos, self::BIG_BLOCK_SIZE);
-            $block = self::getInt4d($this->bigBlockChain, $block*4);
+            $block = self::getInt4d($this->bigBlockChain, $block * 4);
         }
+
         return $data;
     }
 
@@ -248,7 +248,7 @@ class OLERead
             $data = substr($this->entry, $offset, self::PROPERTY_STORAGE_BLOCK_SIZE);
 
             // size in bytes of name
-            $nameSize = ord($data[self::SIZE_OF_NAME_POS]) | (ord($data[self::SIZE_OF_NAME_POS+1]) << 8);
+            $nameSize = ord($data[self::SIZE_OF_NAME_POS]) | (ord($data[self::SIZE_OF_NAME_POS + 1]) << 8);
 
             // type of entry
             $type = ord($data[self::TYPE_POS]);
@@ -259,14 +259,13 @@ class OLERead
 
             $size = self::getInt4d($data, self::SIZE_POS);
 
-            $name = str_replace("\x00", "", substr($data, 0, $nameSize));
+            $name = str_replace("\x00", '', substr($data, 0, $nameSize));
 
-
-            $this->props[] = array (
-                'name' => $name,
-                'type' => $type,
+            $this->props[] = array(
+                'name'       => $name,
+                'type'       => $type,
                 'startBlock' => $startBlock,
-                'size' => $size);
+                'size'       => $size, );
 
             // tmp helper to simplify checks
             $upName = strtoupper($name);
@@ -318,6 +317,7 @@ class OLERead
         } else {
             $ord24 = ($or24 & 127) << 24;
         }
+
         return ord($data[$pos]) | (ord($data[$pos + 1]) << 8) | (ord($data[$pos + 2]) << 16) | $ord24;
     }
 }

--- a/src/PhpWord/Writer/HTML/Element/AbstractElement.php
+++ b/src/PhpWord/Writer/HTML/Element/AbstractElement.php
@@ -17,9 +17,9 @@
 
 namespace PhpOffice\PhpWord\Writer\HTML\Element;
 
+use Laminas\Escaper\Escaper;
 use PhpOffice\PhpWord\Element\AbstractElement as Element;
 use PhpOffice\PhpWord\Writer\AbstractWriter;
-use Zend\Escaper\Escaper;
 
 /**
  * Abstract HTML element writer
@@ -50,7 +50,7 @@ abstract class AbstractElement
     protected $withoutP = false;
 
     /**
-     * @var \Zend\Escaper\Escaper|\PhpOffice\PhpWord\Escaper\AbstractEscaper
+     * @var \Laminas\Escaper\Escaper|\PhpOffice\PhpWord\Escaper\AbstractEscaper
      */
     protected $escaper;
 

--- a/src/PhpWord/Writer/HTML/Part/AbstractPart.php
+++ b/src/PhpWord/Writer/HTML/Part/AbstractPart.php
@@ -17,9 +17,9 @@
 
 namespace PhpOffice\PhpWord\Writer\HTML\Part;
 
+use Laminas\Escaper\Escaper;
 use PhpOffice\PhpWord\Exception\Exception;
 use PhpOffice\PhpWord\Writer\AbstractWriter;
-use Zend\Escaper\Escaper;
 
 /**
  * @since 0.11.0
@@ -32,7 +32,7 @@ abstract class AbstractPart
     private $parentWriter;
 
     /**
-     * @var \Zend\Escaper\Escaper
+     * @var \Laminas\Escaper\Escaper
      */
     protected $escaper;
 


### PR DESCRIPTION
move from "zendframework/zend-escaper" to  "laminas/laminas-escaper"  due to Zend Framework migration

### Description

Zend Framework repos are archived and unmaintaned. New name for this project is laminas
 

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
 
