### PR TITLE
Fix: CloneBlock regexp for different regexp engine with xml line-drop

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -737,7 +737,7 @@ class TemplateProcessor
         $xmlBlock = null;
         $matches = array();
         preg_match(
-            '/(<\?xml.*)(<w:p\b.*>\${' . $blockname . '}<\/w:.*?p>)(.*)(<w:p\b.*\${\/' . $blockname . '}<\/w:.*?p>)/is',
+            '/(.*((?s)<w:p\b(?:(?!<w:p\b).)*?\${' . $blockname . '}<\/w:.*?p>))(.*)((?s)<w:p\b(?:(?!<w:p\b).)*?\${\/' . $blockname . '}<\/w:.*?p>)/is',
             $this->tempDocumentMainPart,
             $matches
         );


### PR DESCRIPTION
### Description
Reference Issue:   #1800 
When you have multiple Blocks in multiple Rows, some of blocks cannot be replaced
Only the last block was replaced.
This because some word file will drop-line after `xml` tag, and the regular expression engine in different versions cannot find the matched block.

Fixes # (issue)
File: `TemplateProcessor.php`
Line: 740

Change the regexp pattern to: 
```php
'/(.*((?s)<w:p\b(?:(?!<w:p\b).)*?\${' . $blockname . '}<\/w:.*?p>))(.*)((?s)<w:p\b(?:(?!<w:p\b).)*?\${\/' . $blockname . '}<\/w:.*?p>)/is',
```
Describe: 
- Do not find for xml.
- Start find the `<w:p` tag that closest to the blockname.
- This `<w:p` does not contain any other `<w:p` inside it.

### Checklist:
All Done

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
