### PR TITLE
Fix data URI scheme regex

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -675,7 +675,7 @@ class Html
             $tmpDir = Settings::getTempDir() . '/';
 
             $match = array();
-            preg_match('/data:image\/(\w+);base64,(.+)/', $src, $match);
+            preg_match('/data:image\/(\w+)(?:;.*)?;base64,(.+)/', $src, $match);
 
             $src = $imgFile = $tmpDir . uniqid() . '.' . $match[1];
 


### PR DESCRIPTION
### Description

According to the data URI scheme [1], the format can also include
more metadata. For example images like:

```
data:image/png;charset=utf-8;base64:...
```

[1]: https://en.wikipedia.org/wiki/Data_URI_scheme

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
