### PR TITLE
Fix typo for GD core extension s/ext-gd2/ext-gd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
     },
     "suggest": {
         "ext-zip": "Allows writing OOXML and ODF",
-        "ext-gd2": "Allows adding images",
+        "ext-gd": "Allows adding images",
         "ext-xmlwriter": "Allows writing OOXML and ODF",
         "ext-xsl": "Allows applying XSL style sheet to headers, to main document part, and to footers of an OOXML template",
         "dompdf/dompdf": "Allows writing PDF"


### PR DESCRIPTION
### Description

This patch fixes typo in composer.json file

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
