### PR TITLE
Fixes PHPDoc @param and @return types for several Converter methods

### DIFF
--- a/src/PhpWord/Shared/Converter.php
+++ b/src/PhpWord/Shared/Converter.php
@@ -133,7 +133,7 @@ class Converter
      * Convert inch to EMU
      *
      * @param float $inch
-     * @return float
+     * @return int
      */
     public static function inchToEmu($inch = 1)
     {
@@ -143,7 +143,7 @@ class Converter
     /**
      * Convert pixel to twip
      *
-     * @param int $pixel
+     * @param float $pixel
      * @return float
      */
     public static function pixelToTwip($pixel = 1)
@@ -154,7 +154,7 @@ class Converter
     /**
      * Convert pixel to centimeter
      *
-     * @param int $pixel
+     * @param float $pixel
      * @return float
      */
     public static function pixelToCm($pixel = 1)
@@ -165,7 +165,7 @@ class Converter
     /**
      * Convert pixel to point
      *
-     * @param int $pixel
+     * @param float $pixel
      * @return float
      */
     public static function pixelToPoint($pixel = 1)
@@ -176,7 +176,7 @@ class Converter
     /**
      * Convert pixel to EMU
      *
-     * @param int $pixel
+     * @param float $pixel
      * @return int
      */
     public static function pixelToEmu($pixel = 1)
@@ -187,7 +187,7 @@ class Converter
     /**
      * Convert point to twip unit
      *
-     * @param int $point
+     * @param float $point
      * @return float
      */
     public static function pointToTwip($point = 1)
@@ -209,7 +209,7 @@ class Converter
     /**
      * Convert point to EMU
      *
-     * @param int $point
+     * @param float $point
      * @return float
      */
     public static function pointToEmu($point = 1)
@@ -231,7 +231,7 @@ class Converter
     /**
      * Convert EMU to pixel
      *
-     * @param int $emu
+     * @param float $emu
      * @return float
      */
     public static function emuToPixel($emu = 1)
@@ -242,7 +242,7 @@ class Converter
     /**
      * Convert pica to point
      *
-     * @param int $pica
+     * @param float $pica
      * @return float
      */
     public static function picaToPoint($pica = 1)
@@ -253,7 +253,7 @@ class Converter
     /**
      * Convert degree to angle
      *
-     * @param int $degree
+     * @param float $degree
      * @return int
      */
     public static function degreeToAngle($degree = 1)
@@ -264,7 +264,7 @@ class Converter
     /**
      * Convert angle to degrees
      *
-     * @param int $angle
+     * @param float $angle
      * @return int
      */
     public static function angleToDegree($angle = 1)


### PR DESCRIPTION
### Description

Fixes PHPDoc `@param` and `@return` types for several `Converter` methods:

* Some methods supposedly expect an `int`, even though `float` values make sense.
* Some methods supposedly return a `float`, even though they return an `int`.

([Psalm](https://psalm.dev/) noticed these inconsistencies for me.)

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
