### PR TITLE
Some document have non-standard locale code

### DIFF
--- a/src/PhpWord/Style/Language.php
+++ b/src/PhpWord/Style/Language.php
@@ -228,6 +228,8 @@ final class Language extends AbstractStyle
      */
     private function validateLocale($locale)
     {
+        $locale = str_replace('_', '-', $locale);
+
         if (strlen($locale) === 2) {
             return strtolower($locale) . '-' . strtoupper($locale);
         }

--- a/src/PhpWord/Style/Language.php
+++ b/src/PhpWord/Style/Language.php
@@ -228,7 +228,9 @@ final class Language extends AbstractStyle
      */
     private function validateLocale($locale)
     {
-        $locale = str_replace('_', '-', $locale);
+        if ($locale !== null) {
+            $locale = str_replace('_', '-', $locale);
+        }
 
         if (strlen($locale) === 2) {
             return strtolower($locale) . '-' . strtoupper($locale);


### PR DESCRIPTION
### Description

Some documents come with style locale as en_GB, en_US this fixes these locale codes

Fixes #

replaces "_" to "-"

### Checklist:

- [x ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
