### PR TITLE
move index for Cloned Blocks with values

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -1085,7 +1085,7 @@ class TemplateProcessor
     {
         $results = array();
         for ($i = 1; $i <= $count; $i++) {
-            $results[] = preg_replace('/\$\{(.*?)\}/', '\${\\1#' . $i . '}', $xmlBlock);
+             $results[] = preg_replace('/\$\{(.*?)(:([^}])*)?\}/', '\${\\1#' . $i . '\\2}', $xmlBlock);
         }
 
         return $results;


### PR DESCRIPTION

### Description

If an image field like `${IMAGE:10cmx15cm}` gets cloned it returns now `${IMAGE#1:10cmx15cm}` instead of `${IMAGE:10cmx15cm#1}` and therefore wouldn't break the image field anymore.

Fixes https://github.com/PHPOffice/PHPWord/issues/1624

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
