### PR TITLE
Fixed setting width of Cell Style

### DIFF
--- a/src/PhpWord/Style/Cell.php
+++ b/src/PhpWord/Style/Cell.php
@@ -299,7 +299,7 @@ class Cell extends Border
      */
     public function setWidth($value)
     {
-        $this->setIntVal($value);
+        $this->width = $this->setIntVal($value);
 
         return $this;
     }


### PR DESCRIPTION


### Description

The setWidth method did not change the width in the style, seems to be a small mistake.
Now the width is correctly for the Cell Style.

Fixes # (issue)
I did not create a separate issue for this.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
_not applicable I would say_
- [ ] I have updated the documentation to describe the changes
_not applicable I would say_
