### PR TITLE
Make Default Paper Configurable

### DIFF
--- a/docs/general.rst
+++ b/docs/general.rst
@@ -130,6 +130,16 @@ To turn it on set ``outputEscapingEnabled`` option to ``true`` in your PHPWord c
 
     \PhpOffice\PhpWord\Settings::setOutputEscapingEnabled(true);
 
+Default Paper
+~~~~~~~~~~~~~
+
+By default, all sections of the document will print on A4 paper.
+You can alter the default paper by using the following function:
+
+.. code-block:: php
+
+    \PhpOffice\PhpWord\Settings::setDefaultPaper('Letter');
+
 Default font
 ~~~~~~~~~~~~
 

--- a/phpword.ini.dist
+++ b/phpword.ini.dist
@@ -14,3 +14,7 @@ outputEscapingEnabled = false
 
 defaultFontName = Arial
 defaultFontSize = 10
+
+[Paper]
+
+defaultPaper = "A4"

--- a/src/PhpWord/Settings.php
+++ b/src/PhpWord/Settings.php
@@ -122,7 +122,7 @@ class Settings
 
     /**
      * Default paper
-     * @var int
+     * @var string
      */
     private static $defaultPaper = self::DEFAULT_PAPER;
 

--- a/src/PhpWord/Settings.php
+++ b/src/PhpWord/Settings.php
@@ -70,6 +70,7 @@ class Settings
     const DEFAULT_FONT_SIZE = 10;
     const DEFAULT_FONT_COLOR = '000000';
     const DEFAULT_FONT_CONTENT_TYPE = 'default'; // default|eastAsia|cs
+    const DEFAULT_PAPER = 'A4';
 
     /**
      * Compatibility option for XMLWriter
@@ -118,6 +119,12 @@ class Settings
      * @var int
      */
     private static $defaultFontSize = self::DEFAULT_FONT_SIZE;
+
+    /**
+     * Default paper
+     * @var int
+     */
+    private static $defaultPaper = self::DEFAULT_PAPER;
 
     /**
      * The user defined temporary directory.
@@ -430,6 +437,33 @@ class Settings
         }
 
         return $config;
+    }
+
+    /**
+     * Get default paper
+     *
+     * @return string
+     */
+    public static function getDefaultPaper()
+    {
+        return self::$defaultPaper;
+    }
+
+    /**
+     * Set default paper
+     *
+     * @param string $value
+     * @return bool
+     */
+    public static function setDefaultPaper($value)
+    {
+        if (is_string($value) && trim($value) !== '') {
+            self::$defaultPaper = $value;
+
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/PhpWord/Style/Section.php
+++ b/src/PhpWord/Style/Section.php
@@ -17,6 +17,7 @@
 
 namespace PhpOffice\PhpWord\Style;
 
+use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\SimpleType\VerticalJc;
 
 /**
@@ -200,8 +201,11 @@ class Section extends Border
      * @param string $value
      * @return self
      */
-    public function setPaperSize($value = 'A4')
+    public function setPaperSize($value = '')
     {
+        if (!$value) {
+            $value = Settings::getDefaultPaper();
+        }
         if ($this->paper === null) {
             $this->paper = new Paper();
         }

--- a/tests/PhpWord/SettingsTest.php
+++ b/tests/PhpWord/SettingsTest.php
@@ -25,6 +25,45 @@ namespace PhpOffice\PhpWord;
  */
 class SettingsTest extends \PHPUnit\Framework\TestCase
 {
+    private $compatibility;
+    private $defaultFontSize;
+    private $defaultFontName;
+    private $defaultPaper;
+    private $measurementUnit;
+    private $outputEscapingEnabled;
+    private $pdfRendererName;
+    private $pdfRendererPath;
+    private $tempDir;
+    private $zipClass;
+
+    public function setUp()
+    {
+        $this->compatibility = Settings::hasCompatibility();
+        $this->defaultFontSize = Settings::getDefaultFontSize();
+        $this->defaultFontName = Settings::getDefaultFontName();
+        $this->defaultPaper = Settings::getDefaultPaper();
+        $this->measurementUnit = Settings::getMeasurementUnit();
+        $this->outputEscapingEnabled = Settings::isOutputEscapingEnabled();
+        $this->pdfRendererName = Settings::getPdfRendererName();
+        $this->pdfRendererPath = Settings::getPdfRendererPath();
+        $this->tempDir = Settings::getTempDir();
+        $this->zipClass = Settings::getZipClass();
+    }
+
+    public function tearDown()
+    {
+        Settings::setCompatibility($this->compatibility);
+        Settings::setDefaultFontSize($this->defaultFontSize);
+        Settings::setDefaultFontName($this->defaultFontName);
+        Settings::setDefaultPaper($this->defaultPaper);
+        Settings::setMeasurementUnit($this->measurementUnit);
+        Settings::setOutputEscapingEnabled($this->outputEscapingEnabled);
+        Settings::setPdfRendererName($this->pdfRendererName);
+        Settings::setPdfRendererPath($this->pdfRendererPath);
+        Settings::setTempDir($this->tempDir);
+        Settings::setZipClass($this->zipClass);
+    }
+
     /**
      * Test set/get compatibity option
      */
@@ -36,13 +75,27 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test set/get outputEscapingEnabled option
+     */
+    public function testSetGetOutputEscapingEnabled()
+    {
+        $this->assertFalse(Settings::isOutputEscapingEnabled());
+        Settings::setOutputEscapingEnabled(true);
+        $this->assertTrue(Settings::isOutputEscapingEnabled());
+    }
+
+    /**
      * Test set/get zip class
      */
     public function testSetGetZipClass()
     {
         $this->assertEquals(Settings::ZIPARCHIVE, Settings::getZipClass());
-        $this->assertTrue(Settings::setZipClass(Settings::PCLZIP));
         $this->assertFalse(Settings::setZipClass('foo'));
+        $this->assertEquals(Settings::ZIPARCHIVE, Settings::getZipClass());
+        $this->assertTrue(Settings::setZipClass(Settings::PCLZIP));
+        $this->assertEquals(Settings::getZipClass(), Settings::PCLZIP);
+        $this->assertFalse(Settings::setZipClass('foo'));
+        $this->assertEquals(Settings::getZipClass(), Settings::PCLZIP);
     }
 
     /**
@@ -57,6 +110,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(Settings::PDF_RENDERER_DOMPDF, Settings::getPdfRendererName());
         $this->assertEquals($domPdfPath, Settings::getPdfRendererPath());
         $this->assertFalse(Settings::setPdfRendererPath('dummy/path'));
+        $this->assertEquals($domPdfPath, Settings::getPdfRendererPath());
     }
 
     /**
@@ -65,8 +119,12 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
     public function testSetGetMeasurementUnit()
     {
         $this->assertEquals(Settings::UNIT_TWIP, Settings::getMeasurementUnit());
-        $this->assertTrue(Settings::setMeasurementUnit(Settings::UNIT_INCH));
         $this->assertFalse(Settings::setMeasurementUnit('foo'));
+        $this->assertEquals(Settings::UNIT_TWIP, Settings::getMeasurementUnit());
+        $this->assertTrue(Settings::setMeasurementUnit(Settings::UNIT_INCH));
+        $this->assertEquals(Settings::UNIT_INCH, Settings::getMeasurementUnit());
+        $this->assertFalse(Settings::setMeasurementUnit('foo'));
+        $this->assertEquals(Settings::UNIT_INCH, Settings::getMeasurementUnit());
     }
 
     /**
@@ -99,8 +157,12 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
     public function testSetGetDefaultFontName()
     {
         $this->assertEquals(Settings::DEFAULT_FONT_NAME, Settings::getDefaultFontName());
-        $this->assertTrue(Settings::setDefaultFontName('Times New Roman'));
         $this->assertFalse(Settings::setDefaultFontName(' '));
+        $this->assertEquals(Settings::DEFAULT_FONT_NAME, Settings::getDefaultFontName());
+        $this->assertTrue(Settings::setDefaultFontName('Times New Roman'));
+        $this->assertEquals('Times New Roman', Settings::getDefaultFontName());
+        $this->assertFalse(Settings::setDefaultFontName(' '));
+        $this->assertEquals('Times New Roman', Settings::getDefaultFontName());
     }
 
     /**
@@ -109,8 +171,35 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
     public function testSetGetDefaultFontSize()
     {
         $this->assertEquals(Settings::DEFAULT_FONT_SIZE, Settings::getDefaultFontSize());
-        $this->assertTrue(Settings::setDefaultFontSize(12));
         $this->assertFalse(Settings::setDefaultFontSize(null));
+        $this->assertEquals(Settings::DEFAULT_FONT_SIZE, Settings::getDefaultFontSize());
+        $this->assertTrue(Settings::setDefaultFontSize(12));
+        $this->assertEquals(12, Settings::getDefaultFontSize());
+        $this->assertFalse(Settings::setDefaultFontSize(null));
+        $this->assertEquals(12, Settings::getDefaultFontSize());
+    }
+
+    /**
+     * Test set/get default paper
+     */
+    public function testSetGetDefaultPaper()
+    {
+        $dflt = Settings::DEFAULT_PAPER;
+        $chng = ($dflt === 'A4') ? 'Letter' : 'A4';
+        $doc = new PhpWord();
+        $this->assertEquals($dflt, Settings::getDefaultPaper());
+        $sec1 = $doc->addSection();
+        $this->assertEquals($dflt, $sec1->getStyle()->getPaperSize());
+        $this->assertFalse(Settings::setDefaultPaper(''));
+        $this->assertEquals($dflt, Settings::getDefaultPaper());
+        $this->assertTrue(Settings::setDefaultPaper($chng));
+        $this->assertEquals($chng, Settings::getDefaultPaper());
+        $sec2 = $doc->addSection();
+        $this->assertEquals($chng, $sec2->getStyle()->getPaperSize());
+        $sec3 = $doc->addSection(array('paperSize' => 'Legal'));
+        $this->assertEquals('Legal', $sec3->getStyle()->getPaperSize());
+        $this->assertFalse(Settings::setDefaultPaper(''));
+        $this->assertEquals($chng, Settings::getDefaultPaper());
     }
 
     /**
@@ -126,6 +215,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             'defaultFontName'       => 'Arial',
             'defaultFontSize'       => 10,
             'outputEscapingEnabled' => false,
+            'defaultPaper'          => 'A4',
         );
 
         // Test default value
@@ -133,6 +223,16 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
 
         // Test with valid file
         $this->assertEquals($expected, Settings::loadConfig(__DIR__ . '/../../phpword.ini.dist'));
+        foreach ($expected as $key => $value) {
+            if ($key === 'compatibility') {
+                $meth = 'hasCompatibility';
+            } elseif ($key === 'outputEscapingEnabled') {
+                $meth = 'isOutputEscapingEnabled';
+            } else {
+                $meth = 'get' . ucfirst($key);
+            }
+            $this->assertEquals(Settings::$meth(), $value);
+        }
 
         // Test with invalid file
         $this->assertEmpty(Settings::loadConfig(__DIR__ . '/../../phpunit.xml.dist'));

--- a/tests/PhpWord/_includes/AbstractWebServerEmbeddedTest.php
+++ b/tests/PhpWord/_includes/AbstractWebServerEmbeddedTest.php
@@ -26,7 +26,26 @@ abstract class AbstractWebServerEmbeddedTest extends \PHPUnit\Framework\TestCase
     public static function setUpBeforeClass()
     {
         if (self::isBuiltinServerSupported()) {
-            self::$httpServer = new Process('php -S localhost:8080 -t tests/PhpWord/_files');
+            $commandLine = 'php -S localhost:8080 -t tests/PhpWord/_files';
+
+            /*
+             * Make sure to invoke \Symfony\Component\Process\Process correctly
+             * regardless of PHP version used.
+             *
+             * In Process version >= 5 / PHP >= 7.2.5, the constructor requires
+             * an array, while in version < 3.3 / PHP < 5.5.9 it requires a string.
+             * In between, it can accept both.
+             *
+             * Process::fromShellCommandLine() was introduced in version 4.2.0,
+             * to enable recent versions of Process to parse a command string,
+             * so if it is not available it means it is still possible to pass
+             * a string to the constructor.
+             */
+            if (method_exists('Symfony\Component\Process\Process', 'fromShellCommandLine')) {
+                self::$httpServer = Process::fromShellCommandline($commandLine);
+            } else {
+                self::$httpServer = new Process($commandLine);
+            }
             self::$httpServer->start();
             while (!self::$httpServer->isRunning()) {
                 usleep(1000);


### PR DESCRIPTION
### Description

Each section currently has a hard-coded default paper of A4.
It would make sense to allow the user to set this default,
and specify it in a configuration file, just as is done
with default font name and size.

Fixes # (issue)

### Checklist:

- [X] I have run `composer run-script check --timeout=0` and no errors were reported
- [X] The new code is covered by unit tests (check build/coverage for coverage report)
- [X] I have updated the documentation to describe the changes
