### PR TITLE
Improve Word2007 Test Coverage

### DIFF
--- a/src/PhpWord/Writer/Word2007/Style/AbstractStyle.php
+++ b/src/PhpWord/Writer/Word2007/Style/AbstractStyle.php
@@ -96,7 +96,7 @@ abstract class AbstractStyle
         );
         $unit = Settings::getMeasurementUnit();
         $factor = 1;
-        if (in_array($unit, $factors) && $value != $default) {
+        if (array_key_exists($unit, $factors) && $value != $default) {
             $factor = $factors[$unit];
         }
 

--- a/tests/PhpWord/Writer/Word2007/Element/ChartTest.php
+++ b/tests/PhpWord/Writer/Word2007/Element/ChartTest.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ * @copyright   2010-2018 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\Word2007;
+
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Settings;
+use PhpOffice\PhpWord\TestHelperDOCX;
+
+/**
+ * Test class for PhpOffice\PhpWord\Writer\Word2007\Element subnamespace
+ */
+class ChartTest extends \PHPUnit\Framework\TestCase
+{
+    private $outputEscapingEnabled;
+
+    /**
+     * Executed before each method of the class
+     */
+    public function setUp()
+    {
+        $this->outputEscapingEnabled = Settings::isOutputEscapingEnabled();
+    }
+
+    /**
+     * Executed after each method of the class
+     */
+    public function tearDown()
+    {
+        Settings::setOutputEscapingEnabled($this->outputEscapingEnabled);
+        TestHelperDOCX::clear();
+    }
+
+    /**
+     * Test chart elements
+     */
+    public function testChartElements()
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $style = array(
+            'width'          => 5000000,
+            'height'         => 5000000,
+            'showAxisLabels' => true,
+            'showGridX'      => true,
+            'showGridY'      => true,
+            'showLegend'     => false,
+            );
+
+        $chartTypes = array('pie', 'doughnut', 'bar', 'line', 'area', 'scatter', 'radar');
+        $categories = array('A', 'B', 'C', 'D', 'E');
+        $series1 = array(1, 3, 2, 5, 4);
+        foreach ($chartTypes as $chartType) {
+            $section->addChart($chartType, $categories, $series1, $style);
+        }
+        $colorArray = array('FFFFFF', '000000', 'FF0000', '00FF00', '0000FF');
+        $numColor = count($colorArray);
+        $chart = $section->addChart('pie', $categories, $series1, $style);
+        $chart->getStyle()->setColors($colorArray)->setTitle('3d chart')->set3d(true);
+        $chart = $section->addChart('stacked_bar', $categories, $series1, $style);
+        $chart->getStyle()->setColors($colorArray)->setShowLegend(true);
+        $chart = $section->addChart('scatter', $categories, $series1, $style);
+        $chart->getStyle()->setMajorTickPosition('cross');
+        $section->addChart('scatter', $categories, $series1, $style, 'seriesname');
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $index = 0;
+        foreach ($chartTypes as $chartType) {
+            ++$index;
+            $file = "word/charts/chart{$index}.xml";
+            $path = "/c:chartSpace/c:chart/c:plotArea/c:{$chartType}Chart";
+            self::assertTrue($doc->elementExists($path, $file), "chart type $chartType");
+        }
+
+        $index = 11;
+        $file = "word/charts/chart{$index}.xml";
+        $doc->setDefaultFile($file);
+        $chartType = 'scatter';
+        $path = "/c:chartSpace/c:chart/c:plotArea/c:{$chartType}Chart";
+        self::assertEquals('seriesname', $doc->getElement($path . '/c:ser/c:tx/c:strRef/c:strCache/c:pt/c:v')->nodeValue);
+
+        $index = 8;
+        $file = "word/charts/chart{$index}.xml";
+        $doc->setDefaultFile($file);
+        $chartType = 'pie3D';
+        $path = "/c:chartSpace/c:chart/c:plotArea/c:{$chartType}Chart";
+        for ($idx = 0; $idx < $numColor; ++$idx) {
+            $idxp1 = $idx + 1;
+            $element = $path . "/c:ser/c:dPt[$idxp1]/c:spPr/a:solidFill/a:srgbClr";
+            self::assertEquals($colorArray[$idx], $doc->getElementAttribute($element, 'val'), "pie3d chart idx=$idx");
+        }
+
+        $index = 9;
+        $file = "word/charts/chart{$index}.xml";
+        $doc->setDefaultFile($file);
+        $chartType = 'bar';
+        $path = "/c:chartSpace/c:chart/c:plotArea/c:{$chartType}Chart";
+        for ($idxp1 = 1; $idxp1 < $numColor; ++$idxp1) {
+            $idx = $idxp1; // stacked bar chart is shifted
+            $element = $path . "/c:ser/c:dPt[$idxp1]/c:spPr/a:solidFill/a:srgbClr";
+            self::assertEquals($colorArray[$idx], $doc->getElementAttribute($element, 'val'), "bar chart idx=$idx");
+        }
+    }
+
+    public function testChartEscapingEnabled()
+    {
+        Settings::setOutputEscapingEnabled(true);
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $style = array(
+            'width'          => 5000000,
+            'height'         => 5000000,
+            'showAxisLabels' => true,
+            'showGridX'      => true,
+            'showGridY'      => true,
+            'showLegend'     => false,
+            'valueAxisTitle' => 'Values',
+            );
+        $categories = array('A&B', 'C<D>', 'E', 'F', 'G');
+        $series1 = array(1, 3, 2, 5, 4);
+        $section->addChart('bar', $categories, $series1, $style);
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $index = 1;
+        $file = "word/charts/chart{$index}.xml";
+        $doc->setDefaultFile($file);
+        $chartType = 'bar';
+        $path = "/c:chartSpace/c:chart/c:plotArea/c:{$chartType}Chart/c:ser/c:cat/c:strLit";
+        $element = "$path/c:pt[1]/c:v";
+        self::assertEquals('A&B', $doc->getElement($element)->nodeValue);
+        $element = "$path/c:pt[2]/c:v";
+        self::assertEquals('C<D>', $doc->getElement($element)->nodeValue);
+    }
+
+    public function testChartEscapingDisabled()
+    {
+        Settings::setOutputEscapingEnabled(false);
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $style = array(
+            'width'          => 5000000,
+            'height'         => 5000000,
+            'showAxisLabels' => true,
+            'showGridX'      => true,
+            'showGridY'      => true,
+            'showLegend'     => false,
+            'valueAxisTitle' => 'Values',
+            );
+        $categories = array('A&amp;B', 'C&lt;D&gt;', 'E', 'F', 'G');
+        $series1 = array(1, 3, 2, 5, 4);
+        $section->addChart('bar', $categories, $series1, $style);
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $index = 1;
+        $file = "word/charts/chart{$index}.xml";
+        $doc->setDefaultFile($file);
+        $chartType = 'bar';
+        $path = "/c:chartSpace/c:chart/c:plotArea/c:{$chartType}Chart/c:ser/c:cat/c:strLit";
+        $element = "$path/c:pt[1]/c:v";
+        self::assertEquals('A&B', $doc->getElement($element)->nodeValue);
+        $element = "$path/c:pt[2]/c:v";
+        self::assertEquals('C<D>', $doc->getElement($element)->nodeValue);
+    }
+
+    public function testValueAxisTitle()
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $style = array(
+            'width'          => 5000000,
+            'height'         => 5000000,
+            'showAxisLabels' => true,
+            'showGridX'      => true,
+            'showGridY'      => true,
+            'showLegend'     => false,
+            'valueAxisTitle' => 'Values',
+            );
+        $chartType = 'line';
+        $categories = array('A', 'B', 'C', 'D', 'E');
+        $series1 = array(1, 3, 2, 5, 4);
+        $section->addChart($chartType, $categories, $series1, $style);
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $index = 1;
+        $file = "word/charts/chart{$index}.xml";
+        $doc->setDefaultFile($file);
+        $chartType = 'line';
+        $path = '/c:chartSpace/c:chart/c:plotArea';
+        $element = "$path/c:{$chartType}Chart";
+        self::assertTrue($doc->elementExists($path));
+        $element = "$path/c:valAx";
+        self::assertTrue($doc->elementExists($element));
+        $element .= '/c:title/c:tx/c:rich/a:p/a:r/a:t';
+        self::assertEquals('Values', $doc->getElement($element)->nodeValue);
+    }
+
+    public function testNoAxisLabels()
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $style = array(
+            'width'          => 5000000,
+            'height'         => 5000000,
+            'showAxisLabels' => false,
+            'showGridX'      => true,
+            'showGridY'      => true,
+            'showLegend'     => false,
+            'valueAxisTitle' => 'Values',
+            );
+        $chartType = 'line';
+        $categories = array('A', 'B', 'C', 'D', 'E');
+        $series1 = array(1, 3, 2, 5, 4);
+        $section->addChart($chartType, $categories, $series1, $style);
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $index = 1;
+        $file = "word/charts/chart{$index}.xml";
+        $doc->setDefaultFile($file);
+        $chartType = 'line';
+        $path = '/c:chartSpace/c:chart/c:plotArea';
+        $element = "$path/c:{$chartType}Chart";
+        $element = "$path/c:valAx";
+        $element .= '/c:tickLblPos';
+        self::assertEquals('none', $doc->getElementAttribute($element, 'val'));
+    }
+}

--- a/tests/PhpWord/Writer/Word2007/Element/FormFieldTest.php
+++ b/tests/PhpWord/Writer/Word2007/Element/FormFieldTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ * @copyright   2010-2018 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\Word2007;
+
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\TestHelperDOCX;
+
+/**
+ * Test class for PhpOffice\PhpWord\Writer\Word2007\Element subnamespace
+ */
+class FormFieldTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Executed before each method of the class
+     */
+    public function tearDown()
+    {
+        TestHelperDOCX::clear();
+    }
+
+    /**
+     * Test form fields
+     */
+    public function testFormFieldElements()
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+
+        $section->addFormField('textinput')->setName('MyTextBox');
+        $section->addFormField('checkbox')->setDefault(true)->setValue('Your name');
+        $section->addFormField('checkbox')->setDefault(true);
+        $section->addFormField('dropdown')->setEntries(array('Choice 1', 'Choice 2', 'Choice 3', ''));
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $path = '/w:document/w:body/w:p[1]/w:r/w:fldChar/w:ffData';
+        $this->assertTrue($doc->elementExists("$path/w:textInput"));
+        $this->assertEquals('MyTextBox', $doc->getElementAttribute("$path/w:name", 'w:val'));
+
+        $path = '/w:document/w:body/w:p[2]/w:r/w:fldChar/w:ffData';
+        $this->assertTrue($doc->elementExists("$path/w:checkBox"));
+        $path = '/w:document/w:body/w:p[2]/w:r[4]/w:t';
+        $this->assertEquals('Your name', $doc->getElement($path)->textContent);
+
+        $path = '/w:document/w:body/w:p[3]/w:r/w:fldChar/w:ffData';
+        $this->assertTrue($doc->elementExists("$path/w:checkBox"));
+
+        $path = '/w:document/w:body/w:p[4]/w:r/w:fldChar/w:ffData/w:ddList';
+        $this->assertTrue($doc->elementExists($path));
+        $this->assertEquals('Choice 1', $doc->getElementAttribute("$path/w:listEntry[1]", 'w:val'));
+        $this->assertEquals('Choice 2', $doc->getElementAttribute("$path/w:listEntry[2]", 'w:val'));
+        $this->assertEquals('Choice 3', $doc->getElementAttribute("$path/w:listEntry[3]", 'w:val'));
+        $this->assertEquals('', trim($doc->getElementAttribute("$path/w:listEntry[4]", 'w:val'), ' '));
+    }
+}

--- a/tests/PhpWord/Writer/Word2007/ElementTest.php
+++ b/tests/PhpWord/Writer/Word2007/ElementTest.php
@@ -249,33 +249,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    /**
-     * Test shape elements
-     */
-    public function testChartElements()
-    {
-        $phpWord = new PhpWord();
-        $section = $phpWord->addSection();
-        $style = array('width' => 1000000, 'height' => 1000000, 'showAxisLabels' => true, 'showGridX' => true, 'showGridY' => true);
-
-        $chartTypes = array('pie', 'doughnut', 'bar', 'line', 'area', 'scatter', 'radar');
-        $categories = array('A', 'B', 'C', 'D', 'E');
-        $series1 = array(1, 3, 2, 5, 4);
-        foreach ($chartTypes as $chartType) {
-            $section->addChart($chartType, $categories, $series1, $style);
-        }
-        $section->addChart('pie', $categories, $series1, array('3d' => true));
-
-        $doc = TestHelperDOCX::getDocument($phpWord);
-
-        $index = 0;
-        foreach ($chartTypes as $chartType) {
-            ++$index;
-            $file = "word/charts/chart{$index}.xml";
-            $path = "/c:chartSpace/c:chart/c:plotArea/c:{$chartType}Chart";
-            $this->assertTrue($doc->elementExists($path, $file));
-        }
-    }
+    // testChartElements moved to Writer/Word2007/Element/ChartTest
 
     public function testFieldElement()
     {
@@ -354,27 +328,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(' MACROBUTTON Zoom100 double click to zoom ', $doc->getElement($element)->textContent);
     }
 
-    /**
-     * Test form fields
-     */
-    public function testFormFieldElements()
-    {
-        $phpWord = new PhpWord();
-        $section = $phpWord->addSection();
-
-        $section->addFormField('textinput')->setName('MyTextBox');
-        $section->addFormField('checkbox')->setDefault(true)->setValue('Your name');
-        $section->addFormField('checkbox')->setDefault(true);
-        $section->addFormField('dropdown')->setEntries(array('Choice 1', 'Choice 2', 'Choice 3'));
-
-        $doc = TestHelperDOCX::getDocument($phpWord);
-
-        $path = '/w:document/w:body/w:p[%d]/w:r/w:fldChar/w:ffData';
-        $this->assertTrue($doc->elementExists(sprintf($path, 1) . '/w:textInput'));
-        $this->assertTrue($doc->elementExists(sprintf($path, 2) . '/w:checkBox'));
-        $this->assertTrue($doc->elementExists(sprintf($path, 3) . '/w:checkBox'));
-        $this->assertTrue($doc->elementExists(sprintf($path, 4) . '/w:ddList'));
-    }
+    // testFormFieldElements moved to Writer/Word2007/Element/FormFieldTest
 
     /**
      * Test SDT elements

--- a/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
+++ b/tests/PhpWord/Writer/Word2007/Part/SettingsTest.php
@@ -67,6 +67,8 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $phpWord->getSettings()->getDocumentProtection()->setSalt(base64_decode('uq81pJRRGFIY5U+E9gt8tA=='));
         $phpWord->getSettings()->getDocumentProtection()->setAlgorithm(PasswordEncoder::ALGORITHM_MD2);
         $phpWord->getSettings()->getDocumentProtection()->setSpinCount(10);
+        $sect = $phpWord->addSection();
+        $sect->addText('This is a protected document');
 
         $doc = TestHelperDOCX::getDocument($phpWord);
 
@@ -75,6 +77,31 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $path = '/w:settings/w:documentProtection';
         $this->assertTrue($doc->elementExists($path, $file));
         $this->assertEquals('rUuJbk6LuN2/qFyp7IUPQA==', $doc->getElement($path, $file)->getAttribute('w:hash'));
+        $this->assertEquals('1', $doc->getElement($path, $file)->getAttribute('w:cryptAlgorithmSid'));
+        $this->assertEquals('10', $doc->getElement($path, $file)->getAttribute('w:cryptSpinCount'));
+    }
+
+    /**
+     * Test document protection with password without setting salt
+     */
+    public function testDocumentProtectionWithPasswordNoSalt()
+    {
+        $phpWord = new PhpWord();
+        $phpWord->getSettings()->getDocumentProtection()->setEditing('readOnly');
+        $phpWord->getSettings()->getDocumentProtection()->setPassword('testÄö@€!$&');
+        //$phpWord->getSettings()->getDocumentProtection()->setSalt(base64_decode('uq81pJRRGFIY5U+E9gt8tA=='));
+        $phpWord->getSettings()->getDocumentProtection()->setAlgorithm(PasswordEncoder::ALGORITHM_MD2);
+        $phpWord->getSettings()->getDocumentProtection()->setSpinCount(10);
+        $sect = $phpWord->addSection();
+        $sect->addText('This is a protected document');
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $file = 'word/settings.xml';
+
+        $path = '/w:settings/w:documentProtection';
+        $this->assertTrue($doc->elementExists($path, $file));
+        //$this->assertEquals('rUuJbk6LuN2/qFyp7IUPQA==', $doc->getElement($path, $file)->getAttribute('w:hash'));
         $this->assertEquals('1', $doc->getElement($path, $file)->getAttribute('w:cryptAlgorithmSid'));
         $this->assertEquals('10', $doc->getElement($path, $file)->getAttribute('w:cryptSpinCount'));
     }

--- a/tests/PhpWord/Writer/Word2007/Style/ImageTest.php
+++ b/tests/PhpWord/Writer/Word2007/Style/ImageTest.php
@@ -54,6 +54,42 @@ class ImageTest extends \PHPUnit\Framework\TestCase
         $section->addImage(__DIR__ . '/../../../_files/images/earth.jpg', $styles);
         $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
 
+        $path = '/w:document/w:body/w:p[1]/w:r/w:rPr/w:position';
+        $this->assertFalse($doc->elementExists($path));
+        $path = '/w:document/w:body/w:p[1]/w:r/w:pict/v:shape';
+        $this->assertTrue($doc->elementExists($path . '/w10:wrap'));
+        $this->assertEquals('inline', $doc->getElementAttribute($path . '/w10:wrap', 'type'));
+
+        $this->assertTrue($doc->elementExists($path));
+        $style = $doc->getElement($path)->getAttribute('style');
+        $this->assertNotNull($style);
+        $this->assertContains('mso-wrap-distance-left:10pt;', $style);
+        $this->assertContains('mso-wrap-distance-right:20pt;', $style);
+        $this->assertContains('mso-wrap-distance-top:30pt;', $style);
+        $this->assertContains('mso-wrap-distance-bottom:40pt;', $style);
+    }
+
+    /**
+     * Test writing image wrapping
+     */
+    public function testWrappingWithPosition()
+    {
+        $styles = array(
+            'wrap'               => Image::WRAP_INLINE,
+            'wrapDistanceLeft'   => 10,
+            'wrapDistanceRight'  => 20,
+            'wrapDistanceTop'    => 30,
+            'wrapDistanceBottom' => 40,
+            'position'           => 10,
+        );
+
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $section->addImage(__DIR__ . '/../../../_files/images/earth.jpg', $styles);
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $path = '/w:document/w:body/w:p[1]/w:r/w:rPr/w:position';
+        $this->assertEquals('10', $doc->getElement($path)->getAttribute('w:val'));
         $path = '/w:document/w:body/w:p[1]/w:r/w:pict/v:shape';
         $this->assertTrue($doc->elementExists($path . '/w10:wrap'));
         $this->assertEquals('inline', $doc->getElementAttribute($path . '/w10:wrap', 'type'));

--- a/tests/PhpWord/Writer/Word2007/Style/SectionTest.php
+++ b/tests/PhpWord/Writer/Word2007/Style/SectionTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ * @copyright   2010-2018 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\Word2007\Style;
+
+use PhpOffice\PhpWord\Settings;
+use PhpOffice\PhpWord\TestHelperDOCX;
+
+/**
+ * Test class for PhpOffice\PhpWord\Writer\Word2007\Style\Section
+ *
+ * @coversDefaultClass \PhpOffice\PhpWord\Writer\Word2007\Style\Section
+ * @runTestsInSeparateProcesses
+ */
+class SectionTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Executed before each method of the class
+     */
+    public function tearDown()
+    {
+        TestHelperDOCX::clear();
+    }
+
+    public function testMarginInInches()
+    {
+        $unit = Settings::getMeasurementUnit();
+        Settings::setMeasurementUnit(\PhpOffice\PhpWord\Settings::UNIT_INCH);
+
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $section->getStyle()->setMarginTop(0.1)->setMarginBottom(0.4)->setMarginLeft(0.2)->setMarginRight(0.3);
+        $section->addText('test');
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        Settings::setMeasurementUnit($unit);
+
+        $path = '/w:document/w:body/w:sectPr/w:pgMar';
+        $this->assertEquals('144', $doc->getElementAttribute($path, 'w:top'));
+        $this->assertEquals('432', $doc->getElementAttribute($path, 'w:right'));
+        $this->assertEquals('576', $doc->getElementAttribute($path, 'w:bottom'));
+        $this->assertEquals('288', $doc->getElementAttribute($path, 'w:left'));
+    }
+}

--- a/tests/PhpWord/_includes/AbstractWebServerEmbeddedTest.php
+++ b/tests/PhpWord/_includes/AbstractWebServerEmbeddedTest.php
@@ -26,7 +26,26 @@ abstract class AbstractWebServerEmbeddedTest extends \PHPUnit\Framework\TestCase
     public static function setUpBeforeClass()
     {
         if (self::isBuiltinServerSupported()) {
-            self::$httpServer = new Process('php -S localhost:8080 -t tests/PhpWord/_files');
+            $commandLine = 'php -S localhost:8080 -t tests/PhpWord/_files';
+
+            /*
+             * Make sure to invoke \Symfony\Component\Process\Process correctly
+             * regardless of PHP version used.
+             *
+             * In Process version >= 5 / PHP >= 7.2.5, the constructor requires
+             * an array, while in version < 3.3 / PHP < 5.5.9 it requires a string.
+             * In between, it can accept both.
+             *
+             * Process::fromShellCommandLine() was introduced in version 4.2.0,
+             * to enable recent versions of Process to parse a command string,
+             * so if it is not available it means it is still possible to pass
+             * a string to the constructor.
+             */
+            if (method_exists('Symfony\Component\Process\Process', 'fromShellCommandLine')) {
+                self::$httpServer = Process::fromShellCommandline($commandLine);
+            } else {
+                self::$httpServer = new Process($commandLine);
+            }
             self::$httpServer->start();
             while (!self::$httpServer->isRunning()) {
                 usleep(1000);

--- a/tests/PhpWord/_includes/TestHelperDOCX.php
+++ b/tests/PhpWord/_includes/TestHelperDOCX.php
@@ -63,7 +63,12 @@ class TestHelperDOCX
             $zip->close();
         }
 
-        return new XmlDocument(Settings::getTempDir() . '/PhpWord_Unit_Test/');
+        $doc = new XmlDocument(Settings::getTempDir() . '/PhpWord_Unit_Test/');
+        if ($writerName === 'ODText') {
+            $doc->setDefaultFile('content.xml');
+        }
+
+        return $doc;
     }
 
     /**

--- a/tests/PhpWord/_includes/XmlDocument.php
+++ b/tests/PhpWord/_includes/XmlDocument.php
@@ -51,6 +51,37 @@ class XmlDocument
     private $file;
 
     /**
+     * Default file name
+     *
+     * @var string
+     */
+    private $defaultFile = 'word/document.xml';
+
+    /**
+     * Get default file
+     *
+     * @return string
+     */
+    public function getDefaultFile()
+    {
+        return $this->defaultFile;
+    }
+
+    /**
+     * Set default file
+     *
+     * @param string $file
+     * @return string
+     */
+    public function setDefaultFile($file)
+    {
+        $temp = $this->defaultFile;
+        $this->defaultFile = $file;
+
+        return $temp;
+    }
+
+    /**
      * Create new instance
      *
      * @param string $path
@@ -66,8 +97,11 @@ class XmlDocument
      * @param string $file
      * @return \DOMDocument
      */
-    public function getFileDom($file = 'word/document.xml')
+    public function getFileDom($file = '')
     {
+        if (!$file) {
+            $file = $this->defaultFile;
+        }
         if (null !== $this->dom && $file === $this->file) {
             return $this->dom;
         }
@@ -91,8 +125,11 @@ class XmlDocument
      * @param string $file
      * @return \DOMNodeList
      */
-    public function getNodeList($path, $file = 'word/document.xml')
+    public function getNodeList($path, $file = '')
     {
+        if (!$file) {
+            $file = $this->defaultFile;
+        }
         if (null === $this->dom || $file !== $this->file) {
             $this->getFileDom($file);
         }
@@ -112,8 +149,11 @@ class XmlDocument
      * @param string $file
      * @return \DOMElement
      */
-    public function getElement($path, $file = 'word/document.xml')
+    public function getElement($path, $file = '')
     {
+        if (!$file) {
+            $file = $this->defaultFile;
+        }
         $elements = $this->getNodeList($path, $file);
 
         return $elements->item(0);
@@ -147,8 +187,12 @@ class XmlDocument
      * @param   string  $file
      * @return  string
      */
-    public function getElementAttribute($path, $attribute, $file = 'word/document.xml')
+    public function getElementAttribute($path, $attribute, $file = '')
     {
+        if (!$file) {
+            $file = $this->defaultFile;
+        }
+
         return $this->getElement($path, $file)->getAttribute($attribute);
     }
 
@@ -159,8 +203,11 @@ class XmlDocument
      * @param   string  $file
      * @return  string
      */
-    public function elementExists($path, $file = 'word/document.xml')
+    public function elementExists($path, $file = '')
     {
+        if (!$file) {
+            $file = $this->defaultFile;
+        }
         $nodeList = $this->getNodeList($path, $file);
 
         return $nodeList->length != 0;
@@ -173,8 +220,11 @@ class XmlDocument
      * @param string $file
      * @return string
      */
-    public function printXml($path = '/', $file = 'word/document.xml')
+    public function printXml($path = '/', $file = '')
     {
+        if (!$file) {
+            $file = $this->defaultFile;
+        }
         $element = $this->getElement($path, $file);
         if ($element instanceof \DOMDocument) {
             $element->formatOutput = true;


### PR DESCRIPTION
### Description

After this change, Writer/Word2007 is 100% covered.
One source change is required. Writer/Word2007/Style/AbstractStyle
has incorrectly searched Measurement Array using
in_array (which searches values) rather than array_key_exists (keys).
There was no test for this, and now there is.

3 changes in tests/PhpWord/_includes are borrowed from "ODT Changes"
(pull request 1796, not yet merged)
and "Fix PHPUnit Tests" (pull request 1771,
merged after work on this change was started).

Writer/Word2007/ElementTest was becoming too unwieldy. Tests for
Chart and FormFields were moved to their own members.

Fixes # (issue)

### Checklist:

- [X] I have run `composer run-script check --timeout=0` and no errors were reported
- [X] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
