### PR TITLE
Read nested table

### DIFF
--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -364,6 +364,9 @@ abstract class AbstractPart
                             if ('w:p' == $cellNode->nodeName) { // Paragraph
                                 $this->readParagraph($xmlReader, $cellNode, $cell, $docPart);
                             }
+                            if ($cellNode->nodeName == 'w:tbl') { // Table
+                                $this->readTable($xmlReader, $cellNode, $cell, $docPart);
+                            }
                         }
                     }
                 }

--- a/tests/PhpWord/Reader/Word2007/ElementTest.php
+++ b/tests/PhpWord/Reader/Word2007/ElementTest.php
@@ -272,4 +272,36 @@ class ElementTest extends AbstractTestReader
         $elements = $phpWord->getSection(0)->getElements();
         $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
     }
+
+    /**
+     * Test reading of nested table
+     */
+    public function testReadNestedTable()
+    {
+        $documentXml = '<w:tbl>
+          <w:tr>
+            <w:tc>
+              <w:tbl>
+                <w:tr>
+                  <w:tc>
+                    <w:p>
+                      <w:t>${Field}</w:t>
+                    </w:p>
+                  </w:tc>
+                </w:tr>
+              </w:tbl>
+              <w:p />
+            </w:tc>
+          </w:tr>
+        </w:tbl>';
+
+        $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
+
+        $section = $phpWord->getSection(0);
+        $table = $section->getElement(0);
+        $rows = $table->getRows();
+        $cells = $rows[0]->getCells();
+        $nestedTable = $cells[0]->getElement(0);
+        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Table', $nestedTable);
+    }
 }


### PR DESCRIPTION
### Description
Because tables are commonly used for structural formatting purposes, it is possible for a table to exist inside another table's cell.  This change will, while iterating table cells, check for a nested table and, if one exists, to call readTable.  This is expected behavior - no documentation changes needed.

Fixes # (issue) 571

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
