### PR TITLE
Fix example for cloneRowAndSetValues

### DIFF
--- a/docs/templates-processing.rst
+++ b/docs/templates-processing.rst
@@ -190,7 +190,7 @@ Finds a row in a table row identified by `$search` param and clones it as many t
         ['userId' => 1, 'userName' => 'Batman', 'userAddress' => 'Gotham City'],
         ['userId' => 2, 'userName' => 'Superman', 'userAddress' => 'Metropolis'],
     ];
-    $templateProcessor->cloneRowAndSetValues('userId', );
+    $templateProcessor->cloneRowAndSetValues('userId', $values);
 
 Will result in
 


### PR DESCRIPTION


### Description

Added a fix for missing parameter to the cloneRowAndSetValues function call in its example.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
