### PR TITLE
Unused variables $rows, $cols

### DIFF
--- a/samples/Sample_09_Tables.php
+++ b/samples/Sample_09_Tables.php
@@ -17,9 +17,9 @@ $cols = 5;
 $section->addText('Basic table', $header);
 
 $table = $section->addTable();
-for ($r = 1; $r <= 8; $r++) {
+for ($r = 1; $r <= $rows; $r++) {
     $table->addRow();
-    for ($c = 1; $c <= 5; $c++) {
+    for ($c = 1; $c <= $cols; $c++) {
         $table->addCell(1750)->addText("Row {$r}, Cell {$c}");
     }
 }


### PR DESCRIPTION
Columns are hardcoded in the basic table loop instead of using the predefined $rows and $cols variables

### Description

Columns are hardcoded in the basic table loop instead of using the predefined $rows and $cols variables

Fixes # (issue)

### Checklist:

- [ x ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ x ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ x ] I have updated the documentation to describe the changes
