### PR TITLE
Enhancements to addHTML parser

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -682,10 +682,14 @@ class Html
                         } else {
                             $which = '';
                         }
-                        // normalization: in HTML 1px means tinest possible line width, so we cannot convert 1px -> 15 twips, coz line'd be bold, we use smallest twip instead
-                        $size = strtolower(trim($matches[1]));
-                        // BC change: up to ver. 0.17.0 incorrectly converted to points - Converter::cssToPoint($size)
-                        $size = ($size == '1px') ? 1 : Converter::cssToTwip($size);
+                        // Note - border width normalization:
+                        // Width of border in Word is calculated differently than HTML borders, usually showing up too bold.
+                        // Smallest 1px (or 1pt) appears in Word like 2-3px/pt in HTML once converted to twips.
+                        // Therefore we need to normalize converted twip value to cca 1/2 of value.
+                        // This may be adjusted, if better ratio or formula found.
+                        // BC change: up to ver. 0.17.0 was $size converted to points - Converter::cssToPoint($size)
+                        $size = Converter::cssToTwip($matches[1]);
+                        $size = intval($size / 2);
                         // valid variants may be e.g. borderSize, borderTopSize, borderLeftColor, etc ..
                         $styles["border{$which}Size"] = $size; // twips
                         $styles["border{$which}Color"] = trim($matches[2], '#');
@@ -884,10 +888,10 @@ class Html
             case 'baseline':
                 return 'top';
             default:
-            	// @discuss - which one should apply:
-            	// - Word uses default vert. alignment: top
-            	// - all browsers use default vert. alignment: middle
-            	// Returning empty string means attribute wont be set so use Word default (top).
+                // @discuss - which one should apply:
+                // - Word uses default vert. alignment: top
+                // - all browsers use default vert. alignment: middle
+                // Returning empty string means attribute wont be set so use Word default (top).
                 return '';
         }
     }

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -109,11 +109,11 @@ class Html
                         break;
                     case 'width':
                         // tables, cells
-                        if(false !== strpos($val, '%')){
-                            // e.g. <table width="100%"> or <td width=50%>
+                        if (false !== strpos($val, '%')) {
+                            // e.g. <table width="100%"> or <td width="50%">
                             $styles['width'] = intval($val) * 50;
                             $styles['unit'] = \PhpOffice\PhpWord\SimpleType\TblWidth::PERCENT;
-                        }else{
+                        } else {
                             // e.g. <table width="250> where "250" = 250px (always pixels)
                             $styles['width'] = Converter::pixelToTwip($val);
                             $styles['unit'] = \PhpOffice\PhpWord\SimpleType\TblWidth::TWIP;
@@ -472,10 +472,10 @@ class Html
             $levels = $style->getLevels();
             /** @var \PhpOffice\PhpWord\Style\NumberingLevel */
             $level = $levels[0];
-            if($start > 0){
+            if ($start > 0) {
                 $level->setStart($start);
             }
-            if($type && !!($type = self::mapListType($type))){
+            if ($type && !!($type = self::mapListType($type))) {
                 $level->setFormat($type);
             }
         }
@@ -675,10 +675,10 @@ class Html
                     // must have exact order [width color style], e.g. "1px #0011CC solid" or "2pt green solid"
                     // Word does not accept shortened hex colors e.g. #CCC, only full e.g. #CCCCCC
                     if (preg_match('/([0-9]+[^0-9]*)\s+(\#[a-fA-F0-9]+|[a-zA-Z]+)\s+([a-z]+)/', $cValue, $matches)) {
-                        if(false !== strpos($cKey, '-')){
+                        if (false !== strpos($cKey, '-')) {
                             $which = explode('-', $cKey)[1];
                             $which = ucfirst($which); // e.g. bottom -> Bottom
-                        }else{
+                        } else {
                             $which = '';
                         }
                         // normalization: in HTML 1px means tinest possible line width, so we cannot convert 1px -> 15 twips, coz line'd be bold, we use smallest twip instead
@@ -883,6 +883,10 @@ class Html
             case 'baseline':
                 return 'top';
             default:
+            	// @discuss - which one should apply:
+            	// - Word uses default vert. alignment: top
+            	// - all browsers use default vert. alignment: middle
+            	// Returning empty string means attribute wont be set so use Word default (top).
                 return '';
         }
     }

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -96,7 +96,7 @@ class Html
             $attributes = $node->attributes; // get all the attributes(eg: id, class)
 
             foreach ($attributes as $attribute) {
-                switch ($attribute->name) {
+                switch (strtolower($attribute->name)) {
                     case 'style':
                         $styles = self::parseStyle($attribute, $styles);
                         break;
@@ -118,6 +118,15 @@ class Html
                             $styles['width'] = Converter::pixelToTwip($val);
                             $styles['unit'] = \PhpOffice\PhpWord\SimpleType\TblWidth::TWIP;
                         }
+                        break;
+                    case 'cellspacing':
+                        // tables e.g. <table cellspacing="2">,  where "2" = 2px (always pixels)
+                        $val = intval($attribute->value).'px';
+                        $styles['cellSpacing'] = Converter::cssToTwip($val);
+                        break;
+                    case 'bgcolor':
+                        // tables, rows, cells e.g. <tr bgColor="#FF0000">
+                        $styles['bgColor'] = trim($attribute->value, '# ');
                         break;
                 }
             }
@@ -519,7 +528,8 @@ class Html
         foreach ($properties as $property) {
             list($cKey, $cValue) = array_pad(explode(':', $property, 2), 2, null);
             $cValue = trim($cValue);
-            switch (trim($cKey)) {
+            $cKey = strtolower(trim($cKey));
+            switch ($cKey) {
                 case 'text-decoration':
                     switch ($cValue) {
                         case 'underline':

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -633,11 +633,18 @@ class Html
                     }
                     $styles['italic'] = $tValue;
                     break;
+                case 'margin':
+                    $cValue = Converter::cssToTwip($cValue);
+                    $styles['spaceBefore'] = $cValue;
+                    $styles['spaceAfter'] = $cValue;
+                    break;
                 case 'margin-top':
-                    $styles['spaceBefore'] = Converter::cssToPoint($cValue);
+                    // BC change: up to ver. 0.17.0 incorrectly converted to points - Converter::cssToPoint($cValue)
+                    $styles['spaceBefore'] = Converter::cssToTwip($cValue);
                     break;
                 case 'margin-bottom':
-                    $styles['spaceAfter'] = Converter::cssToPoint($cValue);
+                    // BC change: up to ver. 0.17.0 incorrectly converted to points - Converter::cssToPoint($cValue)
+                    $styles['spaceAfter'] = Converter::cssToTwip($cValue);
                     break;
                 case 'border-color':
                     self::mapBorderColor($styles, $cValue);
@@ -676,7 +683,7 @@ class Html
                         }
                         // normalization: in HTML 1px means tinest possible line width, so we cannot convert 1px -> 15 twips, coz line'd be bold, we use smallest twip instead
                         $size = strtolower(trim($matches[1]));
-                        // (!) BC change: up to ver. 0.17.0 Converter was incorrectly converting to points - Converter::cssToPoint($matches[1])
+                        // BC change: up to ver. 0.17.0 incorrectly converted to points - Converter::cssToPoint($size)
                         $size = ($size == '1px') ? 1 : Converter::cssToTwip($size);
                         // valid variants may be e.g. borderSize, borderTopSize, borderLeftColor, etc ..
                         $styles["border{$which}Size"] = $size; // twips
@@ -732,14 +739,14 @@ class Html
                                 case 'float':
                                     if (trim($v) == 'right') {
                                         $style['hPos'] = \PhpOffice\PhpWord\Style\Image::POS_RIGHT;
-                                        $style['hPosRelTo'] = \PhpOffice\PhpWord\Style\Image::POS_RELTO_PAGE;
+                                        $style['hPosRelTo'] = \PhpOffice\PhpWord\Style\Image::POS_RELTO_MARGIN; // inner section area
                                         $style['pos'] = \PhpOffice\PhpWord\Style\Image::POS_RELATIVE;
                                         $style['wrap'] = \PhpOffice\PhpWord\Style\Image::WRAP_TIGHT;
                                         $style['overlap'] = true;
                                     }
                                     if (trim($v) == 'left') {
                                         $style['hPos'] = \PhpOffice\PhpWord\Style\Image::POS_LEFT;
-                                        $style['hPosRelTo'] = \PhpOffice\PhpWord\Style\Image::POS_RELTO_PAGE;
+                                        $style['hPosRelTo'] = \PhpOffice\PhpWord\Style\Image::POS_RELTO_MARGIN; // inner section area
                                         $style['pos'] = \PhpOffice\PhpWord\Style\Image::POS_RELATIVE;
                                         $style['wrap'] = \PhpOffice\PhpWord\Style\Image::WRAP_TIGHT;
                                         $style['overlap'] = true;

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -987,5 +987,4 @@ class Html
         // - line - that is a shape, has different behaviour
         // - repeated text, e.g. underline "_", because of unpredictable line wrapping
     }
-
 }

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -106,6 +106,19 @@ class Html
                     case 'lang':
                         $styles['lang'] = $attribute->value;
                         break;
+                    case 'width':
+                        // tables, cells
+                        $val = trim($attribute->value);
+                        if(false !== strpos($val, '%')){
+                            // e.g. <table width="100%"> or <td width=50%>
+                            $styles['width'] = intval($val) * 50;
+                            $styles['unit'] = \PhpOffice\PhpWord\SimpleType\TblWidth::PERCENT;
+                        }else{
+                            // e.g. <table width="250> where "250" = 250px (always pixels)
+                            $styles['width'] = Converter::pixelToTwip($val);
+                            $styles['unit'] = \PhpOffice\PhpWord\SimpleType\TblWidth::TWIP;
+                        }
+                        break;
                 }
             }
         }
@@ -361,7 +374,11 @@ class Html
         if (!empty($colspan)) {
             $cellStyles['gridSpan'] = $colspan - 0;
         }
-        $cell = $element->addCell(null, $cellStyles);
+
+        // set cell width to control column widths
+        $width = isset($cellStyles['width']) ? $cellStyles['width'] : null;
+        unset($cellStyles['width']); // would not apply
+        $cell = $element->addCell($width, $cellStyles);
 
         if (self::shouldAddTextRun($node)) {
             return $cell->addTextRun(self::parseInlineStyle($node, $styles['paragraph']));

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -62,10 +62,10 @@ class Html
         // Preprocess: remove all line ends, decode HTML entity,
         // fix ampersand and angle brackets and add body tag for HTML fragments
         $html = str_replace(array("\n", "\r"), '', $html);
-        $html = str_replace(array('&lt;', '&gt;', '&amp;'), array('_lt_', '_gt_', '_amp_'), $html);
+        $html = str_replace(array('&lt;', '&gt;', '&amp;', '&quot;'), array('_lt_', '_gt_', '_amp_', '_quot_'), $html);
         $html = html_entity_decode($html, ENT_QUOTES, 'UTF-8');
         $html = str_replace('&', '&amp;', $html);
-        $html = str_replace(array('_lt_', '_gt_', '_amp_'), array('&lt;', '&gt;', '&amp;'), $html);
+        $html = str_replace(array('_lt_', '_gt_', '_amp_', '_quot_'), array('&lt;', '&gt;', '&amp;', '&quot;'), $html);
 
         if (false === $fullHTML) {
             $html = '<body>' . $html . '</body>';

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -96,13 +96,13 @@ class Html
             $attributes = $node->attributes; // get all the attributes(eg: id, class)
 
             foreach ($attributes as $attribute) {
-                $val = trim($attribute->value);
+                $val = $attribute->value;
                 switch (strtolower($attribute->name)) {
                     case 'style':
                         $styles = self::parseStyle($attribute, $styles);
                         break;
                     case 'align':
-                        $styles['alignment'] = self::mapAlign($val);
+                        $styles['alignment'] = self::mapAlign(trim($val));
                         break;
                     case 'lang':
                         $styles['lang'] = $val;
@@ -121,7 +121,7 @@ class Html
                         break;
                     case 'cellspacing':
                         // tables e.g. <table cellspacing="2">,  where "2" = 2px (always pixels)
-                        $val = intval($attribute->value).'px';
+                        $val = intval($val).'px';
                         $styles['cellSpacing'] = Converter::cssToTwip($val);
                         break;
                     case 'bgcolor':
@@ -475,7 +475,8 @@ class Html
             if ($start > 0) {
                 $level->setStart($start);
             }
-            if ($type && !!($type = self::mapListType($type))) {
+            $type = $type ? self::mapListType($type) : null;
+            if ($type) {
                 $level->setFormat($type);
             }
         }

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -774,7 +774,7 @@ HTML;
         $xpath = '/w:document/w:body/w:p[4]/w:pPr/w:pBdr/w:bottom';
         $this->assertTrue($doc->elementExists($xpath));
         $this->assertEquals('single', $doc->getElement($xpath)->getAttribute('w:val'));
-        $this->assertEquals(5 * 15, $doc->getElement($xpath)->getAttribute('w:sz'));
+        $this->assertEquals(intval(5 * 15 / 2), $doc->getElement($xpath)->getAttribute('w:sz'));
         $this->assertEquals('lightblue', $doc->getElement($xpath)->getAttribute('w:color'));
 
         $xpath = '/w:document/w:body/w:p[4]/w:pPr/w:spacing';

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -784,4 +784,64 @@ HTML;
         $this->assertEquals(240, $doc->getElement($xpath)->getAttribute('w:line'));
     }
 
+    /**
+    * Parse ordered list start & numbering style
+    */
+    public function testParseOrderedList()
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+
+        // borders & backgrounds are here just for better visual comparison
+        $html = <<<HTML
+<ol>
+    <li>standard ordered list line 1</li>
+    <li>standard ordered list line 2</li>
+</ol>
+
+<ol start="5" type="A">
+    <li>ordered list alphabetical, <span style="background-color: #EEEEEE; color: #FF0000;">line 5 => E</span></li>
+    <li>ordered list alphabetical, <span style="background-color: #EEEEEE; color: #FF0000;">line 6 => F</span></li>
+</ol>
+
+<ol start="3" type="i">
+    <li>ordered list roman lower, line <b>3 => iii</b></li>
+    <li>ordered list roman lower, line <b>4 => iv</b></li>
+</ol>
+
+HTML;
+
+        Html::addHtml($section, $html);
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        // compare numbering file
+        $xmlFile = 'word/numbering.xml';
+
+        // default - decimal start = 1
+        $xpath = '/w:numbering/w:abstractNum[1]/w:lvl[1]/w:start';
+        $this->assertTrue($doc->elementExists($xpath, $xmlFile));
+        $this->assertEquals('1', $doc->getElement($xpath, $xmlFile)->getAttribute('w:val'));
+
+        $xpath = '/w:numbering/w:abstractNum[1]/w:lvl[1]/w:numFmt';
+        $this->assertTrue($doc->elementExists($xpath, $xmlFile));
+        $this->assertEquals('decimal', $doc->getElement($xpath, $xmlFile)->getAttribute('w:val'));
+
+        // second list - start = 5, type A = upperLetter
+        $xpath = '/w:numbering/w:abstractNum[2]/w:lvl[1]/w:start';
+        $this->assertTrue($doc->elementExists($xpath, $xmlFile));
+        $this->assertEquals('5', $doc->getElement($xpath, $xmlFile)->getAttribute('w:val'));
+
+        $xpath = '/w:numbering/w:abstractNum[2]/w:lvl[1]/w:numFmt';
+        $this->assertTrue($doc->elementExists($xpath, $xmlFile));
+        $this->assertEquals('upperLetter', $doc->getElement($xpath, $xmlFile)->getAttribute('w:val'));
+
+        // third list - start = 3, type i = lowerRoman
+        $xpath = '/w:numbering/w:abstractNum[3]/w:lvl[1]/w:start';
+        $this->assertTrue($doc->elementExists($xpath, $xmlFile));
+        $this->assertEquals('3', $doc->getElement($xpath, $xmlFile)->getAttribute('w:val'));
+
+        $xpath = '/w:numbering/w:abstractNum[3]/w:lvl[1]/w:numFmt';
+        $this->assertTrue($doc->elementExists($xpath, $xmlFile));
+        $this->assertEquals('lowerRoman', $doc->getElement($xpath, $xmlFile)->getAttribute('w:val'));
+    }
 }

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -884,4 +884,22 @@ HTML;
         $this->assertTrue($doc->elementExists($xpath));
         $this->assertEquals('bottom', $doc->getElement($xpath)->getAttribute('w:val'));
     }
+
+    /**
+    * Fix bug - don't decode double quotes inside double quoted string
+    */
+    public function testDontDecodeAlreadyEncodedDoubleQuotes()
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+
+        // borders & backgrounds are here just for better visual comparison
+        $html = <<<HTML
+<div style="font-family: Arial, &quot;Helvetice Neue&quot;">This would crash if inline quotes also decoded at loading XML into DOMDocument!</div>
+HTML;
+
+        Html::addHtml($section, $html);
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        $this->assertTrue(is_object($doc));
+    }
 }

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -702,4 +702,46 @@ HTML;
         $this->assertEquals('dxa', $doc->getElement($xpath)->getAttribute('w:type'));
     }
 
+    public function testParseCellspacingRowBgColor()
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection([
+            'orientation' => \PhpOffice\PhpWord\Style\Section::ORIENTATION_LANDSCAPE,
+        ]);
+
+        // borders & backgrounds are here just for better visual comparison
+        $html = <<<HTML
+<table cellspacing="3" bgColor="lightgreen" width="50%" align="center">
+    <tr>
+        <td>A</td>
+        <td>B</td>
+    </tr>
+    <tr bgcolor="#FF0000">
+        <td>C</td>
+        <td>D</td>
+    </tr>
+</table>
+HTML;
+
+        Html::addHtml($section, $html);
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        // uncomment to see results
+        file_put_contents('./table_src.html', $html);
+        file_put_contents('./table_result_'.time().'.docx', file_get_contents( TestHelperDOCX::getFile() ) );
+
+        $xpath = '/w:document/w:body/w:tbl/w:tblPr/w:tblCellSpacing';
+        $this->assertTrue($doc->elementExists($xpath));
+        $this->assertEquals(3 * 15, $doc->getElement($xpath)->getAttribute('w:w'));
+        $this->assertEquals('dxa', $doc->getElement($xpath)->getAttribute('w:type'));
+
+        $xpath = '/w:document/w:body/w:tbl/w:tr[1]/w:tc[1]/w:tcPr/w:shd';
+        $this->assertTrue($doc->elementExists($xpath));
+        $this->assertEquals('lightgreen', $doc->getElement($xpath)->getAttribute('w:fill'));
+
+        $xpath = '/w:document/w:body/w:tbl/w:tr[2]/w:tc[1]/w:tcPr/w:shd';
+        $this->assertTrue($doc->elementExists($xpath));
+        $this->assertEquals('FF0000', $doc->getElement($xpath)->getAttribute('w:fill'));
+    }
+
 }

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -779,7 +779,7 @@ HTML;
 
         $xpath = '/w:document/w:body/w:p[4]/w:pPr/w:spacing';
         $this->assertTrue($doc->elementExists($xpath));
-        $this->assertEquals(22.5, $doc->getElement($xpath)->getAttribute('w:before'));
+        $this->assertEquals(450, $doc->getElement($xpath)->getAttribute('w:before'));
         $this->assertEquals(0, $doc->getElement($xpath)->getAttribute('w:after'));
         $this->assertEquals(240, $doc->getElement($xpath)->getAttribute('w:line'));
     }
@@ -868,10 +868,6 @@ HTML;
 
         Html::addHtml($section, $html);
         $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
-
-        // uncomment to see results
-        file_put_contents('./table_src.html', $html);
-        file_put_contents('./table_result_'.time().'.docx', file_get_contents( TestHelperDOCX::getFile() ) );
 
         $xpath = '/w:document/w:body/w:tbl/w:tr/w:tc[1]/w:tcPr/w:vAlign';
         $this->assertFalse($doc->elementExists($xpath));

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -844,4 +844,48 @@ HTML;
         $this->assertTrue($doc->elementExists($xpath, $xmlFile));
         $this->assertEquals('lowerRoman', $doc->getElement($xpath, $xmlFile)->getAttribute('w:val'));
     }
+
+    /**
+    * Parse ordered list start & numbering style
+    */
+    public function testParseVerticalAlign()
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+
+        // borders & backgrounds are here just for better visual comparison
+        $html = <<<HTML
+<table width="100%">
+    <tr>
+        <td width="20%" style="border: 1px #666666 solid;">default</td>
+        <td width="20%" style="vertical-align: top; border: 1px #666666 solid;">top</td>
+        <td width="20%" style="vertical-align: middle; border: 1px #666666 solid;">middle</td>
+        <td width="20%" valign="bottom" style="border: 1px #666666 solid;">bottom</td>
+        <td bgcolor="#DDDDDD"><br/><br/><br/><br/><br/><br/><br/></td>
+    </tr>
+</table>
+HTML;
+
+        Html::addHtml($section, $html);
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        // uncomment to see results
+        file_put_contents('./table_src.html', $html);
+        file_put_contents('./table_result_'.time().'.docx', file_get_contents( TestHelperDOCX::getFile() ) );
+
+        $xpath = '/w:document/w:body/w:tbl/w:tr/w:tc[1]/w:tcPr/w:vAlign';
+        $this->assertFalse($doc->elementExists($xpath));
+
+        $xpath = '/w:document/w:body/w:tbl/w:tr/w:tc[2]/w:tcPr/w:vAlign';
+        $this->assertTrue($doc->elementExists($xpath));
+        $this->assertEquals('top', $doc->getElement($xpath)->getAttribute('w:val'));
+
+        $xpath = '/w:document/w:body/w:tbl/w:tr/w:tc[3]/w:tcPr/w:vAlign';
+        $this->assertTrue($doc->elementExists($xpath));
+        $this->assertEquals('center', $doc->getElement($xpath)->getAttribute('w:val'));
+
+        $xpath = '/w:document/w:body/w:tbl/w:tr/w:tc[4]/w:tcPr/w:vAlign';
+        $this->assertTrue($doc->elementExists($xpath));
+        $this->assertEquals('bottom', $doc->getElement($xpath)->getAttribute('w:val'));
+    }
 }

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -702,6 +702,9 @@ HTML;
         $this->assertEquals('dxa', $doc->getElement($xpath)->getAttribute('w:type'));
     }
 
+    /**
+    * Test parsing background color for table rows and table cellspacing
+    */
     public function testParseCellspacingRowBgColor()
     {
         $phpWord = new \PhpOffice\PhpWord\PhpWord();
@@ -726,10 +729,6 @@ HTML;
         Html::addHtml($section, $html);
         $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
 
-        // uncomment to see results
-        file_put_contents('./table_src.html', $html);
-        file_put_contents('./table_result_'.time().'.docx', file_get_contents( TestHelperDOCX::getFile() ) );
-
         $xpath = '/w:document/w:body/w:tbl/w:tblPr/w:tblCellSpacing';
         $this->assertTrue($doc->elementExists($xpath));
         $this->assertEquals(3 * 15, $doc->getElement($xpath)->getAttribute('w:w'));
@@ -742,6 +741,47 @@ HTML;
         $xpath = '/w:document/w:body/w:tbl/w:tr[2]/w:tc[1]/w:tcPr/w:shd';
         $this->assertTrue($doc->elementExists($xpath));
         $this->assertEquals('FF0000', $doc->getElement($xpath)->getAttribute('w:fill'));
+    }
+
+    /**
+    * Parse horizontal rule
+    */
+    public function testParseHorizRule()
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+
+        // borders & backgrounds are here just for better visual comparison
+        $html = <<<HTML
+<p>Simple default rule:</p>
+<hr/>
+<p>Custom style rule:</p>
+<hr style="margin-top: 30px; margin-bottom: 0; border-bottom: 5px lightblue solid;" />
+<p>END</p>
+HTML;
+
+        Html::addHtml($section, $html);
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        // default rule
+        $xpath = '/w:document/w:body/w:p[2]/w:pPr/w:pBdr/w:bottom';
+        $this->assertTrue($doc->elementExists($xpath));
+        $this->assertEquals('single', $doc->getElement($xpath)->getAttribute('w:val')); // solid
+        $this->assertEquals('1', $doc->getElement($xpath)->getAttribute('w:sz')); // 1 twip
+        $this->assertEquals('000000', $doc->getElement($xpath)->getAttribute('w:color')); // black
+
+        // custom style rule
+        $xpath = '/w:document/w:body/w:p[4]/w:pPr/w:pBdr/w:bottom';
+        $this->assertTrue($doc->elementExists($xpath));
+        $this->assertEquals('single', $doc->getElement($xpath)->getAttribute('w:val'));
+        $this->assertEquals(5 * 15, $doc->getElement($xpath)->getAttribute('w:sz'));
+        $this->assertEquals('lightblue', $doc->getElement($xpath)->getAttribute('w:color'));
+
+        $xpath = '/w:document/w:body/w:p[4]/w:pPr/w:spacing';
+        $this->assertTrue($doc->elementExists($xpath));
+        $this->assertEquals(22.5, $doc->getElement($xpath)->getAttribute('w:before'));
+        $this->assertEquals(0, $doc->getElement($xpath)->getAttribute('w:after'));
+        $this->assertEquals(240, $doc->getElement($xpath)->getAttribute('w:line'));
     }
 
 }


### PR DESCRIPTION
### Description

Currently importing HTML via `PhpWord\Shared\Html::addHtml()` has couple of bugs and misses support for some at least basic HTML tags & attributes. This PR attempts to fix these issues without BC break (at least no existing unit test break):

### Fixed legacy issues:

* fix [passing](https://github.com/PHPOffice/PHPWord/blob/develop/src/PhpWord/Shared/Html.php#L364) `width` property into cells, allowing also to control colum widths inside tables. Following would currently not work `style="width: 35%"` - because width is passed as a wrong argument. Once fixed, it will also allow to control columns width inside tables. Since all widths are currently ignored (not recognized) they are set to `width = "auto"`.
* fix unit conversion for margins/spacing - instead of converting to [points](https://github.com/PHPOffice/PHPWord/blob/develop/src/PhpWord/Shared/Html.php#L588), it should convert to `twips`. Currently passing 10px results into 7.5 twips therefore value is seemingly ignored, unless users sets some absurd value like `width: 600px`. 

### New enhancements:

* support width also as an attribute e.g. `<td width="25%">`
* support cellspacing for tables e.g. `<table cellspacing="3">`
* support all `border-*` variants e.g. `border-bottom: 1px #DDDDDD solid;` (top, right, left, bottom) - useful for tables & cells
* support bgColor for rows, cells, e.g. `<tr bgColor="#DDDDDD">`
* support horiz. rule `<hr />` with limited custom styling
* support both inline vertical-align and valign for cells e.g. `<th valign="bottom">` or `style="vertical-align: middle;"`
* support start & numbering type in ordered lists e.g. `<ol type="A" start="3">`

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes

### More enhancements possible (with BC break)

A two more fixes should be fixed to make current method `addHtml()` more usable and compatible:

* fix `cell property inheritance` - currently all elements always inherit all properties from parent node. This however should not apply to cells. Cells should not inherit most of parent properties e.g. borders, margins etc. because it produces unexpected output. In spite of BC break this should be fixed ASAP. Current behaviour is quite incompatible with legacy HTML output. Moreover, inheriting widths from parent nodes causes unpredictable results in table layouts.
* add support for Headings `<h1> .. <h6>` out of the box. Current implementation relies that user will somewhere define his own heading style `Heading1`, `Heading2` etc., which adds extra code boilerplate for developers and also requires to study how to do that (increases learning curve). Since H1 .. H6 are very basic elements in any HTML, these should work out of the box.

Unfortunatelly, both improvements above will cause BC break, and therefore have been excluded from this PR in order to make space for discussion. 