### PR TITLE
Invalid characters passed for attempted conversion, these have been i…

### DIFF
--- a/src/PhpWord/Style/Shading.php
+++ b/src/PhpWord/Style/Shading.php
@@ -128,7 +128,7 @@ class Shading extends AbstractStyle
      */
     public function getFill()
     {
-        return $this->fill;
+        return $this->fill == "auto" ? null : $this->fill;
     }
 
     /**

--- a/src/PhpWord/Style/Shape.php
+++ b/src/PhpWord/Style/Shape.php
@@ -168,7 +168,7 @@ class Shape extends AbstractStyle
      */
     public function getFill()
     {
-        return $this->fill;
+        return $this->fill == "auto" ? null : $this->fill;
     }
 
     /**


### PR DESCRIPTION
…gnored

.docx generated from TemplateProcessor throws
"Invalid characters passed for attempted conversion, these have been ignored" when is converted in PDF. the error is propagated from $cellBgColor = $cellStyle->getBgColor() when hexdec(substr($cellBgColor... is evaluated in vendor/phpoffice/phpword/src/PhpWord/Writer/HTML/Element/Table.php

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
