### PR TITLE
Limit of setImageValue

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -585,6 +585,9 @@ class TemplateProcessor
                     return ($partVar == $searchString) || preg_match('/^' . preg_quote($searchString) . ':/', $partVar);
                 });
 
+                // Exclude multiple same variable name
+                $varsToReplace = array_unique($varsToReplace);
+
                 foreach ($varsToReplace as $varNameWithArgs) {
                     $varInlineArgs = $this->getImageArgs($varNameWithArgs);
                     $preparedImageAttrs = $this->prepareImageAttrs($replaceImage, $varInlineArgs);

--- a/tests/PhpWord/TemplateProcessorTest.php
+++ b/tests/PhpWord/TemplateProcessorTest.php
@@ -844,4 +844,82 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
         $templateProcessor->setUpdateFields(false);
         $this->assertContains('<w:updateFields w:val="false"/>', $templateProcessor->getSettingsPart());
     }
+
+    /**
+     * @covers ::setImageValue
+     * @test
+     */
+    public function testSetImageValueLimit()
+    {
+        $templateProcessor = new TemplateProcessor(__DIR__ . '/_files/templates/setImageValue-limit.docx');
+        $imagePath = __DIR__ . '/_files/images/earth.jpg';
+
+        $variablesReplace = array(
+                                'picture'   => array('path' => $imagePath, 'width' => 500, 'height' => 500),
+        );
+        $templateProcessor->setImageValue(array_keys($variablesReplace), $variablesReplace, 2);
+
+        $docName = 'setImageValue-limit-test-result.docx';
+        $templateProcessor->saveAs($docName);
+
+        $this->assertFileExists($docName, "Generated file '{$docName}' not found!");
+
+        $expectedDocumentZip = new \ZipArchive();
+        $expectedDocumentZip->open($docName);
+        $expectedContentTypesXml = $expectedDocumentZip->getFromName('[Content_Types].xml');
+        $expectedDocumentRelationsXml = $expectedDocumentZip->getFromName('word/_rels/document.xml.rels');
+        $expectedMainPartXml = $expectedDocumentZip->getFromName('word/document.xml');
+        $expectedImage = $expectedDocumentZip->getFromName('word/media/image_rId14_document.jpeg');
+        if (false === $expectedDocumentZip->close()) {
+            throw new \Exception("Could not close zip file \"{$docName}\".");
+        }
+
+        $this->assertNotEmpty($expectedImage, 'Embed image doesn\'t found.');
+        $this->assertContains('/word/media/image_rId14_document.jpeg', $expectedContentTypesXml, '[Content_Types].xml missed "/word/media/image5_document.jpeg"');
+    
+        $this->assertContains('${picture}', $expectedMainPartXml, 'word/document.xml has replace second item.');
+
+        $this->assertSame(1, substr_count($expectedMainPartXml, '${picture}'), 'word/document.xml only first item has been replaced.');
+        $this->assertContains('media/image_rId14_document.jpeg', $expectedDocumentRelationsXml, 'word/_rels/document.xml.rels missed "media/image5_document.jpeg"');
+
+        unlink($docName);
+    }
+
+    /**
+     * @covers ::setImageValue
+     * @test
+     */
+    public function testSetImageValueNoLimit()
+    {
+        $templateProcessor = new TemplateProcessor(__DIR__ . '/_files/templates/setImageValue-limit.docx');
+        $imagePath = __DIR__ . '/_files/images/earth.jpg';
+
+        $variablesReplace = array(
+            'picture'   => array('path' => $imagePath, 'width' => 500, 'height' => 500),
+        );
+        $templateProcessor->setImageValue(array_keys($variablesReplace), $variablesReplace);
+
+        $docName = 'setImageValue-limit-test-result.docx';
+        $templateProcessor->saveAs($docName);
+
+        $this->assertFileExists($docName, "Generated file '{$docName}' not found!");
+
+        $expectedDocumentZip = new \ZipArchive();
+        $expectedDocumentZip->open($docName);
+        $expectedContentTypesXml = $expectedDocumentZip->getFromName('[Content_Types].xml');
+        $expectedDocumentRelationsXml = $expectedDocumentZip->getFromName('word/_rels/document.xml.rels');
+        $expectedMainPartXml = $expectedDocumentZip->getFromName('word/document.xml');
+        $expectedImage = $expectedDocumentZip->getFromName('word/media/image_rId14_document.jpeg');
+        if (false === $expectedDocumentZip->close()) {
+            throw new \Exception("Could not close zip file \"{$docName}\".");
+        }
+
+        $this->assertNotEmpty($expectedImage, 'Embed image doesn\'t found.');
+        $this->assertContains('/word/media/image_rId14_document.jpeg', $expectedContentTypesXml, '[Content_Types].xml missed "/word/media/image5_document.jpeg"');
+
+        $this->assertNotContains('${picture}', $expectedMainPartXml, 'word/document.xml has replace second item.');
+        $this->assertContains('media/image_rId14_document.jpeg', $expectedDocumentRelationsXml, 'word/_rels/document.xml.rels missed "media/image5_document.jpeg"');
+
+        unlink($docName);
+    }
 }


### PR DESCRIPTION
### Description

When you try to setImage with limit, the processor apply correctly the limit instead replace all tags.

Fixes #1825

### Checklist:

- [ x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
