### PR TITLE
Update requirement to PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,37 +3,19 @@ language: php
 dist: xenial
 
 php:
-    - 5.3
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
-    - 7.1
     - 7.2
     - 7.3
-    - 7.4snapshot
+    - 7.4
 
 matrix:
     include:
-        - php: 5.3
-          dist: precise
-          env: COMPOSER_MEMORY_LIMIT=3G
-        - php: 5.4
-          dist: trusty
-        - php: 5.5
-          dist: trusty
-        - php: 7.0
+        - php: 7.2
           env: COVERAGE=1
         - php: 7.3
           env: DEPENDENCIES="--ignore-platform-reqs"
     exclude:
-        - php: 5.3
-        - php: 5.4
-        - php: 5.5
-        - php: 7.0
+        - php: 7.2
         - php: 7.3
-    allow_failures:
-        - php: 7.4snapshot
 
 cache:
     directories:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ With PHPWord, you can create OOXML, ODF, or RTF documents dynamically using your
 
 PHPWord requires the following:
 
-- PHP 5.3.3+
+- A [supported version of PHP](https://www.php.net/supported-versions.php) 
 - [XML Parser extension](http://www.php.net/manual/en/xml.installation.php)
 - [Zend\Escaper component](http://framework.zend.com/manual/current/en/modules/zend.escaper.introduction.html)
 - [Zend\Stdlib component](http://framework.zend.com/manual/current/en/modules/zend.stdlib.hydrator.html)

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "fix": "Fixes issues found by PHP-CS"
     },
     "require": {
-        "php": "^5.3.3 || ^7.0",
+        "php": "^7.2",
         "ext-xml": "*",
         "zendframework/zend-escaper": "^2.2",
         "phpoffice/common": "^0.2.9"
@@ -70,10 +70,11 @@
         "squizlabs/php_codesniffer": "^2.9",
         "friendsofphp/php-cs-fixer": "^2.2",
         "phpmd/phpmd": "2.*",
-        "phploc/phploc": "2.* || 3.* || 4.*",
+        "phploc/phploc": "2.* || 3.* || 4.* || 5.*",
         "dompdf/dompdf":"0.8.*",
         "tecnickcom/tcpdf": "6.*",
-        "mpdf/mpdf": "5.7.4 || 6.* || 7.*",
+        "mpdf/mpdf": "7.* || 8.*",
+        "rector/rector": "^0.8",
         "php-coveralls/php-coveralls": "1.1.0 || ^2.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "ext-zip": "*",
         "ext-gd": "*",
         "phpunit/phpunit": "^4.8.36 || ^7.0",
-        "squizlabs/php_codesniffer": "^2.9",
+        "squizlabs/php_codesniffer": "^3.5",
         "friendsofphp/php-cs-fixer": "^2.2",
         "phpmd/phpmd": "2.*",
         "phploc/phploc": "2.* || 3.* || 4.* || 5.*",

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::SETS, [
+        SetList::PHP_52,
+        SetList::PHP_53,
+        SetList::PHP_54,
+        SetList::PHP_55,
+        SetList::PHP_56,
+        SetList::PHP_70,
+        SetList::PHP_71,
+        SetList::PHP_72,
+    ]);
+};

--- a/src/PhpWord/ComplexType/TrackChangesView.php
+++ b/src/PhpWord/ComplexType/TrackChangesView.php
@@ -77,7 +77,7 @@ final class TrackChangesView
      */
     public function setMarkup($markup)
     {
-        $this->markup = $markup === null ? true : $markup;
+        $this->markup = $markup ?? true;
     }
 
     /**
@@ -98,7 +98,7 @@ final class TrackChangesView
      */
     public function setComments($comments)
     {
-        $this->comments = $comments === null ? true : $comments;
+        $this->comments = $comments ?? true;
     }
 
     /**
@@ -119,7 +119,7 @@ final class TrackChangesView
      */
     public function setInsDel($insDel)
     {
-        $this->insDel = $insDel === null ? true : $insDel;
+        $this->insDel = $insDel ?? true;
     }
 
     /**
@@ -140,7 +140,7 @@ final class TrackChangesView
      */
     public function setFormatting($formatting = null)
     {
-        $this->formatting = $formatting === null ? true : $formatting;
+        $this->formatting = $formatting ?? true;
     }
 
     /**
@@ -161,6 +161,6 @@ final class TrackChangesView
      */
     public function setInkAnnotations($inkAnnotations)
     {
-        $this->inkAnnotations = $inkAnnotations === null ? true : $inkAnnotations;
+        $this->inkAnnotations = $inkAnnotations ?? true;
     }
 }

--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -38,7 +38,7 @@ namespace PhpOffice\PhpWord\Element;
  * @method Image addImage(string $source, mixed $style = null, bool $isWatermark = false, $name = null)
  * @method OLEObject addOLEObject(string $source, mixed $style = null)
  * @method TextBox addTextBox(mixed $style = null)
- * @method Field addField(string $type = null, array $properties = array(), array $options = array(), mixed $text = null)
+ * @method Field addField(string $type = null, array $properties = [], array $options = [], mixed $text = null)
  * @method Line addLine(mixed $lineStyle = null)
  * @method Shape addShape(string $type, mixed $style = null)
  * @method Chart addChart(string $type, array $categories, array $values, array $style = null, $seriesName = null)
@@ -99,7 +99,7 @@ abstract class AbstractContainer extends AbstractElement
             // Special case for TextBreak
             // @todo Remove the `$count` parameter in 1.0.0 to make this element similiar to other elements?
             if ($element == 'TextBreak') {
-                list($count, $fontStyle, $paragraphStyle) = array_pad($args, 3, null);
+                [$count, $fontStyle, $paragraphStyle] = array_pad($args, 3, null);
                 if ($count === null) {
                     $count = 1;
                 }
@@ -109,6 +109,7 @@ abstract class AbstractContainer extends AbstractElement
             } else {
                 // All other elements
                 array_unshift($args, $element); // Prepend element name to the beginning of args array
+
                 return call_user_func_array(array($this, 'addElement'), $args);
             }
         }

--- a/src/PhpWord/Element/AbstractElement.php
+++ b/src/PhpWord/Element/AbstractElement.php
@@ -254,7 +254,7 @@ abstract class AbstractElement
      */
     public function setElementId()
     {
-        $this->elementId = substr(md5(rand()), 0, 6);
+        $this->elementId = substr(md5(random_int(0, mt_getrandmax())), 0, 6);
     }
 
     /**

--- a/src/PhpWord/Element/Image.php
+++ b/src/PhpWord/Element/Image.php
@@ -338,7 +338,7 @@ class Image extends AbstractElement
         // Return null if not found
         if ($this->sourceType == self::SOURCE_ARCHIVE) {
             $source = substr($source, 6);
-            list($zipFilename, $imageFilename) = explode('#', $source);
+            [$zipFilename, $imageFilename] = explode('#', $source);
 
             $zip = new ZipArchive();
             if ($zip->open($zipFilename) !== false) {
@@ -417,7 +417,7 @@ class Image extends AbstractElement
         if (!is_array($imageData)) {
             throw new InvalidImageException(sprintf('Invalid image: %s', $this->source));
         }
-        list($actualWidth, $actualHeight, $imageType) = $imageData;
+        [$actualWidth, $actualHeight, $imageType] = $imageData;
 
         // Check image type support
         $supportedTypes = array(IMAGETYPE_JPEG, IMAGETYPE_GIF, IMAGETYPE_PNG);
@@ -478,7 +478,7 @@ class Image extends AbstractElement
     {
         $imageData = null;
         $source = substr($source, 6);
-        list($zipFilename, $imageFilename) = explode('#', $source);
+        [$zipFilename, $imageFilename] = explode('#', $source);
 
         $tempFilename = tempnam(Settings::getTempDir(), 'PHPWordImage');
         if (false === $tempFilename) {

--- a/src/PhpWord/Element/Section.php
+++ b/src/PhpWord/Element/Section.php
@@ -217,7 +217,7 @@ class Section extends AbstractContainer
         $collection = &$this->$collectionArray;
 
         if (in_array($type, array(Header::AUTO, Header::FIRST, Header::EVEN))) {
-            $index = count($collection);
+            $index = is_countable($collection) ? count($collection) : 0;
             /** @var \PhpOffice\PhpWord\Element\AbstractContainer $container Type hint */
             $container = new $containerClass($this->sectionId, ++$index, $type);
             $container->setPhpWord($this->phpWord);

--- a/src/PhpWord/Metadata/Settings.php
+++ b/src/PhpWord/Metadata/Settings.php
@@ -213,7 +213,7 @@ class Settings
      */
     public function setHideSpellingErrors($hideSpellingErrors)
     {
-        $this->hideSpellingErrors = $hideSpellingErrors === null ? true : $hideSpellingErrors;
+        $this->hideSpellingErrors = $hideSpellingErrors ?? true;
     }
 
     /**
@@ -233,7 +233,7 @@ class Settings
      */
     public function setHideGrammaticalErrors($hideGrammaticalErrors)
     {
-        $this->hideGrammaticalErrors = $hideGrammaticalErrors === null ? true : $hideGrammaticalErrors;
+        $this->hideGrammaticalErrors = $hideGrammaticalErrors ?? true;
     }
 
     /**
@@ -249,7 +249,7 @@ class Settings
      */
     public function setEvenAndOddHeaders($evenAndOddHeaders)
     {
-        $this->evenAndOddHeaders = $evenAndOddHeaders === null ? true : $evenAndOddHeaders;
+        $this->evenAndOddHeaders = $evenAndOddHeaders ?? true;
     }
 
     /**
@@ -285,7 +285,7 @@ class Settings
      */
     public function setTrackRevisions($trackRevisions)
     {
-        $this->trackRevisions = $trackRevisions === null ? true : $trackRevisions;
+        $this->trackRevisions = $trackRevisions ?? true;
     }
 
     /**
@@ -301,7 +301,7 @@ class Settings
      */
     public function setDoNotTrackMoves($doNotTrackMoves)
     {
-        $this->doNotTrackMoves = $doNotTrackMoves === null ? true : $doNotTrackMoves;
+        $this->doNotTrackMoves = $doNotTrackMoves ?? true;
     }
 
     /**
@@ -317,7 +317,7 @@ class Settings
      */
     public function setDoNotTrackFormatting($doNotTrackFormatting)
     {
-        $this->doNotTrackFormatting = $doNotTrackFormatting === null ? true : $doNotTrackFormatting;
+        $this->doNotTrackFormatting = $doNotTrackFormatting ?? true;
     }
 
     /**
@@ -391,7 +391,7 @@ class Settings
      */
     public function setUpdateFields($updateFields)
     {
-        $this->updateFields = $updateFields === null ? false : $updateFields;
+        $this->updateFields = $updateFields ?? false;
     }
 
     /**

--- a/src/PhpWord/PhpWord.php
+++ b/src/PhpWord/PhpWord.php
@@ -158,12 +158,12 @@ class PhpWord
             /** @var \PhpOffice\PhpWord\Collection\AbstractCollection $collectionObject */
             $collectionObject = $this->collections[$key];
 
-            return $collectionObject->addItem(isset($args[0]) ? $args[0] : null);
+            return $collectionObject->addItem($args[0] ?? null);
         }
 
         // Run add style method
         if (in_array($function, $addStyle)) {
-            return forward_static_call_array(array('PhpOffice\\PhpWord\\Style', $function), $args);
+            return forward_static_call_array(array(\PhpOffice\PhpWord\Style::class, $function), $args);
         }
 
         // Exception

--- a/src/PhpWord/Reader/RTF/Document.php
+++ b/src/PhpWord/Reader/RTF/Document.php
@@ -246,7 +246,7 @@ class Document
     private function flushControl($isControl = false)
     {
         if (1 === preg_match('/^([A-Za-z]+)(-?[0-9]*) ?$/', $this->control, $match)) {
-            list(, $control, $parameter) = $match;
+            [, $control, $parameter] = $match;
             $this->parseControl($control, $parameter);
         }
 
@@ -337,7 +337,7 @@ class Document
         );
 
         if (isset($controls[$control])) {
-            list($function) = $controls[$control];
+            [$function] = $controls[$control];
             if (method_exists($this, $function)) {
                 $directives = $controls[$control];
                 array_shift($directives); // remove the function variable; we won't need it
@@ -353,7 +353,7 @@ class Document
      */
     private function readParagraph($directives)
     {
-        list($property, $value) = $directives;
+        [$property, $value] = $directives;
         $this->textrun = $this->section->addTextRun();
         $this->flags[$property] = $value;
     }
@@ -365,7 +365,7 @@ class Document
      */
     private function readStyle($directives)
     {
-        list($style, $property, $value) = $directives;
+        [$style, $property, $value] = $directives;
         $this->flags['styles'][$style][$property] = $value;
     }
 
@@ -376,7 +376,7 @@ class Document
      */
     private function readSkip($directives)
     {
-        list($property) = $directives;
+        [$property] = $directives;
         $this->flags['property'] = $property;
         $this->flags['skipped'] = true;
     }

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -631,7 +631,7 @@ abstract class AbstractPart
         $styles = array();
 
         foreach ($styleDefs as $styleProp => $styleVal) {
-            list($method, $element, $attribute, $expected) = array_pad($styleVal, 4, null);
+            [$method, $element, $attribute, $expected] = array_pad($styleVal, 4, null);
 
             $element = $this->findPossibleElement($xmlReader, $parentNode, $element);
             if ($element === null) {
@@ -644,7 +644,7 @@ abstract class AbstractPart
                 $attribute = $this->findPossibleAttribute($xmlReader, $node, $attribute);
 
                 // Use w:val as default if no attribute assigned
-                $attribute = ($attribute === null) ? 'w:val' : $attribute;
+                $attribute = $attribute ?? 'w:val';
                 $attributeValue = $xmlReader->getAttribute($attribute, $node);
 
                 $styleValue = $this->readStyleDef($method, $attributeValue, $expected);

--- a/src/PhpWord/Reader/Word2007/Document.php
+++ b/src/PhpWord/Reader/Word2007/Document.php
@@ -73,7 +73,7 @@ class Document extends AbstractPart
         if (is_array($settings) && isset($settings['hf'])) {
             foreach ($settings['hf'] as $rId => $hfSetting) {
                 if (isset($this->rels['document'][$rId])) {
-                    list($hfType, $xmlFile, $docPart) = array_values($this->rels['document'][$rId]);
+                    [$hfType, $xmlFile, $docPart] = array_values($this->rels['document'][$rId]);
                     $addMethod = "add{$hfType}";
                     $hfObject = $section->$addMethod($hfSetting['type']);
 

--- a/src/PhpWord/Reader/Word2007/Settings.php
+++ b/src/PhpWord/Reader/Word2007/Settings.php
@@ -149,7 +149,7 @@ class Settings extends AbstractPart
         $val = $xmlReader->getAttribute('w:val', $node);
 
         if ($percent !== null || $val !== null) {
-            $phpWord->getSettings()->setZoom($percent === null ? $val : $percent);
+            $phpWord->getSettings()->setZoom($percent ?? $val);
         }
     }
 

--- a/src/PhpWord/Settings.php
+++ b/src/PhpWord/Settings.php
@@ -29,9 +29,9 @@ class Settings
      *
      * @const string
      */
-    const ZIPARCHIVE = 'ZipArchive';
-    const PCLZIP = 'PclZip';
-    const OLD_LIB = 'PhpOffice\\PhpWord\\Shared\\ZipArchive'; // @deprecated 0.11
+    const ZIPARCHIVE = \ZipArchive::class;
+    const PCLZIP = \PclZip::class;
+    const OLD_LIB = \PhpOffice\PhpWord\Shared\ZipArchive::class; // @deprecated 0.11
 
     /**
      * PDF rendering libraries
@@ -39,7 +39,7 @@ class Settings
      * @const string
      */
     const PDF_RENDERER_DOMPDF = 'DomPDF';
-    const PDF_RENDERER_TCPDF = 'TCPDF';
+    const PDF_RENDERER_TCPDF = \TCPDF::class;
     const PDF_RENDERER_MPDF = 'MPDF';
 
     /**

--- a/src/PhpWord/Shared/Converter.php
+++ b/src/PhpWord/Shared/Converter.php
@@ -331,9 +331,9 @@ class Converter
         }
 
         if (strlen($value) == 6) {
-            list($red, $green, $blue) = array($value[0] . $value[1], $value[2] . $value[3], $value[4] . $value[5]);
+            [$red, $green, $blue] = array($value[0] . $value[1], $value[2] . $value[3], $value[4] . $value[5]);
         } elseif (strlen($value) == 3) {
-            list($red, $green, $blue) = array($value[0] . $value[0], $value[1] . $value[1], $value[2] . $value[2]);
+            [$red, $green, $blue] = array($value[0] . $value[0], $value[1] . $value[1], $value[2] . $value[2]);
         } else {
             return false;
         }

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -171,19 +171,19 @@ class Html
             // Arguments are passed by reference
             $arguments = array();
             $args = array();
-            list($method, $args[0], $args[1], $args[2], $args[3], $args[4], $args[5]) = $nodes[$node->nodeName];
+            [$method, $args[0], $args[1], $args[2], $args[3], $args[4], $args[5]] = $nodes[$node->nodeName];
             for ($i = 0; $i <= 5; $i++) {
                 if ($args[$i] !== null) {
                     $arguments[$keys[$i]] = &$args[$i];
                 }
             }
             $method = "parse{$method}";
-            $newElement = call_user_func_array(array('PhpOffice\PhpWord\Shared\Html', $method), $arguments);
+            $newElement = call_user_func_array(array(self::class, $method), $arguments);
 
             // Retrieve back variables from arguments
             foreach ($keys as $key) {
                 if (array_key_exists($key, $arguments)) {
-                    $$key = $arguments[$key];
+                    ${$key} = $arguments[$key];
                 }
             }
         }
@@ -500,7 +500,7 @@ class Html
         $properties = explode(';', trim($attribute->value, " \t\n\r\0\x0B;"));
 
         foreach ($properties as $property) {
-            list($cKey, $cValue) = array_pad(explode(':', $property, 2), 2, null);
+            [$cKey, $cValue] = array_pad(explode(':', $property, 2), 2, null);
             $cValue = trim($cValue);
             switch (trim($cKey)) {
                 case 'text-decoration':
@@ -646,7 +646,7 @@ class Html
                     $styleattr = explode(';', $attribute->value);
                     foreach ($styleattr as $attr) {
                         if (strpos($attr, ':')) {
-                            list($k, $v) = explode(':', $attr);
+                            [$k, $v] = explode(':', $attr);
                             switch ($k) {
                                 case 'float':
                                     if (trim($v) == 'right') {

--- a/src/PhpWord/Shared/OLERead.php
+++ b/src/PhpWord/Shared/OLERead.php
@@ -262,6 +262,7 @@ class OLERead
             $name = str_replace("\x00", "", substr($data, 0, $nameSize));
 
 
+            $this->props = (array) $this->props;
             $this->props[] = array (
                 'name' => $name,
                 'type' => $type,

--- a/src/PhpWord/Shared/PCLZip/pclzip.lib.php
+++ b/src/PhpWord/Shared/PCLZip/pclzip.lib.php
@@ -2456,6 +2456,7 @@ class PclZip
     // --------------------------------------------------------------------------------
     public function privAddFile($p_filedescr, &$p_header, &$p_options)
     {
+        $v_file = null;
         $v_result = 1;
 
         // ----- Working variable
@@ -3778,6 +3779,7 @@ class PclZip
     // --------------------------------------------------------------------------------
     public function privExtractFileUsingTempFile(&$p_entry, &$p_options)
     {
+        $v_file = null;
         $v_result = 1;
 
         // ----- Creates a temporary file
@@ -4319,6 +4321,7 @@ class PclZip
     // --------------------------------------------------------------------------------
     public function privReadEndCentralDir(&$p_central_dir)
     {
+        $v_pos = null;
         $v_result = 1;
 
         // ----- Go to the end of the zip file

--- a/src/PhpWord/Shared/ZipArchive.php
+++ b/src/PhpWord/Shared/ZipArchive.php
@@ -80,7 +80,7 @@ class ZipArchive
      */
     public function __construct()
     {
-        $this->usePclzip = (Settings::getZipClass() != 'ZipArchive');
+        $this->usePclzip = (Settings::getZipClass() != \ZipArchive::class);
         if ($this->usePclzip) {
             if (!defined('PCLZIP_TEMPORARY_DIR')) {
                 define('PCLZIP_TEMPORARY_DIR', Settings::getTempDir() . '/');
@@ -384,7 +384,7 @@ class ZipArchive
         /** @var \PclZip $zip Type hint */
         $zip = $this->zip;
         $list = $zip->listContent();
-        $listCount = count($list);
+        $listCount = is_countable($list) ? count($list) : 0;
         $listIndex = -1;
         for ($i = 0; $i < $listCount; ++$i) {
             if (strtolower($list[$i]['filename']) == strtolower($filename) ||

--- a/src/PhpWord/Style/ListItem.php
+++ b/src/PhpWord/Style/ListItem.php
@@ -263,7 +263,7 @@ class ListItem extends AbstractStyle
 
         // Populate style and register to global Style register
         $style = $listTypeStyles[$this->listType];
-        $numProperties = count($properties);
+        $numProperties = is_countable($properties) ? count($properties) : 0;
         foreach ($style['levels'] as $key => $value) {
             $level = array();
             $levelProperties = explode(', ', $value);

--- a/src/PhpWord/Style/Paper.php
+++ b/src/PhpWord/Style/Paper.php
@@ -159,7 +159,7 @@ class Paper extends AbstractStyle
     {
         $this->size = $this->setEnumVal($size, array_keys($this->sizes), $this->size);
 
-        list($width, $height, $unit) = $this->sizes[$this->size];
+        [$width, $height, $unit] = $this->sizes[$this->size];
 
         if ($unit == 'mm') {
             $this->width = Converter::cmToTwip($width / 10);

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -355,15 +355,15 @@ class TemplateProcessor
         // size format documentation: https://msdn.microsoft.com/en-us/library/documentformat.openxml.vml.shape%28v=office.14%29.aspx?f=255&MSPPError=-2147217396
         foreach ($varElements as $argIdx => $varArg) {
             if (strpos($varArg, '=')) { // arg=value
-                list($argName, $argValue) = explode('=', $varArg, 2);
+                [$argName, $argValue] = explode('=', $varArg, 2);
                 $argName = strtolower($argName);
                 if ($argName == 'size') {
-                    list($varInlineArgs['width'], $varInlineArgs['height']) = explode('x', $argValue, 2);
+                    [$varInlineArgs['width'], $varInlineArgs['height']] = explode('x', $argValue, 2);
                 } else {
                     $varInlineArgs[strtolower($argName)] = $argValue;
                 }
             } elseif (preg_match('/^([0-9]*[a-z%]{0,2}|auto)x([0-9]*[a-z%]{0,2}|auto)$/i', $varArg)) { // 60x40
-                list($varInlineArgs['width'], $varInlineArgs['height']) = explode('x', $varArg, 2);
+                [$varInlineArgs['width'], $varInlineArgs['height']] = explode('x', $varArg, 2);
             } else { // :60:40:f
                 switch ($argIdx) {
                     case 0:
@@ -462,14 +462,14 @@ class TemplateProcessor
             $imgPath = $replaceImage;
         }
 
-        $width = $this->chooseImageDimension($width, isset($varInlineArgs['width']) ? $varInlineArgs['width'] : null, 115);
-        $height = $this->chooseImageDimension($height, isset($varInlineArgs['height']) ? $varInlineArgs['height'] : null, 70);
+        $width = $this->chooseImageDimension($width, $varInlineArgs['width'] ?? null, 115);
+        $height = $this->chooseImageDimension($height, $varInlineArgs['height'] ?? null, 70);
 
         $imageData = @getimagesize($imgPath);
         if (!is_array($imageData)) {
             throw new Exception(sprintf('Invalid image: %s', $imgPath));
         }
-        list($actualWidth, $actualHeight, $imageType) = $imageData;
+        [$actualWidth, $actualHeight, $imageType] = $imageData;
 
         // fix aspect ratio (by default)
         if (is_null($ratio) && isset($varInlineArgs['ratio'])) {
@@ -559,7 +559,7 @@ class TemplateProcessor
 
         $searchReplace = array();
         foreach ($search as $searchIdx => $searchString) {
-            $searchReplace[$searchString] = isset($replacesList[$searchIdx]) ? $replacesList[$searchIdx] : $replacesList[0];
+            $searchReplace[$searchString] = $replacesList[$searchIdx] ?? $replacesList[0];
         }
 
         // collect document parts
@@ -604,7 +604,7 @@ class TemplateProcessor
                     if (preg_match('/(<[^<]+>)([^<]*)(' . preg_quote($varNameWithArgsFixed) . ')([^>]*)(<[^>]+>)/Uu', $partContent, $matches)) {
                         $wholeTag = $matches[0];
                         array_shift($matches);
-                        list($openTag, $prefix, , $postfix, $closeTag) = $matches;
+                        [$openTag, $prefix, , $postfix, $closeTag] = $matches;
                         $replaceXml = $openTag . $prefix . $closeTag . $xmlImage . $openTag . $postfix . $closeTag;
                         // replace on each iteration, because in one tag we can have 2+ inline variables => before proceed next variable we need to change $partContent
                         $partContent = $this->setValueForPart($wholeTag, $replaceXml, $partContent, $limit);

--- a/src/PhpWord/Writer/AbstractWriter.php
+++ b/src/PhpWord/Writer/AbstractWriter.php
@@ -383,7 +383,7 @@ abstract class AbstractWriter implements WriterInterface
         $actualSource = null;
         if ($isArchive) {
             $source = substr($source, 6);
-            list($zipFilename, $imageFilename) = explode('#', $source);
+            [$zipFilename, $imageFilename] = explode('#', $source);
 
             $zip = new ZipArchive();
             if ($zip->open($zipFilename) !== false) {

--- a/src/PhpWord/Writer/HTML/Part/Body.php
+++ b/src/PhpWord/Writer/HTML/Part/Body.php
@@ -68,7 +68,7 @@ class Body extends AbstractPart
         if (!empty($notes)) {
             $content .= '<hr />' . PHP_EOL;
             foreach ($notes as $noteId => $noteMark) {
-                list($noteType, $noteTypeId) = explode('-', $noteMark);
+                [$noteType, $noteTypeId] = explode('-', $noteMark);
                 $method = 'get' . ($noteType == 'endnote' ? 'Endnotes' : 'Footnotes');
                 $collection = $phpWord->$method()->getItems();
 

--- a/src/PhpWord/Writer/PDF/MPDF.php
+++ b/src/PhpWord/Writer/PDF/MPDF.php
@@ -94,6 +94,6 @@ class MPDF extends AbstractRenderer implements WriterInterface
         }
 
         // MPDF version > 6.*
-        return '\Mpdf\Mpdf';
+        return \Mpdf\Mpdf::class;
     }
 }

--- a/src/PhpWord/Writer/RTF/Part/Document.php
+++ b/src/PhpWord/Writer/RTF/Part/Document.php
@@ -69,7 +69,7 @@ class Document extends AbstractPart
         $content .= '{';
         $content .= '\info';
         foreach ($properties as $property) {
-            $method = 'get' . (isset($mapping[$property]) ? $mapping[$property] : $property);
+            $method = 'get' . ($mapping[$property] ?? $property);
             if (!in_array($property, $dateFields) && Settings::isOutputEscapingEnabled()) {
                 $value = $this->escaper->escape($docProps->$method());
             } else {

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -155,7 +155,7 @@ class Header extends AbstractPart
         $content .= '{';
         $content .= '\colortbl;';
         foreach ($this->colorTable as $color) {
-            list($red, $green, $blue) = Converter::htmlToRgb($color);
+            [$red, $green, $blue] = Converter::htmlToRgb($color);
             $content .= "\\red{$red}\\green{$green}\\blue{$blue};";
         }
         $content .= '}';

--- a/src/PhpWord/Writer/Word2007.php
+++ b/src/PhpWord/Writer/Word2007.php
@@ -175,7 +175,7 @@ class Word2007 extends AbstractWriter implements WriterInterface
         $elements = Media::getElements($docPart);
         if (!empty($elements)) {
             foreach ($elements as $file => $media) {
-                if (count($media) > 0) {
+                if ((is_countable($media) ? count($media) : 0) > 0) {
                     if (!empty($media)) {
                         $this->addFilesToPackage($zip, $media);
                         $this->registerContentTypes($media);

--- a/src/PhpWord/Writer/Word2007/Element/SDT.php
+++ b/src/PhpWord/Writer/Word2007/Element/SDT.php
@@ -56,7 +56,7 @@ class SDT extends Text
         $xmlWriter->startElement('w:sdtPr');
         $xmlWriter->writeElementIf($alias != null, 'w:alias', 'w:val', $alias);
         $xmlWriter->writeElementBlock('w:lock', 'w:val', 'sdtLocked');
-        $xmlWriter->writeElementBlock('w:id', 'w:val', rand(100000000, 999999999));
+        $xmlWriter->writeElementBlock('w:id', 'w:val', random_int(100000000, 999999999));
         $xmlWriter->writeElementIf($tag != null, 'w:tag', 'w:val', $tag);
         $this->$writeFormField($xmlWriter, $element);
         $xmlWriter->endElement(); // w:sdtPr

--- a/src/PhpWord/Writer/Word2007/Element/Shape.php
+++ b/src/PhpWord/Writer/Word2007/Element/Shape.php
@@ -154,12 +154,12 @@ class Shape extends AbstractElement
             case 'arc':
             case 'line':
                 $points = explode(' ', $value);
-                list($start, $end) = array_pad($points, 2, null);
+                [$start, $end] = array_pad($points, 2, null);
                 $points = array('start' => $start, 'end' => $end);
                 break;
             case 'curve':
                 $points = explode(' ', $value);
-                list($start, $end, $point1, $point2) = array_pad($points, 4, null);
+                [$start, $end, $point1, $point2] = array_pad($points, 4, null);
                 $points = array('start' => $start, 'end' => $end, 'point1' => $point1, 'point2' => $point2);
                 break;
         }

--- a/src/PhpWord/Writer/Word2007/Part/Chart.php
+++ b/src/PhpWord/Writer/Word2007/Part/Chart.php
@@ -306,7 +306,7 @@ class Chart extends AbstractPart
             'xVal' => array('c:xVal', 'c:strLit'),
             'yVal' => array('c:yVal', 'c:numLit'),
         );
-        list($itemType, $itemLit) = $types[$type];
+        [$itemType, $itemLit] = $types[$type];
 
         $xmlWriter->startElement($itemType);
         $xmlWriter->startElement($itemLit);
@@ -345,7 +345,7 @@ class Chart extends AbstractPart
             'cat' => array('c:catAx', 1, 'b', 2),
             'val' => array('c:valAx', 2, 'l', 1),
         );
-        list($axisType, $axisId, $axisPos, $axisCross) = $types[$type];
+        [$axisType, $axisId, $axisPos, $axisCross] = $types[$type];
 
         $xmlWriter->startElement($axisType);
 

--- a/src/PhpWord/Writer/Word2007/Part/Numbering.php
+++ b/src/PhpWord/Writer/Word2007/Part/Numbering.php
@@ -196,6 +196,6 @@ class Numbering extends AbstractPart
      */
     private function getRandomHexNumber($length = 8)
     {
-        return strtoupper(substr(md5(rand()), 0, $length));
+        return strtoupper(substr(md5(random_int(0, mt_getrandmax())), 0, $length));
     }
 }

--- a/src/PhpWord/Writer/Word2007/Part/Rels.php
+++ b/src/PhpWord/Writer/Word2007/Part/Rels.php
@@ -87,8 +87,8 @@ class Rels extends AbstractPart
         $targetMapping = array('image' => 'media/', 'object' => 'embeddings/');
 
         $mediaType = $mediaRel['type'];
-        $type = isset($typeMapping[$mediaType]) ? $typeMapping[$mediaType] : $mediaType;
-        $targetPrefix = isset($targetMapping[$mediaType]) ? $targetMapping[$mediaType] : '';
+        $type = $typeMapping[$mediaType] ?? $mediaType;
+        $targetPrefix = $targetMapping[$mediaType] ?? '';
         $target = $mediaRel['target'];
         $targetMode = ($type == 'hyperlink') ? 'External' : '';
 

--- a/src/PhpWord/Writer/Word2007/Part/Settings.php
+++ b/src/PhpWord/Writer/Word2007/Part/Settings.php
@@ -262,8 +262,8 @@ class Settings extends AbstractPart
         $lang = array();
         $lang['w:val'] = $latinLanguage;
         if ($language != null) {
-            $lang['w:eastAsia'] = $language->getEastAsia() === null ? 'x-none' : $language->getEastAsia();
-            $lang['w:bidi'] = $language->getBidirectional() === null ? 'x-none' : $language->getBidirectional();
+            $lang['w:eastAsia'] = $language->getEastAsia() ?? 'x-none';
+            $lang['w:bidi'] = $language->getBidirectional() ?? 'x-none';
         }
         $this->settings['w:themeFontLang'] = array('@attributes' => $lang);
     }

--- a/src/PhpWord/Writer/Word2007/Style/MarginBorder.php
+++ b/src/PhpWord/Writer/Word2007/Style/MarginBorder.php
@@ -69,7 +69,7 @@ class MarginBorder extends AbstractStyle
                 if (isset($this->colors[$i])) {
                     $color = $this->colors[$i];
                 }
-                $style = isset($this->styles[$i]) ? $this->styles[$i] : 'single';
+                $style = $this->styles[$i] ?? 'single';
                 $this->writeSide($xmlWriter, $sides[$i], $this->sizes[$i], $color, $style);
             }
         }

--- a/src/PhpWord/Writer/Word2007/Style/Section.php
+++ b/src/PhpWord/Writer/Word2007/Style/Section.php
@@ -64,7 +64,7 @@ class Section extends AbstractStyle
         );
         $xmlWriter->startElement('w:pgMar');
         foreach ($margins as $attribute => $value) {
-            list($method, $default) = $value;
+            [$method, $default] = $value;
             $xmlWriter->writeAttribute($attribute, $this->convertTwip($style->$method(), $default));
         }
         $xmlWriter->endElement();


### PR DESCRIPTION
### Description

I've updated the required PHP to 7.2 Please note that this version is already out of active support: https://www.php.net/supported-versions.php. It has security support until 30 Nov 2020.

I've used Rector to do some small updates to the codebase. I haven't added any typing (type hints, return types) yet.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes

Should be merged after #1946. 
Fixes #1948.
