### PR TITLE
Fix typo in docs. Update templates-processing.rst

### DIFF
--- a/docs/templates-processing.rst
+++ b/docs/templates-processing.rst
@@ -190,7 +190,7 @@ Finds a row in a table row identified by `$search` param and clones it as many t
         ['userId' => 1, 'userName' => 'Batman', 'userAddress' => 'Gotham City'],
         ['userId' => 2, 'userName' => 'Superman', 'userAddress' => 'Metropolis'],
     ];
-    $templateProcessor->cloneRowAndSetValues('userId', );
+    $templateProcessor->cloneRowAndSetValues('userId', $values);
 
 Will result in
 


### PR DESCRIPTION
fix typo in doc

### Description

Before:  
`$templateProcessor->cloneRowAndSetValues('userId', );`

After:  
`$templateProcessor->cloneRowAndSetValues('userId', $values);`

Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
