### PR TITLE
Update addHTML parser to handle max-width style attribute on images

### DIFF
--- a/samples/Sample_26_Html.php
+++ b/samples/Sample_26_Html.php
@@ -92,6 +92,8 @@ $html .= '<table align="center" style="width: 80%; border: 6px #0000FF double;">
 $html .= '<p style="margin-top: 240pt;">The text below is not visible, click on show/hide to reveil it:</p>';
 $html .= '<p style="display: none">This is hidden text</p>';
 
+$html .= '<p><img src="resources/_earth.jpg" style="max-width: 5cm"/></p>';
+
 \PhpOffice\PhpWord\Shared\Html::addHtml($section, $html, false, false);
 
 // Save file

--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -109,6 +109,7 @@ abstract class AbstractContainer extends AbstractElement
             } else {
                 // All other elements
                 array_unshift($args, $element); // Prepend element name to the beginning of args array
+
                 return call_user_func_array(array($this, 'addElement'), $args);
             }
         }

--- a/src/PhpWord/Element/Image.php
+++ b/src/PhpWord/Element/Image.php
@@ -566,14 +566,23 @@ class Image extends AbstractElement
         $styleHeight = $this->style->getHeight();
         if (!($styleWidth && $styleHeight)) {
             if ($styleWidth == null && $styleHeight == null) {
-                $this->style->setWidth($actualWidth);
-                $this->style->setHeight($actualHeight);
+                $styleWidth = $actualWidth;
+                $styleHeight = $actualHeight;
             } elseif ($styleWidth) {
-                $this->style->setHeight($actualHeight * ($styleWidth / $actualWidth));
+                $styleHeight = $actualHeight * ($styleWidth / $actualWidth);
             } else {
-                $this->style->setWidth($actualWidth * ($styleHeight / $actualHeight));
+                $styleWidth = $actualWidth * ($styleHeight / $actualHeight);
             }
         }
+        $styleMaxWidth = $this->style->getMaxWidth();
+        if ($styleMaxWidth) {
+            if ($styleMaxWidth < $styleWidth) {
+                $styleWidth = $styleMaxWidth;
+                $styleHeight = $actualHeight * ($styleMaxWidth / $actualWidth);
+            }
+        }
+        $this->style->setWidth($styleWidth);
+        $this->style->setHeight($styleHeight);
     }
 
     /**

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -647,16 +647,17 @@ class Html
                     foreach ($styleattr as $attr) {
                         if (strpos($attr, ':')) {
                             list($k, $v) = explode(':', $attr);
+                            $v = trim($v);
                             switch ($k) {
                                 case 'float':
-                                    if (trim($v) == 'right') {
+                                    if ($v == 'right') {
                                         $style['hPos'] = \PhpOffice\PhpWord\Style\Image::POS_RIGHT;
                                         $style['hPosRelTo'] = \PhpOffice\PhpWord\Style\Image::POS_RELTO_PAGE;
                                         $style['pos'] = \PhpOffice\PhpWord\Style\Image::POS_RELATIVE;
                                         $style['wrap'] = \PhpOffice\PhpWord\Style\Image::WRAP_TIGHT;
                                         $style['overlap'] = true;
                                     }
-                                    if (trim($v) == 'left') {
+                                    if ($v == 'left') {
                                         $style['hPos'] = \PhpOffice\PhpWord\Style\Image::POS_LEFT;
                                         $style['hPosRelTo'] = \PhpOffice\PhpWord\Style\Image::POS_RELTO_PAGE;
                                         $style['pos'] = \PhpOffice\PhpWord\Style\Image::POS_RELATIVE;
@@ -664,6 +665,12 @@ class Html
                                         $style['overlap'] = true;
                                     }
                                     break;
+                                case 'max-width':
+                                    if (preg_match('/([0-9]+[a-z]+)/', $v, $matches)) {
+                                        $style['maxWidth'] = Converter::cssToPixel($matches[1]);
+                                        $style['unit'] = \PhpOffice\PhpWord\Style\Image::UNIT_PX;
+                                    }
+                                break;
                             }
                         }
                     }

--- a/src/PhpWord/Style/Frame.php
+++ b/src/PhpWord/Style/Frame.php
@@ -116,6 +116,13 @@ class Frame extends AbstractStyle
     private $height;
 
     /**
+     * Height
+     *
+     * @var int|float
+     */
+    private $maxWidth;
+
+    /**
      * Leftmost (horizontal) position
      *
      * @var int|float
@@ -334,6 +341,29 @@ class Frame extends AbstractStyle
     public function setHeight($value = null)
     {
         $this->height = $this->setNumericVal($value, null);
+
+        return $this;
+    }
+
+    /**
+     * Get max width
+     *
+     * @return int|float
+     */
+    public function getMaxWidth()
+    {
+        return $this->maxWidth;
+    }
+
+    /**
+     * Set height
+     *
+     * @param int|float $value
+     * @return self
+     */
+    public function setMaxWidth($value = null)
+    {
+        $this->maxWidth = $this->setNumericVal($value, null);
 
         return $this;
     }

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -566,6 +566,28 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
         Html::addHtml($section, $html, false, true);
     }
 
+    /**
+     * Test parsing of img with max-width attribute
+     */
+    public function testParseImageWithMaxWidthAttribute()
+    {
+        $src = __DIR__ . '/../_files/images/earth.jpg';
+
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<p><img src="' . $src . '" style="max-width: 200px"/><img src="' . $src . '" style="max-width: 5cm"/></p>';
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $baseXpath = '/w:document/w:body/w:p/w:r';
+        $this->assertTrue($doc->elementExists($baseXpath . '/w:pict/v:shape'));
+        $this->assertStringMatchesFormat('%Swidth:200px%S', $doc->getElementAttribute($baseXpath . '[1]/w:pict/v:shape', 'style'));
+        $this->assertStringMatchesFormat('%Sheight:200px%S', $doc->getElementAttribute($baseXpath . '[1]/w:pict/v:shape', 'style'));
+        $this->assertStringMatchesFormat('%Swidth:188.97637795276%S', $doc->getElementAttribute($baseXpath . '[2]/w:pict/v:shape', 'style'));
+        $this->assertStringMatchesFormat('%Sheight:188.97637795276%S', $doc->getElementAttribute($baseXpath . '[2]/w:pict/v:shape', 'style'));
+    }
+
     public function testParseLink()
     {
         $phpWord = new \PhpOffice\PhpWord\PhpWord();


### PR DESCRIPTION
### Description

The max-width attribute can be added in \<img> tags. Only actual width values can be used. Percentage (%) is not allowed.

Sample_26_Html is modified to show the effect of this attribute.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes **(Nothing to update.)**
