### PR TITLE
Fix TemplateProcessor::fixBrokenMacros to handle whitespaces

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -1070,7 +1070,11 @@ class TemplateProcessor
         return preg_replace_callback(
             '/\\' . $brokenMacroOpeningChars . '(?:\\' . $endMacroOpeningChars . '|[^{$]*\>\{)[^' . $macroClosingChars . '$]*\}/U',
             function ($match) {
-                return strip_tags($match[0]);
+                preg_match_all('/<.+?\s*\/?\s*>/si', $match[0], $tags);
+                $tags = implode('', $tags[0]);
+                $tags = str_replace('<w:t>', '<w:t xml:space="preserve">', $tags);
+
+                return strip_tags($match[0]) . $tags;
             },
             $documentPart
         );

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -1063,14 +1063,24 @@ class TemplateProcessor
      */
     protected function fixBrokenMacros($documentPart)
     {
-        $brokenMacroOpeningChars = substr(self::$macroOpeningChars, 0, 1);
-        $endMacroOpeningChars = substr(self::$macroOpeningChars, 1);
-        $macroClosingChars = self::$macroClosingChars;
-
         return preg_replace_callback(
-            '/\\' . $brokenMacroOpeningChars . '(?:\\' . $endMacroOpeningChars . '|[^{$]*\>\{)[^' . $macroClosingChars . '$]*\}/U',
+            sprintf(
+                '/%s.+%s/U',
+                implode('', array_map(
+                    function (string $char) {
+                        return preg_quote($char) . '(?:<[^>]+>)*';
+                    },
+                    str_split(self::$macroOpeningChars)
+                )),
+                implode('', array_map(
+                    function (string $char) {
+                        return '(?:<[^>]+>)*' . preg_quote($char);
+                    },
+                    str_split(self::$macroClosingChars)
+                ))
+            ),
             function ($match) {
-                preg_match_all('/<.+?\s*\/?\s*>/si', $match[0], $tags);
+                preg_match_all('/<[^>]+>/s', $match[0], $tags);
                 $tags = implode('', $tags[0]);
                 $tags = str_replace('<w:t>', '<w:t xml:space="preserve">', $tags);
 

--- a/tests/PhpWordTests/TemplateProcessorTest.php
+++ b/tests/PhpWordTests/TemplateProcessorTest.php
@@ -1294,19 +1294,31 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
         self::assertEquals('<w:r><w:t>{{documentContent}}</w:t></w:r>', $fixed);
 
         $fixed = $templateProcessor->fixBrokenMacros('<w:r><w:t>{</w:t><w:t>{documentContent}}</w:t></w:r>');
-        self::assertEquals('<w:r><w:t>{{documentContent}}</w:t></w:r>', $fixed);
+        self::assertEquals('<w:r><w:t>{{documentContent}}</w:t><w:t xml:space="preserve"></w:t></w:r>', $fixed);
+
+        $fixed = $templateProcessor->fixBrokenMacros('<w:r><w:t>{</w:t><w:t>{documentContent}}</w:t></w:r>');
+        self::assertEquals('<w:r><w:t>{{documentContent}}</w:t><w:t xml:space="preserve"></w:t></w:r>', $fixed);
 
         $fixed = $templateProcessor->fixBrokenMacros('<w:r><w:t>$1500</w:t><w:t>{{documentContent}}</w:t></w:r>');
         self::assertEquals('<w:r><w:t>$1500</w:t><w:t>{{documentContent}}</w:t></w:r>', $fixed);
 
         $fixed = $templateProcessor->fixBrokenMacros('<w:r><w:t>$1500</w:t><w:t>{</w:t><w:t>{documentContent}}</w:t></w:r>');
-        self::assertEquals('<w:r><w:t>$1500</w:t><w:t>{{documentContent}}</w:t></w:r>', $fixed);
+        self::assertEquals('<w:r><w:t>$1500</w:t><w:t>{{documentContent}}</w:t><w:t xml:space="preserve"></w:t></w:r>', $fixed);
 
         $fixed = $templateProcessor->fixBrokenMacros('<w:r><w:t>25$ plus some info {hint}</w:t></w:r>');
         self::assertEquals('<w:r><w:t>25$ plus some info {hint}</w:t></w:r>', $fixed);
 
         $fixed = $templateProcessor->fixBrokenMacros('<w:t>$</w:t></w:r><w:bookmarkStart w:id="0" w:name="_GoBack"/><w:bookmarkEnd w:id="0"/><w:r><w:t xml:space="preserve">15,000.00. </w:t></w:r><w:r w:rsidR="0056499B"><w:t>{</w:t></w:r><w:r w:rsidR="00573DFD" w:rsidRPr="00573DFD"><w:rPr><w:iCs/></w:rPr><w:t>{</w:t></w:r><w:proofErr w:type="spellStart"/><w:r w:rsidR="00573DFD" w:rsidRPr="00573DFD"><w:rPr><w:iCs/></w:rPr><w:t>variable_name</w:t></w:r><w:proofErr w:type="spellEnd"/><w:r w:rsidR="00573DFD" w:rsidRPr="00573DFD"><w:rPr><w:iCs/></w:rPr><w:t>}}</w:t></w:r>');
-        self::assertEquals('<w:t>$</w:t></w:r><w:bookmarkStart w:id="0" w:name="_GoBack"/><w:bookmarkEnd w:id="0"/><w:r><w:t xml:space="preserve">15,000.00. </w:t></w:r><w:r w:rsidR="0056499B"><w:t>{{variable_name}}</w:t></w:r>', $fixed);
+        self::assertEquals('<w:t>$</w:t></w:r><w:bookmarkStart w:id="0" w:name="_GoBack"/><w:bookmarkEnd w:id="0"/><w:r><w:t xml:space="preserve">15,000.00. </w:t></w:r><w:r w:rsidR="0056499B"><w:t>{{variable_name}}</w:t></w:r><w:r w:rsidR="00573DFD" w:rsidRPr="00573DFD"><w:rPr><w:iCs/></w:rPr><w:t xml:space="preserve"></w:t></w:r><w:proofErr w:type="spellStart"/><w:r w:rsidR="00573DFD" w:rsidRPr="00573DFD"><w:rPr><w:iCs/></w:rPr><w:t xml:space="preserve"></w:t></w:r><w:proofErr w:type="spellEnd"/><w:r w:rsidR="00573DFD" w:rsidRPr="00573DFD"><w:rPr><w:iCs/></w:rPr><w:t xml:space="preserve"></w:t></w:r>', $fixed);
+
+        $fixed = $templateProcessor->fixBrokenMacros('<w:r><w:t>before {{</w:t></w:r><w:r><w:t xml:space="preserve">variable}} </w:t></w:r><w:r><w:t>after</w:t></w:r>');
+        self::assertEquals('<w:r><w:t>before {{variable}}</w:t></w:r><w:r><w:t xml:space="preserve"> </w:t></w:r><w:r><w:t>after</w:t></w:r>', $fixed);
+
+        $fixed = $templateProcessor->fixBrokenMacros('<w:r><w:t>before {{</w:t></w:r><w:r><w:t>variable</w:t></w:r><w:r><w:t xml:space="preserve">}} </w:t></w:r><w:r><w:t>after</w:t></w:r>');
+        self::assertEquals('<w:r><w:t>before {{variable}}</w:t></w:r><w:r><w:t xml:space="preserve"></w:t></w:r><w:r><w:t xml:space="preserve"> </w:t></w:r><w:r><w:t>after</w:t></w:r>', $fixed);
+
+        $fixed = $templateProcessor->fixBrokenMacros('<w:r><w:t>{{</w:t></w:r><w:r><w:t>variable1</w:t></w:r><w:r><w:t>}} {{</w:t></w:r><w:r><w:t>variable2</w:t></w:r><w:r><w:t>}}</w:t></w:r>');
+        self::assertEquals('<w:r><w:t>{{variable1}}</w:t></w:r><w:r><w:t xml:space="preserve"></w:t></w:r><w:r><w:t xml:space="preserve"> {{variable2}}</w:t></w:r><w:r><w:t xml:space="preserve"></w:t></w:r><w:r><w:t xml:space="preserve"></w:t></w:r>', $fixed);
     }
 
     /**

--- a/tests/PhpWordTests/TemplateProcessorTest.php
+++ b/tests/PhpWordTests/TemplateProcessorTest.php
@@ -1253,19 +1253,28 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
         self::assertEquals('<w:r><w:t>${documentContent}</w:t></w:r>', $fixed);
 
         $fixed = $templateProcessor->fixBrokenMacros('<w:r><w:t>$</w:t><w:t>{documentContent}</w:t></w:r>');
-        self::assertEquals('<w:r><w:t>${documentContent}</w:t></w:r>', $fixed);
+        self::assertEquals('<w:r><w:t>${documentContent}</w:t><w:t xml:space="preserve"></w:t></w:r>', $fixed);
 
         $fixed = $templateProcessor->fixBrokenMacros('<w:r><w:t>$1500</w:t><w:t>${documentContent}</w:t></w:r>');
         self::assertEquals('<w:r><w:t>$1500</w:t><w:t>${documentContent}</w:t></w:r>', $fixed);
 
         $fixed = $templateProcessor->fixBrokenMacros('<w:r><w:t>$1500</w:t><w:t>$</w:t><w:t>{documentContent}</w:t></w:r>');
-        self::assertEquals('<w:r><w:t>$1500</w:t><w:t>${documentContent}</w:t></w:r>', $fixed);
+        self::assertEquals('<w:r><w:t>$1500</w:t><w:t>${documentContent}</w:t><w:t xml:space="preserve"></w:t></w:r>', $fixed);
 
         $fixed = $templateProcessor->fixBrokenMacros('<w:r><w:t>25$ plus some info {hint}</w:t></w:r>');
         self::assertEquals('<w:r><w:t>25$ plus some info {hint}</w:t></w:r>', $fixed);
 
         $fixed = $templateProcessor->fixBrokenMacros('<w:t>$</w:t></w:r><w:bookmarkStart w:id="0" w:name="_GoBack"/><w:bookmarkEnd w:id="0"/><w:r><w:t xml:space="preserve">15,000.00. </w:t></w:r><w:r w:rsidR="0056499B"><w:t>$</w:t></w:r><w:r w:rsidR="00573DFD" w:rsidRPr="00573DFD"><w:rPr><w:iCs/></w:rPr><w:t>{</w:t></w:r><w:proofErr w:type="spellStart"/><w:r w:rsidR="00573DFD" w:rsidRPr="00573DFD"><w:rPr><w:iCs/></w:rPr><w:t>variable_name</w:t></w:r><w:proofErr w:type="spellEnd"/><w:r w:rsidR="00573DFD" w:rsidRPr="00573DFD"><w:rPr><w:iCs/></w:rPr><w:t>}</w:t></w:r>');
-        self::assertEquals('<w:t>$</w:t></w:r><w:bookmarkStart w:id="0" w:name="_GoBack"/><w:bookmarkEnd w:id="0"/><w:r><w:t xml:space="preserve">15,000.00. </w:t></w:r><w:r w:rsidR="0056499B"><w:t>${variable_name}</w:t></w:r>', $fixed);
+        self::assertEquals('<w:t>$</w:t></w:r><w:bookmarkStart w:id="0" w:name="_GoBack"/><w:bookmarkEnd w:id="0"/><w:r><w:t xml:space="preserve">15,000.00. </w:t></w:r><w:r w:rsidR="0056499B"><w:t>${variable_name}</w:t></w:r><w:r w:rsidR="00573DFD" w:rsidRPr="00573DFD"><w:rPr><w:iCs/></w:rPr><w:t xml:space="preserve"></w:t></w:r><w:proofErr w:type="spellStart"/><w:r w:rsidR="00573DFD" w:rsidRPr="00573DFD"><w:rPr><w:iCs/></w:rPr><w:t xml:space="preserve"></w:t></w:r><w:proofErr w:type="spellEnd"/><w:r w:rsidR="00573DFD" w:rsidRPr="00573DFD"><w:rPr><w:iCs/></w:rPr><w:t xml:space="preserve"></w:t></w:r>', $fixed);
+
+        $fixed = $templateProcessor->fixBrokenMacros('<w:r><w:t>before ${</w:t></w:r><w:r><w:t xml:space="preserve">variable} </w:t></w:r><w:r><w:t>after</w:t></w:r>');
+        self::assertEquals('<w:r><w:t>before ${variable}</w:t></w:r><w:r><w:t xml:space="preserve"> </w:t></w:r><w:r><w:t>after</w:t></w:r>', $fixed);
+
+        $fixed = $templateProcessor->fixBrokenMacros('<w:r><w:t>before ${</w:t></w:r><w:r><w:t>variable</w:t></w:r><w:r><w:t xml:space="preserve">} </w:t></w:r><w:r><w:t>after</w:t></w:r>');
+        self::assertEquals('<w:r><w:t>before ${variable}</w:t></w:r><w:r><w:t xml:space="preserve"></w:t></w:r><w:r><w:t xml:space="preserve"> </w:t></w:r><w:r><w:t>after</w:t></w:r>', $fixed);
+
+        $fixed = $templateProcessor->fixBrokenMacros('<w:r><w:t>${</w:t></w:r><w:r><w:t>variable1</w:t></w:r><w:r><w:t>} ${</w:t></w:r><w:r><w:t>variable2</w:t></w:r><w:r><w:t>}</w:t></w:r>');
+        self::assertEquals('<w:r><w:t>${variable1}</w:t></w:r><w:r><w:t xml:space="preserve"></w:t></w:r><w:r><w:t xml:space="preserve"> ${variable2}</w:t></w:r><w:r><w:t xml:space="preserve"></w:t></w:r><w:r><w:t xml:space="preserve"></w:t></w:r>', $fixed);
     }
 
     /**


### PR DESCRIPTION
### Description

This is a proposal to fix #590 in a cleaner way than a global regex on the whole document, which might change parts of the document that must not change.

*Edit: see https://github.com/PHPOffice/PHPWord/pull/1971#issuecomment-970481810*

`TemplateProcessor::fixBrokenMacros()` is a method that strip all tags between `${`, the name of the variable and `}` (let's call them the 3 parts). If there is a `<w:t xml:space="preserve">` in those tags it means that there is a trailing space at the end of the content of the tag, because there is not supposed to be any space between the 3 parts, so the whole must be inside of it in order to keep this trailing space.

Examples:
```xml
<w:r><w:t>before ${</w:t></w:r><w:r><w:t xml:space="preserve">variable} </w:t></w:r><w:r><w:t>after</w:t></w:r>
                                                                       |
                                                              the trailing space

<w:r><w:t>before ${</w:t></w:r><w:r><w:t>variable</w:t></w:r><w:r><w:t xml:space="preserve">} </w:t></w:r><w:r><w:t>after</w:t></w:r>
                                                                                             |
                                                                                    the trailing space
```

I think it's safe to move the opening tag just before the variable, but one thing I'm not sure about because I don't know Open XML very well, is whether it's safe to prepend the variable by `</w:t></w:r><w:r><w:t xml:space="preserve">`. I think it's ok if a `<w:t>` is necessarily in a `<w:r>` and there cannot be multiple `<w:t>` in a `<w:r>` (otherwise we could just remove the `</w:r><w:r>` part).

Expected result of the above examples:
```xml
<w:r><w:t>before </w:t></w:r><w:r><w:t xml:space="preserve">${variable} </w:t></w:r><w:r><w:t>after</w:t></w:r>
```

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
=> it's a bug fix
