### PR TITLE
Replace abandoned zend-escaper by laminas-escaper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     "require": {
         "php": "^5.3.3 || ^7.0",
         "ext-xml": "*",
-        "zendframework/zend-escaper": "^2.2",
+        "laminas/laminas-escaper": "^2.2",
         "phpoffice/common": "^0.2.9"
     },
     "require-dev": {


### PR DESCRIPTION
See: https://github.com/zendframework/zend-escaper

### Description

This fixes the following warning when installing `phpoffice/phpword` by replacing the *abandoned* [zendframework/zend-escaper](https://github.com/zendframework/zend-escaper) by [laminas/laminas-escaper](https://github.com/laminas/laminas-escaper):

```
Package zendframework/zend-escaper is abandoned, you should avoid using it. Use laminas/laminas-escaper instead.
```

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
