### PR TITLE
php 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "fix": "Fixes issues found by PHP-CS"
     },
     "require": {
-        "php": "^5.3.3 || ^7.0",
+        "php": "^5.3.3 || ^7.0 || ^8.0",
         "ext-xml": "*",
         "zendframework/zend-escaper": "^2.2",
         "phpoffice/common": "^0.2.9"


### PR DESCRIPTION
### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

phpword can't be included into a PHP 8.0 project

phpoffice/phpword 0.17.0 requires php ^5.3.3 || ^7.0 -> your PHP version (8.0.0) does not satisfy that requirement.


Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
