### PR TITLE
Clone row issue [Text between two tables (both with merge cell) got c…

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -686,8 +686,8 @@ class TemplateProcessor
 
                 // If tmpXmlRow doesn't contain continue, this row is no longer part of the spanned row.
                 $tmpXmlRow = $this->getSlice($extraRowStart, $extraRowEnd);
-                if (!preg_match('#<w:vMerge/>#', $tmpXmlRow) &&
-                    !preg_match('#<w:vMerge w:val="continue"\s*/>#', $tmpXmlRow)) {
+                if (preg_match('#</w:tbl>#', $tmpXmlRow) || (!preg_match('#<w:vMerge/>#', $tmpXmlRow) &&
+                    !preg_match('#<w:vMerge w:val="continue"\s*/>#', $tmpXmlRow))) {
                     break;
                 }
                 // This row was a spanned row, update $rowEnd and search for the next row.


### PR DESCRIPTION
Clone row issue [Text between two tables (both with merge cell) got clone when applying cloneRow to the last row (with merge cell) of first table] fix

### Description

I have two tables in a word template, both with merge cells. When applying cloneRow to the last row (with merge cells) on the first table, the text between the first and second table got clone as well. 

Fixes # (issue)
In the merge cell checking, added a checking to stop cloning when close table tag is found.

`if (`**preg_match('#</w:tbl>#', $tmpXmlRow)** `|| (!preg_match('#<w:vMerge/>#', $tmpXmlRow) &&
                    !preg_match('#<w:vMerge w:val="continue"\s*/>#', $tmpXmlRow))) {
                    break;
                }`

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
