### PR TITLE
allow to use customized pdf library

### DIFF
--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -109,6 +109,7 @@ abstract class AbstractContainer extends AbstractElement
             } else {
                 // All other elements
                 array_unshift($args, $element); // Prepend element name to the beginning of args array
+
                 return call_user_func_array(array($this, 'addElement'), $args);
             }
         }

--- a/src/PhpWord/Writer/PDF/DomPDF.php
+++ b/src/PhpWord/Writer/PDF/DomPDF.php
@@ -36,6 +36,16 @@ class DomPDF extends AbstractRenderer implements WriterInterface
     protected $includeFile = null;
 
     /**
+     * Gets the implementation of external PDF library that should be used.
+     *
+     * @return Dompdf implementation
+     */
+    protected function createExternalWriterInstance()
+    {
+        return new DompdfLib();
+    }
+
+    /**
      * Save PhpWord to file.
      *
      * @param string $filename Name of the file to save as
@@ -49,7 +59,7 @@ class DomPDF extends AbstractRenderer implements WriterInterface
         $orientation = 'portrait';
 
         //  Create PDF
-        $pdf = new DompdfLib();
+        $pdf = $this->createExternalWriterInstance();
         $pdf->setPaper(strtolower($paperSize), $orientation);
         $pdf->loadHtml(str_replace(PHP_EOL, '', $this->getContent()));
         $pdf->render();

--- a/src/PhpWord/Writer/PDF/MPDF.php
+++ b/src/PhpWord/Writer/PDF/MPDF.php
@@ -45,6 +45,18 @@ class MPDF extends AbstractRenderer implements WriterInterface
     }
 
     /**
+     * Gets the implementation of external PDF library that should be used.
+     *
+     * @return Mpdf implementation
+     */
+    protected function createExternalWriterInstance()
+    {
+        $mPdfClass = $this->getMPdfClassName();
+
+        return new $mPdfClass();
+    }
+
+    /**
      * Save PhpWord to file.
      *
      * @param string $filename Name of the file to save as
@@ -58,8 +70,7 @@ class MPDF extends AbstractRenderer implements WriterInterface
         $orientation = strtoupper('portrait');
 
         //  Create PDF
-        $mPdfClass = $this->getMPdfClassName();
-        $pdf = new $mPdfClass();
+        $pdf = $this->createExternalWriterInstance();
         $pdf->_setPageSize($paperSize, $orientation);
         $pdf->addPage($orientation);
 

--- a/src/PhpWord/Writer/PDF/TCPDF.php
+++ b/src/PhpWord/Writer/PDF/TCPDF.php
@@ -37,6 +37,20 @@ class TCPDF extends AbstractRenderer implements WriterInterface
     protected $includeFile = 'tcpdf.php';
 
     /**
+     * Gets the implementation of external PDF library that should be used.
+     *
+     * @param string $orientation Page orientation
+     * @param string $unit Unit measure
+     * @param string $paperSize Paper size
+     *
+     * @return \TCPDF implementation
+     */
+    protected function createExternalWriterInstance($orientation, $unit, $paperSize)
+    {
+        return new \TCPDF($orientation, $unit, $paperSize);
+    }
+
+    /**
      * Save PhpWord to file.
      *
      * @param string $filename Name of the file to save as
@@ -50,7 +64,7 @@ class TCPDF extends AbstractRenderer implements WriterInterface
         $orientation = 'P';
 
         // Create PDF
-        $pdf = new \TCPDF($orientation, 'pt', $paperSize);
+        $pdf = $this->createExternalWriterInstance($orientation, 'pt', $paperSize);
         $pdf->setFontSubsetting(false);
         $pdf->setPrintHeader(false);
         $pdf->setPrintFooter(false);


### PR DESCRIPTION
### Description

Allow to use customized PDF library without rewriting save() method.
Customized PDF libray sample: https://tcpdf.org/examples/example_003/

Similar to PhpSpreadsheet merged PR (https://github.com/PHPOffice/PhpSpreadsheet/pull/266)

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
