### PR TITLE
html writer: pgbreak, tabs, borders

### DIFF
--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -109,6 +109,7 @@ abstract class AbstractContainer extends AbstractElement
             } else {
                 // All other elements
                 array_unshift($args, $element); // Prepend element name to the beginning of args array
+
                 return call_user_func_array(array($this, 'addElement'), $args);
             }
         }

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -165,7 +165,7 @@ abstract class AbstractPart
             // Text and TextRun
             $textRunContainers = $xmlReader->countElements('w:r|w:ins|w:del|w:hyperlink|w:smartTag', $domNode);
             if (0 === $textRunContainers) {
-                $parent->addTextBreak(null, $paragraphStyle);
+                $parent->addTextBreak(null, null, $paragraphStyle);
             } else {
                 $nodes = $xmlReader->getElements('*', $domNode);
                 $paragraph = $parent->addTextRun($paragraphStyle);
@@ -289,9 +289,13 @@ abstract class AbstractPart
                 $parent->addText($textContent, $fontStyle, $paragraphStyle);
             }
         } elseif ($node->nodeName == 'w:br') {
-            $parent->addTextBreak();
+            if ($xmlReader->getAttribute('w:type', $node) == 'page') {
+                $parent->getParent()->addPageBreak(); // PageBreak
+            } else {
+                $parent->addTextBreak(null, null, $paragraphStyle);
+            }
         } elseif ($node->nodeName == 'w:tab') {
-            $parent->addText("\t");
+            $parent->addText("\t", $fontStyle, $paragraphStyle);
         } elseif ($node->nodeName == 'w:t' || $node->nodeName == 'w:delText') {
             // TextRun
             $textContent = htmlspecialchars($xmlReader->getValue('.', $node), ENT_QUOTES, 'UTF-8');
@@ -407,7 +411,35 @@ abstract class AbstractPart
             'suppressAutoHyphens' => array(self::READ_TRUE,  'w:suppressAutoHyphens'),
         );
 
-        return $this->readStyleDefs($xmlReader, $styleNode, $styleDefs);
+        $styles = $this->readStyleDefs($xmlReader, $styleNode, $styleDefs);
+
+        // fontStyle
+        if ($xmlReader->elementExists('w:rPr', $styleNode)) {
+            $styles['fontStyle'] = $this->readFontStyle($xmlReader, $styleNode);
+        }
+
+        // tabs config
+        if ($xmlReader->elementExists('w:tabs', $styleNode)) {
+            // http://officeopenxml.com/WPtab.php
+            $tabs = array();
+            $tabsList = $xmlReader->getElements('w:tabs/w:tab', $styleNode);
+            foreach ($tabsList as $tabNode) {
+                $tab = array();
+                $attrs = array('leader', 'pos', 'val'); // pos in twips!
+                foreach ($attrs as $attr) {
+                    if ($val = $xmlReader->getAttribute('w:' . $attr, $tabNode)) {
+                        $tab[$attr] = $val;
+                    }
+                }
+                $tabs[] = $tab;
+            }
+
+            if ($tabs) {
+                $styles['tabs'] = $tabs;
+            }
+        }
+
+        return $styles;
     }
 
     /**
@@ -565,6 +597,18 @@ abstract class AbstractPart
             'vMerge'        => array(self::READ_VALUE, 'w:vMerge'),
             'bgColor'       => array(self::READ_VALUE, 'w:shd', 'w:fill'),
         );
+
+        // border style defs
+        // http://officeopenxml.com/WPtableCellProperties-Borders.php
+        $margins = array('top', 'left', 'bottom', 'right');
+        $borders = array_merge($margins, array('insideH', 'insideV'));
+        foreach ($borders as $side) {
+            $ucfSide = ucfirst($side);
+            $styleDefs["border{$ucfSide}Size"] = array(self::READ_VALUE, "w:tcBorders/w:$side", 'w:sz');
+            $styleDefs["border{$ucfSide}Color"] = array(self::READ_VALUE, "w:tcBorders/w:$side", 'w:color');
+            $styleDefs["border{$ucfSide}Style"] = array(self::READ_VALUE, "w:tcBorders/w:$side", 'w:val');
+//            $styleDefs["border{$ucfSide}Space"] = array(self::READ_VALUE, "w:tcBorders/w:$side", 'w:space');
+        }
 
         return $this->readStyleDefs($xmlReader, $domNode, $styleDefs);
     }

--- a/src/PhpWord/Reader/Word2007/Document.php
+++ b/src/PhpWord/Reader/Word2007/Document.php
@@ -149,11 +149,6 @@ class Document extends AbstractPart
      */
     private function readWPNode(XMLReader $xmlReader, \DOMElement $node, Section &$section)
     {
-        // Page break
-        if ($xmlReader->getAttribute('w:type', $node, 'w:r/w:br') == 'page') {
-            $section->addPageBreak(); // PageBreak
-        }
-
         // Paragraph
         $this->readParagraph($xmlReader, $node, $section);
 

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -282,7 +282,16 @@ class Html
      */
     protected static function parseProperty(&$styles, $argument1, $argument2)
     {
-        $styles['font'][$argument1] = $argument2;
+        if ($argument1 !== 'span') {
+            $styles['font'][$argument1] = $argument2;
+        } else {
+            if (!is_null($argument2->attributes)) {
+                $nodeAttr = $argument2->attributes->getNamedItem('style');
+                if (!is_null($nodeAttr) && property_exists($nodeAttr, 'value')) {
+                    $styles['font'] = self::parseStyle($nodeAttr, $styles['font']);
+                }
+            }
+        }
     }
 
     /**

--- a/src/PhpWord/Style/Paragraph.php
+++ b/src/PhpWord/Style/Paragraph.php
@@ -43,7 +43,6 @@ use PhpOffice\PhpWord\SimpleType\TextAlignment;
  * - Outline & numbering
  * - Tabs
  * - Dropcaps
- * - Tabs
  * - Borders
  * - Background
  *
@@ -186,6 +185,13 @@ class Paragraph extends Border
      * @var bool
      */
     private $suppressAutoHyphens = false;
+
+    /**
+     * Text style
+     *
+     * @var string|\PhpOffice\PhpWord\Style\Font
+     */
+    protected $fontStyle;
 
     /**
      * Set Style value
@@ -870,5 +876,37 @@ class Paragraph extends Border
     public function setSuppressAutoHyphens($suppressAutoHyphens)
     {
         $this->suppressAutoHyphens = (bool) $suppressAutoHyphens;
+    }
+
+    /**
+     * Get Text style
+     *
+     * @return string|\PhpOffice\PhpWord\Style\Font
+     */
+    public function getFontStyle()
+    {
+        return $this->fontStyle;
+    }
+
+    /**
+     * Set Text style
+     *
+     * @param string|array|\PhpOffice\PhpWord\Style\Font $style
+     * @return string|\PhpOffice\PhpWord\Style\Font
+     */
+    public function setFontStyle($style = null)
+    {
+        if ($style instanceof Font) {
+            $this->fontStyle = $style;
+        } elseif (is_array($style)) {
+            $this->fontStyle = new Font('text');
+            $this->fontStyle->setStyleByArray($style);
+        } elseif (null === $style) {
+            $this->fontStyle = new Font('text');
+        } else {
+            $this->fontStyle = $style;
+        }
+
+        return $this->fontStyle;
     }
 }

--- a/src/PhpWord/Style/Table.php
+++ b/src/PhpWord/Style/Table.php
@@ -216,7 +216,7 @@ class Table extends Border
     }
 
     /**
-     * Set first row
+     * Get first row
      *
      * @return \PhpOffice\PhpWord\Style\Table
      */

--- a/src/PhpWord/Writer/HTML/Element/Container.php
+++ b/src/PhpWord/Writer/HTML/Element/Container.php
@@ -76,7 +76,7 @@ class Container extends AbstractElement
                 /** @var \PhpOffice\PhpWord\Writer\HTML\Element\AbstractElement $writer Type hint */
                 $writer = new $writerClass($this->parentWriter, $element, $withoutP);
                 if ($tabsCfg && (count($tabsCfg) > $tabsIdx) && ($writerClass == $this->namespace . '\\Text') && ($element->getText() == "\t")) {
-                    $this->SetupTabStopElement($elementsContent, $currentColumnIdx, $currentFontStyle, $tabsCfg, $tabsIdx, $prevColumnSize);
+                    $this->setupTabStopElement($elementsContent, $currentColumnIdx, $currentFontStyle, $tabsCfg, $tabsIdx, $prevColumnSize);
 
                     // setup new tabs start
                     $currentFontStyle = array();
@@ -92,7 +92,7 @@ class Container extends AbstractElement
         }
 
         if ($tabsCfg) {
-            $this->SetupTabStopElement($elementsContent, $currentColumnIdx, $currentFontStyle, $tabsCfg, $tabsIdx, $prevColumnSize);
+            $this->setupTabStopElement($elementsContent, $currentColumnIdx, $currentFontStyle, $tabsCfg, $tabsIdx, $prevColumnSize);
             if (is_null($elementsContent[$currentColumnIdx])) {
                 $elementsContent[$currentColumnIdx] = ($currentColumnIdx > 1 ? '</td>' : '') . '<td class="tabstop">';
             }
@@ -104,7 +104,7 @@ class Container extends AbstractElement
         return $content;
     }
 
-    private function SetupTabStopElement(&$elementsContent, $currentColumnIdx, $currentFontStyle, $tabsCfg, &$tabsIdx, &$prevColumnSize)
+    private function setupTabStopElement(&$elementsContent, $currentColumnIdx, $currentFontStyle, $tabsCfg, &$tabsIdx, &$prevColumnSize)
     {
         $columnHtml = implode('', array_slice($elementsContent, $currentColumnIdx + 1));
         $columnText = preg_replace("/\s+/", ' ', strip_tags($columnHtml));

--- a/src/PhpWord/Writer/HTML/Element/Container.php
+++ b/src/PhpWord/Writer/HTML/Element/Container.php
@@ -45,9 +45,29 @@ class Container extends AbstractElement
             return '';
         }
         $containerClass = substr(get_class($container), strrpos(get_class($container), '\\') + 1);
-        $withoutP = in_array($containerClass, array('TextRun', 'Footnote', 'Endnote')) ? true : false;
+        $withoutP = in_array($containerClass, array('TextRun', 'Footnote', 'Endnote'));
         $content = '';
 
+        $tabsIdx = -1;
+        $tabsCfg = array();
+        if ($withoutP) {
+            $paragraphStyle = $container->getParagraphStyle();
+            if (is_object($paragraphStyle)) {
+                $tabsCfg = $paragraphStyle->getTabs();
+            }
+        }
+
+        $currentFontStyle = array();
+        $currentColumnIdx = -1;
+        $elementsContent = array();
+        $prevColumnSize = 0;
+        if ($tabsCfg) {
+            $elementsContent[] = '<table class="tabstops"><tr>';
+            $elementsContent[] = null;
+            $currentColumnIdx = count($elementsContent) - 1;
+        }
+
+        $tabIdxs = array();
         $elements = $container->getElements();
         foreach ($elements as $element) {
             $elementClass = get_class($element);
@@ -55,10 +75,70 @@ class Container extends AbstractElement
             if (class_exists($writerClass)) {
                 /** @var \PhpOffice\PhpWord\Writer\HTML\Element\AbstractElement $writer Type hint */
                 $writer = new $writerClass($this->parentWriter, $element, $withoutP);
-                $content .= $writer->write();
+                if ($tabsCfg && (count($tabsCfg) > $tabsIdx) && ($writerClass == $this->namespace . '\\Text') && ($element->getText() == "\t")) {
+                    $this->SetupTabStopElement($elementsContent, $currentColumnIdx, $currentFontStyle, $tabsCfg, $tabsIdx, $prevColumnSize);
+
+                    // setup new tabs start
+                    $currentFontStyle = array();
+                    $elementsContent[] = null;
+                    $currentColumnIdx = count($elementsContent) - 1;
+                } else {
+                    $elementsContent[] = $writer->write();
+                    if (method_exists($element, 'getFontStyle') && ($fontStyle = $element->getFontStyle())) {
+                        $currentFontStyle = array_merge_recursive($currentFontStyle, $fontStyle->getStyleValues());
+                    }
+                }
             }
         }
 
+        if ($tabsCfg) {
+            $this->SetupTabStopElement($elementsContent, $currentColumnIdx, $currentFontStyle, $tabsCfg, $tabsIdx, $prevColumnSize);
+            if (is_null($elementsContent[$currentColumnIdx])) {
+                $elementsContent[$currentColumnIdx] = ($currentColumnIdx > 1 ? '</td>' : '') . '<td class="tabstop">';
+            }
+            $elementsContent[] = '</td></tr></table>';
+        }
+
+        $content .= implode('', $elementsContent);
+
         return $content;
+    }
+
+    private function SetupTabStopElement(&$elementsContent, $currentColumnIdx, $currentFontStyle, $tabsCfg, &$tabsIdx, &$prevColumnSize)
+    {
+        $columnHtml = implode('', array_slice($elementsContent, $currentColumnIdx + 1));
+        $columnText = preg_replace("/\s+/", ' ', strip_tags($columnHtml));
+
+        $fontSize = null;
+        if (isset($currentFontStyle['basic']['size'])) {
+            $fontSize = $currentFontStyle['basic']['size'];
+            if (is_array($fontSize)) {
+                $fontSize = max($fontSize);
+            }
+        }
+        if (!$fontSize) {
+            $fontSize = 10;
+        } // default value
+
+        if (isset($currentFontStyle['style']['bold']) && $currentFontStyle['style']['bold']) {
+            if (!is_array($currentFontStyle['style']['bold']) || in_array(true, $currentFontStyle['style']['bold'])) {
+                $fontSize *= 1.2;
+            }
+        }
+
+        $textWidthPt = strlen($columnText) * $fontSize * 0.35; // TODO: make better calculation size of text
+        $textWidthTwip = $textWidthPt * 20;
+        $idx = $tabsIdx + 1;
+        while ($idx < count($tabsCfg)) {
+            if (($tabsCfg[$idx]['pos'] - $prevColumnSize) > $textWidthTwip) {
+                $tabsIdx = $idx;
+                $size = ($tabsCfg[$idx]['pos'] - $prevColumnSize) / 20;
+                $elementsContent[$currentColumnIdx] = ($currentColumnIdx > 1 ? '</td>' : '')
+                                                        . '<td class="tabstop" style="width:' . $size . 'pt;">';
+                $prevColumnSize = $tabsCfg[$idx]['pos'];
+                break;
+            }
+            $idx++;
+        }
     }
 }

--- a/src/PhpWord/Writer/HTML/Element/PageBreak.php
+++ b/src/PhpWord/Writer/HTML/Element/PageBreak.php
@@ -39,6 +39,6 @@ class PageBreak extends TextBreak
             return '<pagebreak style="page-break-before: always;" pagebreak="true"></pagebreak>';
         }
 
-        return '';
+        return '<div style="line-height:0; margin:0; padding:0; page-break-before: always;"></div>';
     }
 }

--- a/src/PhpWord/Writer/HTML/Element/Table.php
+++ b/src/PhpWord/Writer/HTML/Element/Table.php
@@ -54,8 +54,8 @@ class Table extends AbstractElement
 
             $borderStyleConverter = array(
                 'single'=> 'solid',
-                'none'	 => 'none',
-                'nil'	  => 'hidden',
+                'none'  => 'none',
+                'nil'   => 'hidden',
                 'dotted'=> 'dotted',
                 'dashed'=> 'dashed',
                 'double'=> 'double',
@@ -131,7 +131,7 @@ class Table extends AbstractElement
                             if ($cellBorderSizes[$k] > 0) {
                                 $borderColor = $cellBorderColors[$k];
                                 if ($borderColor == 'auto') {
-                                    $borderColor = '000';	// TODO: Detect better color
+                                    $borderColor = '000';  // TODO: Detect better color
                                 }
                                 $borderStyle = $cellBorderStyles[$k];
                                 if (isset($borderStyleConverter[$borderStyle])) {

--- a/src/PhpWord/Writer/HTML/Element/Table.php
+++ b/src/PhpWord/Writer/HTML/Element/Table.php
@@ -17,6 +17,9 @@
 
 namespace PhpOffice\PhpWord\Writer\HTML\Element;
 
+use PhpOffice\PhpWord\Style;
+use PhpOffice\PhpWord\Writer\HTML\Style\Table as TextStyleWriter;
+
 /**
  * Table element HTML writer
  *
@@ -36,10 +39,45 @@ class Table extends AbstractElement
         }
 
         $content = '';
+        $tableStyle = $this->element->getStyle();
         $rows = $this->element->getRows();
         $rowCount = count($rows);
         if ($rowCount > 0) {
-            $content .= '<table' . self::getTableStyle($this->element->getStyle()) . '>' . PHP_EOL;
+            $content .= '<table' . $this->getTableStyle($tableStyle) . '>' . PHP_EOL;
+
+            if (is_string($tableStyle)) {
+                $customStyles = Style::getStyles();
+                if (is_array($customStyles) && isset($customStyles[$tableStyle])) {
+                    $tableStyle = $customStyles[$tableStyle];
+                }
+            }
+
+            $borderStyleConverter = array(
+                'single'=> 'solid',
+                'none'	 => 'none',
+                'nil'	  => 'hidden',
+                'dotted'=> 'dotted',
+                'dashed'=> 'dashed',
+                'double'=> 'double',
+                'inset' => 'inset',
+                'outset'=> 'outset',
+            );
+            $cellStyles = array();
+            if (is_object($tableStyle)) {
+                $cellHBorderSize = $tableStyle->getBorderInsideHSize();
+                $cellVBorderSize = $tableStyle->getBorderInsideVSize();
+                if (!is_null($cellHBorderSize)) {
+                    $style = ($cellHBorderSize / 8) . 'pt solid #' . $tableStyle->getBorderInsideHColor();
+                    $cellStyles[] = 'border-top: ' . $style;
+                    $cellStyles[] = 'border-bottom: ' . $style;
+                }
+                if (!is_null($cellVBorderSize)) {
+                    $style = ($cellVBorderSize / 8) . 'pt solid #' . $tableStyle->getBorderInsideVColor();
+                    $cellStyles[] = 'border-left: ' . $style;
+                    $cellStyles[] = 'border-right: ' . $style;
+                }
+            }
+            $cellStyleString = implode('; ', $cellStyles);
 
             for ($i = 0; $i < $rowCount; $i++) {
                 /** @var $row \PhpOffice\PhpWord\Element\Row Type hint */
@@ -84,7 +122,33 @@ class Table extends AbstractElement
                         $cellRowSpanAttr = ($cellRowSpan > 1 ? " rowspan=\"{$cellRowSpan}\"" : '');
                         $cellBgColorAttr = (is_null($cellBgColor) ? '' : " bgcolor=\"#{$cellBgColor}\"");
                         $cellFgColorAttr = (is_null($cellFgColor) ? '' : " color=\"#{$cellFgColor}\"");
-                        $content .= "<{$cellTag}{$cellColSpanAttr}{$cellRowSpanAttr}{$cellBgColorAttr}{$cellFgColorAttr}>" . PHP_EOL;
+
+                        $localBorderStyles = array();
+                        $cellBorderSizes = $cellStyle->getBorderSize();
+                        $cellBorderColors = $cellStyle->getBorderColor();
+                        $cellBorderStyles = $cellStyle->getBorderStyle();
+                        foreach (array('top', 'left', 'right', 'bottom') as $k => $name) {
+                            if ($cellBorderSizes[$k] > 0) {
+                                $borderColor = $cellBorderColors[$k];
+                                if ($borderColor == 'auto') {
+                                    $borderColor = '000';	// TODO: Detect better color
+                                }
+                                $borderStyle = $cellBorderStyles[$k];
+                                if (isset($borderStyleConverter[$borderStyle])) {
+                                    $borderStyle = $borderStyleConverter[$borderStyle];
+                                } else {
+                                    $borderStyle = 'solid';
+                                }
+                                $localBorderStyles[] = "border-{$name}:" . ($cellBorderSizes[$k] / 8) . 'pt ' . $borderStyle . ' #' . $borderColor;
+                            }
+                        }
+                        $localCellStylesString = $cellStyleString;
+                        if ($localBorderStyles) {
+                            $localCellStylesString .= '; ' . implode('; ', $localBorderStyles);
+                        }
+                        $cellStyle = (empty($localCellStylesString) ? '' : " style=\"{$localCellStylesString}\"");
+
+                        $content .= "<{$cellTag}{$cellColSpanAttr}{$cellRowSpanAttr}{$cellBgColorAttr}{$cellFgColorAttr}{$cellStyle}>" . PHP_EOL;
                         $writer = new Container($this->parentWriter, $rowCells[$j]);
                         $content .= $writer->write();
                         if ($cellRowSpan > 1) {
@@ -129,11 +193,8 @@ class Table extends AbstractElement
             $style = ' class="' . $tableStyle;
         } else {
             $style = ' style="';
-            if ($tableStyle->getLayout() == \PhpOffice\PhpWord\Style\Table::LAYOUT_FIXED) {
-                $style .= 'table-layout: fixed;';
-            } elseif ($tableStyle->getLayout() == \PhpOffice\PhpWord\Style\Table::LAYOUT_AUTO) {
-                $style .= 'table-layout: auto;';
-            }
+            $styleWriter = new TextStyleWriter($tableStyle);
+            $style .= $styleWriter->write();
         }
 
         return $style . '"';

--- a/src/PhpWord/Writer/HTML/Element/Text.php
+++ b/src/PhpWord/Writer/HTML/Element/Text.php
@@ -79,7 +79,7 @@ class Text extends AbstractElement
         } elseif ($textContent === "\t") {
             $textContent = '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;';
         } elseif ($textContent === '') {
-            $textContent = '&nbsp;';	// html do not output empty paragraphs => add at least space
+            $textContent = '&nbsp;'; // html do not output empty paragraphs => add at least space
         }
 
         $content = '';

--- a/src/PhpWord/Writer/HTML/Element/TextBreak.php
+++ b/src/PhpWord/Writer/HTML/Element/TextBreak.php
@@ -17,6 +17,9 @@
 
 namespace PhpOffice\PhpWord\Writer\HTML\Element;
 
+use PhpOffice\PhpWord\Style\Font;
+use PhpOffice\PhpWord\Writer\HTML\Style\Font as FontStyleWriter;
+
 /**
  * TextBreak element HTML writer
  *
@@ -34,9 +37,40 @@ class TextBreak extends AbstractElement
         if ($this->withoutP) {
             $content = '<br />' . PHP_EOL;
         } else {
-            $content = '<p>&nbsp;</p>' . PHP_EOL;
+            $style = $this->getFontStyle();
+            $content = "<p{$style}>&nbsp;</p>" . PHP_EOL;
         }
 
         return $content;
+    }
+
+    /**
+     * Get font style.
+     */
+    private function getFontStyle()
+    {
+        /** @var \PhpOffice\PhpWord\Element\Text $element Type hint */
+        $element = $this->element;
+        $pargraphStyle = $element->getParagraphStyle();
+        if (!$pargraphStyle) {
+            return '';
+        }
+
+        $style = '';
+        $fontStyle = $pargraphStyle->getFontStyle();
+        $fStyleIsObject = ($fontStyle instanceof Font);
+        if ($fStyleIsObject) {
+            $styleWriter = new FontStyleWriter($fontStyle);
+            $style = $styleWriter->write();
+        } elseif (is_string($fontStyle)) {
+            $style = $fontStyle;
+        }
+        if ($style) {
+            $attribute = $fStyleIsObject ? 'style' : 'class';
+
+            return " {$attribute}=\"{$style}\"";
+        }
+
+        return '';
     }
 }

--- a/src/PhpWord/Writer/HTML/Part/Head.php
+++ b/src/PhpWord/Writer/HTML/Part/Head.php
@@ -110,11 +110,11 @@ class Head extends AbstractPart
                 'border'        => '0',
             ),
             'p' => array(
-                'margin-top'	   => '0',
+                'margin-top'    => '0',
                 'margin-bottom' => '0',
             ),
             'div.paragraph' => array(
-                'margin'    	   => '0',
+                'margin'        => '0',
                 'margin-bottom' => '0',
             ),
             'table.tabstops'=> array(

--- a/src/PhpWord/Writer/HTML/Part/Head.php
+++ b/src/PhpWord/Writer/HTML/Part/Head.php
@@ -21,9 +21,11 @@ use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\Style;
 use PhpOffice\PhpWord\Style\Font;
 use PhpOffice\PhpWord\Style\Paragraph;
+use PhpOffice\PhpWord\Style\Table;
 use PhpOffice\PhpWord\Writer\HTML\Style\Font as FontStyleWriter;
 use PhpOffice\PhpWord\Writer\HTML\Style\Generic as GenericStyleWriter;
 use PhpOffice\PhpWord\Writer\HTML\Style\Paragraph as ParagraphStyleWriter;
+use PhpOffice\PhpWord\Writer\HTML\Style\Table as TableStyleWriter;
 
 /**
  * RTF head part writer
@@ -96,15 +98,33 @@ class Head extends AbstractPart
                 'padding'    => '0',
                 'margin'     => '1em 0',
                 'border'     => '0',
-                'border-top' => '1px solid #CCC',
+                'border-top' => '1px solid #ccc',
             ),
             'table' => array(
-                'border'         => '1px solid black',
-                'border-spacing' => '0px',
+                'border'         => '0',
+                'border-collapse'=> 'collapse',
+                'border-spacing' => '0',
                 'width '         => '100%',
             ),
             'td' => array(
-                'border' => '1px solid black',
+                'border'        => '0',
+            ),
+            'p' => array(
+                'margin-top'	   => '0',
+                'margin-bottom' => '0',
+            ),
+            'div.paragraph' => array(
+                'margin'    	   => '0',
+                'margin-bottom' => '0',
+            ),
+            'table.tabstops'=> array(
+                'width'         => 'auto',
+                'table-layout'  => 'fixed',
+                'border'        => '0',
+            ),
+            'td.tabstop'=> array(
+                'white-space'   => 'nowrap',
+                'border'        => '0',
             ),
         );
         foreach ($defaultStyles as $selector => $style) {
@@ -126,6 +146,10 @@ class Head extends AbstractPart
                     $css .= "{$name} {" . $styleWriter->write() . '}' . PHP_EOL;
                 } elseif ($style instanceof Paragraph) {
                     $styleWriter = new ParagraphStyleWriter($style);
+                    $name = '.' . $name;
+                    $css .= "{$name} {" . $styleWriter->write() . '}' . PHP_EOL;
+                } elseif ($style instanceof Table) {
+                    $styleWriter = new TableStyleWriter($style);
                     $name = '.' . $name;
                     $css .= "{$name} {" . $styleWriter->write() . '}' . PHP_EOL;
                 }

--- a/src/PhpWord/Writer/HTML/Style/Paragraph.php
+++ b/src/PhpWord/Writer/HTML/Style/Paragraph.php
@@ -18,6 +18,7 @@
 namespace PhpOffice\PhpWord\Writer\HTML\Style;
 
 use PhpOffice\PhpWord\SimpleType\Jc;
+use PhpOffice\PhpWord\Writer\HTML\Style\Font as FontStyleWriter;
 
 /**
  * Paragraph style HTML writer
@@ -78,6 +79,13 @@ class Paragraph extends AbstractStyle
         } else {
             $css['margin-top'] = '0';
             $css['margin-bottom'] = '0';
+        }
+
+        $fontStyle = $style->getFontStyle();
+        if ($fontStyle) {
+            $styleWriter = new FontStyleWriter($fontStyle);
+
+            return $this->assembleCss($css) . ' ' . $styleWriter->write();
         }
 
         return $this->assembleCss($css);


### PR DESCRIPTION
### Description

Add support in html writer page breakers, tabs and table borders.
Plus few fixes.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
