### PR TITLE
add/setting page element border style.

### DIFF
--- a/src/PhpWord/SimpleType/Border.php
+++ b/src/PhpWord/SimpleType/Border.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ * @copyright   2010-2018 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\SimpleType;
+
+use PhpOffice\PhpWord\Shared\AbstractEnum;
+
+/**
+ * Border Styles.
+ *
+ * @since 0.18.0
+ *
+ * @see  http://www.datypic.com/sc/ooxml/t-w_ST_Border.html
+ */
+final class Border extends AbstractEnum
+{
+    const SINGLE = 'single'; //A single line
+    const DASH_DOT_STROKED = 'dashDotStroked'; //A line with a series of alternating thin and thick strokes
+    const DASHED = 'dashed'; //A dashed line
+    const DASH_SMALL_GAP = 'dashSmallGap'; //A dashed line with small gaps
+    const DOT_DASH = 'dotDash'; //A line with alternating dots and dashes
+    const DOT_DOT_DASH = 'dotDotDash'; //A line with a repeating dot - dot - dash sequence
+    const DOTTED = 'dotted'; //A dotted line
+    const DOUBLE = 'double'; //A double line
+    const DOUBLE_WAVE = 'doubleWave'; //A double wavy line
+    const INSET = 'inset'; //An inset set of lines
+    const NIL = 'nil'; //No border
+    const NONE = 'none'; //No border
+    const OUTSET = 'outset'; //An outset set of lines
+    const THICK = 'thick'; //A single line
+    const THICK_THIN_LARGE_GAP = 'thickThinLargeGap'; //A thick line contained within a thin line with a large-sized intermediate gap
+    const THICK_THIN_MEDIUM_GAP = 'thickThinMediumGap'; //A thick line contained within a thin line with a medium-sized intermediate gap
+    const THICK_THIN_SMALL_GAP = 'thickThinSmallGap'; //A thick line contained within a thin line with a small intermediate gap
+    const THIN_THICK_LARGE_GAP = 'thinThickLargeGap'; //A thin line contained within a thick line with a large-sized intermediate gap
+    const THIN_THICK_MEDIUM_GAP = 'thinThickMediumGap'; //A thick line contained within a thin line with a medium-sized intermediate gap
+    const THIN_THICK_SMALL_GAP = 'thinThickSmallGap'; //A thick line contained within a thin line with a small intermediate gap
+    const THIN_THICK_THINLARGE_GAP = 'thinThickThinLargeGap'; //A thin-thick-thin line with a large gap
+    const THIN_THICK_THIN_MEDIUM_GAP = 'thinThickThinMediumGap'; //A thin-thick-thin line with a medium gap
+    const THIN_THICK_THIN_SMALL_GAP = 'thinThickThinSmallGap'; //A thin-thick-thin line with a small gap
+    const THREE_D_EMBOSS = 'threeDEmboss'; //A three-staged gradient line, getting darker towards the paragraph
+    const THREE_D_ENGRAVE = 'threeDEngrave'; //A three-staged gradient like, getting darker away from the paragraph
+    const TRIPLE = 'triple'; //A triple line
+    const WAVE = 'wave'; //A wavy line
+}

--- a/src/PhpWord/Style/Border.php
+++ b/src/PhpWord/Style/Border.php
@@ -23,41 +23,6 @@ namespace PhpOffice\PhpWord\Style;
 class Border extends AbstractStyle
 {
     /**
-     * Border Style Val.
-     * Wordprocessing Paragraphs Borders
-     * Specifies the style of the border. Paragraph borders can be only line borders. (Page borders can also be art borders.) Possible values are:
-     * @see http://officeopenxml.com/WPborders.php
-     * @const string
-     */
-    const BORDER_STYLE_SINGLE = 'single'; //A single line
-    const BORDER_STYLE_DASH_DOT_STROKED = 'dashDotStroked'; //A line with a series of alternating thin and thick strokes
-    const BORDER_STYLE_DASHED = 'dashed'; //A dashed line
-    const BORDER_STYLE_DASH_SMALL_GAP = 'dashSmallGap'; //A dashed line with small gaps
-    const BORDER_STYLE_DOT_DASH = 'dotDash'; //A line with alternating dots and dashes
-    const BORDER_STYLE_DOT_DOT_DASH = 'dotDotDash'; //A line with a repeating dot - dot - dash sequence
-    const BORDER_STYLE_DOTTED = 'dotted'; //A dotted line
-    const BORDER_STYLE_DOUBLE = 'double'; //A double line
-    const BORDER_STYLE_DOUBLE_WAVE = 'doubleWave'; //A double wavy line
-    const BORDER_STYLE_INSET = 'inset'; //An inset set of lines
-    const BORDER_STYLE_NIL = 'nil'; //No border
-    const BORDER_STYLE_NONE = 'none'; //No border
-    const BORDER_STYLE_OUTSET = 'outset'; //An outset set of lines
-    const BORDER_STYLE_THICK = 'thick'; //A single line
-    const BORDER_STYLE_THICK_THIN_LARGE_GAP = 'thickThinLargeGap'; //A thick line contained within a thin line with a large-sized intermediate gap
-    const BORDER_STYLE_THICK_THIN_MEDIUM_GAP = 'thickThinMediumGap'; //A thick line contained within a thin line with a medium-sized intermediate gap
-    const BORDER_STYLE_THICK_THIN_SMALL_GAP = 'thickThinSmallGap'; //A thick line contained within a thin line with a small intermediate gap
-    const BORDER_STYLE_THIN_THICK_LARGE_GAP = 'thinThickLargeGap'; //A thin line contained within a thick line with a large-sized intermediate gap
-    const BORDER_STYLE_THIN_THICK_MEDIUM_GAP = 'thinThickMediumGap'; //A thick line contained within a thin line with a medium-sized intermediate gap
-    const BORDER_STYLE_THIN_THICK_SMALL_GAP = 'thinThickSmallGap'; //A thick line contained within a thin line with a small intermediate gap
-    const BORDER_STYLE_THIN_THICK_THINLARGE_GAP = 'thinThickThinLargeGap'; //A thin-thick-thin line with a large gap
-    const BORDER_STYLE_THIN_THICK_THIN_MEDIUM_GAP = 'thinThickThinMediumGap'; //A thin-thick-thin line with a medium gap
-    const BORDER_STYLE_THIN_THICK_THIN_SMALL_GAP = 'thinThickThinSmallGap'; //A thin-thick-thin line with a small gap
-    const BORDER_STYLE_THREE_D_EMBOSS = 'threeDEmboss'; //A three-staged gradient line, getting darker towards the paragraph
-    const BORDER_STYLE_THREE_D_ENGRAVE = 'threeDEngrave'; //A three-staged gradient like, getting darker away from the paragraph
-    const BORDER_STYLE_TRIPLE = 'triple'; //A triple line
-    const BORDER_STYLE_WAVE = 'wave'; //A wavy line
-    
-    /**
      * Border Top Size
      *
      * @var int|float

--- a/src/PhpWord/Style/Border.php
+++ b/src/PhpWord/Style/Border.php
@@ -23,6 +23,41 @@ namespace PhpOffice\PhpWord\Style;
 class Border extends AbstractStyle
 {
     /**
+     * Border Style Val.
+     * Wordprocessing Paragraphs Borders
+     * Specifies the style of the border. Paragraph borders can be only line borders. (Page borders can also be art borders.) Possible values are:
+     * @see http://officeopenxml.com/WPborders.php
+     * @const string
+     */
+    const BORDER_STYLE_SINGLE = 'single'; //A single line
+    const BORDER_STYLE_DASH_DOT_STROKED = 'dashDotStroked'; //A line with a series of alternating thin and thick strokes
+    const BORDER_STYLE_DASHED = 'dashed'; //A dashed line
+    const BORDER_STYLE_DASH_SMALL_GAP = 'dashSmallGap'; //A dashed line with small gaps
+    const BORDER_STYLE_DOT_DASH = 'dotDash'; //A line with alternating dots and dashes
+    const BORDER_STYLE_DOT_DOT_DASH = 'dotDotDash'; //A line with a repeating dot - dot - dash sequence
+    const BORDER_STYLE_DOTTED = 'dotted'; //A dotted line
+    const BORDER_STYLE_DOUBLE = 'double'; //A double line
+    const BORDER_STYLE_DOUBLE_WAVE = 'doubleWave'; //A double wavy line
+    const BORDER_STYLE_INSET = 'inset'; //An inset set of lines
+    const BORDER_STYLE_NIL = 'nil'; //No border
+    const BORDER_STYLE_NONE = 'none'; //No border
+    const BORDER_STYLE_OUTSET = 'outset'; //An outset set of lines
+    const BORDER_STYLE_THICK = 'thick'; //A single line
+    const BORDER_STYLE_THICK_THIN_LARGE_GAP = 'thickThinLargeGap'; //A thick line contained within a thin line with a large-sized intermediate gap
+    const BORDER_STYLE_THICK_THIN_MEDIUM_GAP = 'thickThinMediumGap'; //A thick line contained within a thin line with a medium-sized intermediate gap
+    const BORDER_STYLE_THICK_THIN_SMALL_GAP = 'thickThinSmallGap'; //A thick line contained within a thin line with a small intermediate gap
+    const BORDER_STYLE_THIN_THICK_LARGE_GAP = 'thinThickLargeGap'; //A thin line contained within a thick line with a large-sized intermediate gap
+    const BORDER_STYLE_THIN_THICK_MEDIUM_GAP = 'thinThickMediumGap'; //A thick line contained within a thin line with a medium-sized intermediate gap
+    const BORDER_STYLE_THIN_THICK_SMALL_GAP = 'thinThickSmallGap'; //A thick line contained within a thin line with a small intermediate gap
+    const BORDER_STYLE_THIN_THICK_THINLARGE_GAP = 'thinThickThinLargeGap'; //A thin-thick-thin line with a large gap
+    const BORDER_STYLE_THIN_THICK_THIN_MEDIUM_GAP = 'thinThickThinMediumGap'; //A thin-thick-thin line with a medium gap
+    const BORDER_STYLE_THIN_THICK_THIN_SMALL_GAP = 'thinThickThinSmallGap'; //A thin-thick-thin line with a small gap
+    const BORDER_STYLE_THREE_D_EMBOSS = 'threeDEmboss'; //A three-staged gradient line, getting darker towards the paragraph
+    const BORDER_STYLE_THREE_D_ENGRAVE = 'threeDEngrave'; //A three-staged gradient like, getting darker away from the paragraph
+    const BORDER_STYLE_TRIPLE = 'triple'; //A triple line
+    const BORDER_STYLE_WAVE = 'wave'; //A wavy line
+    
+    /**
      * Border Top Size
      *
      * @var int|float

--- a/src/PhpWord/Writer/Word2007/Style/Paragraph.php
+++ b/src/PhpWord/Writer/Word2007/Style/Paragraph.php
@@ -132,6 +132,7 @@ class Paragraph extends AbstractStyle
 
             $styleWriter = new MarginBorder($xmlWriter);
             $styleWriter->setSizes($style->getBorderSize());
+            $styleWriter->setStyles($style->getBorderStyle());
             $styleWriter->setColors($style->getBorderColor());
             $styleWriter->write();
 


### PR DESCRIPTION
In the [issue#294](https://github.com/PHPOffice/PHPWord/issues/294) problem, it is found that a piece of code is applied, but the disadvantage is that the border style setting is not added when setting the border, so the code of adding paragraph style is supplemented. And added a list of static constants for border styles.