### PR TITLE
Fix image stroke in libreoffice 7.x

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -575,7 +575,7 @@ class TemplateProcessor
 
         // define templates
         // result can be verified via "Open XML SDK 2.5 Productivity Tool" (http://www.microsoft.com/en-us/download/details.aspx?id=30425)
-        $imgTpl = '<w:pict><v:shape type="#_x0000_t75" style="width:{WIDTH};height:{HEIGHT}"><v:imagedata r:id="{RID}" o:title=""/></v:shape></w:pict>';
+        $imgTpl = '<w:pict><v:shape type="#_x0000_t75" style="width:{WIDTH};height:{HEIGHT}" stroked="f"><v:imagedata r:id="{RID}" o:title=""/></v:shape></w:pict>';
 
         foreach ($searchParts as $partFileName => &$partContent) {
             $partVariables = $this->getVariablesForPart($partContent);


### PR DESCRIPTION
### Description
Recently I've updated to libreoffice 7.x and noticed weird bug, by default ms word and libreoffice 6.x and below show no line, but starting from libreoffice 7.x border appeared around images which was inserted using `setImageValue`

MsWord
![image](https://user-images.githubusercontent.com/10253982/102990786-cd045e00-4539-11eb-968d-024450887913.png)

Libreoffice 7.x
![image](https://user-images.githubusercontent.com/10253982/102990819-d8578980-4539-11eb-9cd4-ddb5c2230a62.png)