### PR TITLE
Fix cloneBlock issue

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -781,14 +781,14 @@ class TemplateProcessor
     {
         $matches = array();
         preg_match(
-            '/(<\?xml.*)(<w:p.*>\${' . $blockname . '}<\/w:.*?p>)(.*)(<w:p.*\${\/' . $blockname . '}<\/w:.*?p>)/is',
+            '/(<w:p\b(.(?!<w:p\b))*?\${' . $blockname . '}.*?<\/w:p>)(.*?)(<w:p\b(.(?!<w:p\b))*?\${\/' . $blockname . '}.*?<\/w:p>)/is',
             $this->tempDocumentMainPart,
             $matches
         );
 
         if (isset($matches[3])) {
             $this->tempDocumentMainPart = str_replace(
-                $matches[2] . $matches[3] . $matches[4],
+                $matches[1] . $matches[3] . $matches[4],
                 $replacement,
                 $this->tempDocumentMainPart
             );

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -741,7 +741,7 @@ class TemplateProcessor
         $xmlBlock = null;
         $matches = array();
         preg_match(
-            '/(<\?xml.*)(<w:p\b.*>\${' . $blockname . '}<\/w:.*?p>)(.*)(<w:p\b.*\${\/' . $blockname . '}<\/w:.*?p>)/is',
+            '/(<w:p\b(.(?!<w:p\b))*?\${' . $blockname . '}.*?<\/w:p>)(.*?)(<w:p\b(.(?!<w:p\b))*?\${\/' . $blockname . '}.*?<\/w:p>)/is',
             $this->tempDocumentMainPart,
             $matches
         );
@@ -761,7 +761,7 @@ class TemplateProcessor
 
             if ($replace) {
                 $this->tempDocumentMainPart = str_replace(
-                    $matches[2] . $matches[3] . $matches[4],
+                    $matches[1] . $matches[3] . $matches[4],
                     implode('', $cloned),
                     $this->tempDocumentMainPart
                 );


### PR DESCRIPTION
### Description

The regex function in cloneBlock may be too complicated or result in too many matches. Therefore, it can occur that the function results in no matches and therefore doesn't replace any blocks. I've solved this issue by making the regex more precise (by adding an extra group) and this solves the issue. It could probably also be fixed by increasing one of [these]
(https://www.php.net/manual/en/pcre.configuration.php) PHP configurations. This however is not what should be expected from users of this package.

Might fix many cloneBlock and replaceBlock issues
https://github.com/PHPOffice/PHPWord/issues?q=cloneBlock
https://github.com/PHPOffice/PHPWord/issues?q=replaceBlock
