### PR TITLE
Fix image border in Word2007 Writer for LibreOffice 7

### DIFF
--- a/src/PhpWord/Writer/Word2007/Element/Image.php
+++ b/src/PhpWord/Writer/Word2007/Element/Image.php
@@ -78,6 +78,7 @@ class Image extends AbstractElement
         $xmlWriter->startElement('w:pict');
         $xmlWriter->startElement('v:shape');
         $xmlWriter->writeAttribute('type', '#_x0000_t75');
+        $xmlWriter->writeAttribute('stroked', 'f');
 
         $styleWriter->write();
 
@@ -110,6 +111,7 @@ class Image extends AbstractElement
         $xmlWriter->startElement('w:pict');
         $xmlWriter->startElement('v:shape');
         $xmlWriter->writeAttribute('type', '#_x0000_t75');
+        $xmlWriter->writeAttribute('stroked', 'f');
 
         $styleWriter->write();
 


### PR DESCRIPTION
### Description

Recently I switched LibreOffice from version 6 to 7 for my docx documents and noticed that a border appeared around all images that I add by using addImage. This fixes the problem by adding an attribute 'stroked' with a value 'f' to the v:shape element in Word2007 Image Element Writer. This resolves #2031.

MS Word:
![msword](https://user-images.githubusercontent.com/74183333/108175502-2388b580-7101-11eb-9b7d-46a54ccb44f1.png)

LibreOffice 7:
![libreoffice7](https://user-images.githubusercontent.com/74183333/108175514-271c3c80-7101-11eb-9626-e4fd32abc167.png)

### Checklist:

- [X] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
 
solves #2031