### PR TITLE
Fix BC break in #1946. This package does not replace laminas/laminas-zendframework-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,9 +75,6 @@
         "mpdf/mpdf": "5.7.4 || 6.* || 7.* || 8.*",
         "php-coveralls/php-coveralls": "1.1.0 || ^2.0"
     },
-    "replace": {
-        "laminas/laminas-zendframework-bridge": "*"
-    },
     "suggest": {
         "ext-zip": "Allows writing OOXML and ODF",
         "ext-gd2": "Allows adding images",


### PR DESCRIPTION
### Description

This commit fixes the BC break introduced by #1946 where it was stated
that phpword replaces package laminas/laminas-zendframework-bridge which
is not the case. Package laminas/laminas-zendframework-bridge only was
replaced from phpword.

Fixes #2028 (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
