### PR TITLE
Update Html parser to accept line-height:normal

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -661,16 +661,9 @@ class Html
                     break;
                 case 'line-height':
                     $matches = array();
-                    if (preg_match('/([a-z]+)/', $cValue, $matches)) {
-                        //$cvalue text and not number
-                        if ($cValue == 'normal') {
-                            $cValue = 1.12;
-                        } else {
-                            $cValue = 1.13;
-                        }
+                    if ($cValue === 'normal') {
                         $spacingLineRule = \PhpOffice\PhpWord\SimpleType\LineSpacingRule::AUTO;
-                        //we are subtracting 1 line height because the Spacing writer is adding one line
-                        $spacing = ($cValue * Paragraph::LINE_HEIGHT) - Paragraph::LINE_HEIGHT;
+                        $spacing = 0;
                     } elseif (preg_match('/([0-9]+\.?[0-9]*[a-z]+)/', $cValue, $matches)) {
                         //matches number with a unit, e.g. 12px, 15pt, 20mm, ...
                         $spacingLineRule = \PhpOffice\PhpWord\SimpleType\LineSpacingRule::EXACT;

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -663,19 +663,15 @@ class Html
                     $matches = array();
                     if (preg_match('/([a-z]+)/', $cValue, $matches)) {
                         //$cvalue text and not number
-                        if($cValue == 'normal') {
+                        if ($cValue == 'normal') {
                             $cValue = 1.12;
-                            $spacingLineRule = \PhpOffice\PhpWord\SimpleType\LineSpacingRule::AUTO;
-                            //we are subtracting 1 line height because the Spacing writer is adding one line
-                            $spacing = ($cValue * Paragraph::LINE_HEIGHT) - Paragraph::LINE_HEIGHT;
-                        }else{
+                        } else {
                             $cValue = 1.13;
-                            $spacingLineRule = \PhpOffice\PhpWord\SimpleType\LineSpacingRule::AUTO;
-                            //we are subtracting 1 line height because the Spacing writer is adding one line
-                            $spacing = ($cValue * Paragraph::LINE_HEIGHT) - Paragraph::LINE_HEIGHT;
                         }
-                    }
-                    elseif (preg_match('/([0-9]+\.?[0-9]*[a-z]+)/', $cValue, $matches)) {
+                        $spacingLineRule = \PhpOffice\PhpWord\SimpleType\LineSpacingRule::AUTO;
+                        //we are subtracting 1 line height because the Spacing writer is adding one line
+                        $spacing = ($cValue * Paragraph::LINE_HEIGHT) - Paragraph::LINE_HEIGHT;
+                    } elseif (preg_match('/([0-9]+\.?[0-9]*[a-z]+)/', $cValue, $matches)) {
                         //matches number with a unit, e.g. 12px, 15pt, 20mm, ...
                         $spacingLineRule = \PhpOffice\PhpWord\SimpleType\LineSpacingRule::EXACT;
                         $spacing = Converter::cssToTwip($matches[1]);

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -661,7 +661,21 @@ class Html
                     break;
                 case 'line-height':
                     $matches = array();
-                    if (preg_match('/([0-9]+\.?[0-9]*[a-z]+)/', $cValue, $matches)) {
+                    if (preg_match('/([a-z]+)/', $cValue, $matches)) {
+                        //$cvalue text and not number
+                        if($cValue == 'normal') {
+                            $cValue = 1.12;
+                            $spacingLineRule = \PhpOffice\PhpWord\SimpleType\LineSpacingRule::AUTO;
+                            //we are subtracting 1 line height because the Spacing writer is adding one line
+                            $spacing = ($cValue * Paragraph::LINE_HEIGHT) - Paragraph::LINE_HEIGHT;
+                        }else{
+                            $cValue = 1.13;
+                            $spacingLineRule = \PhpOffice\PhpWord\SimpleType\LineSpacingRule::AUTO;
+                            //we are subtracting 1 line height because the Spacing writer is adding one line
+                            $spacing = ($cValue * Paragraph::LINE_HEIGHT) - Paragraph::LINE_HEIGHT;
+                        }
+                    }
+                    elseif (preg_match('/([0-9]+\.?[0-9]*[a-z]+)/', $cValue, $matches)) {
                         //matches number with a unit, e.g. 12px, 15pt, 20mm, ...
                         $spacingLineRule = \PhpOffice\PhpWord\SimpleType\LineSpacingRule::EXACT;
                         $spacing = Converter::cssToTwip($matches[1]);

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -158,6 +158,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
         Html::addHtml($section, '<p style="line-height: 15pt;">test</p>');
         Html::addHtml($section, '<p style="line-height: 120%;">test</p>');
         Html::addHtml($section, '<p style="line-height: 0.17in;">test</p>');
+        Html::addHtml($section, '<p style="line-height: normal;">test</p>');
 
         $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
         $this->assertTrue($doc->elementExists('/w:document/w:body/w:p[1]/w:pPr/w:spacing'));
@@ -175,6 +176,10 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
         $this->assertTrue($doc->elementExists('/w:document/w:body/w:p[4]/w:pPr/w:spacing'));
         $this->assertEquals(244.8, $doc->getElementAttribute('/w:document/w:body/w:p[4]/w:pPr/w:spacing', 'w:line'));
         $this->assertEquals(LineSpacingRule::EXACT, $doc->getElementAttribute('/w:document/w:body/w:p[4]/w:pPr/w:spacing', 'w:lineRule'));
+
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:p[5]/w:pPr/w:spacing'));
+        $this->assertEquals(Paragraph::LINE_HEIGHT, $doc->getElementAttribute('/w:document/w:body/w:p[5]/w:pPr/w:spacing', 'w:line'));
+        $this->assertEquals(LineSpacingRule::AUTO, $doc->getElementAttribute('/w:document/w:body/w:p[5]/w:pPr/w:spacing', 'w:lineRule'));
     }
 
     /**


### PR DESCRIPTION
For acept text in line-height how "line-height:normal", etc.

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
