### PR TITLE
check if macro is inside table

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -1310,4 +1310,29 @@ class TemplateProcessor
     {
         return preg_match('/[^>]\${|}[^<]/i', $text) == 1;
     }
+
+    /**
+     * Check if the first macro is inside table
+     * @param string $macro
+     * 
+     * @return bool
+     */
+    public function isInsideTable($macro)
+    {
+        $macro = static::ensureMacroCompleted($macro);
+
+        $tagPos = strpos($this->tempDocumentMainPart, $macro);
+
+        $rowStart = strrpos($this->tempDocumentMainPart, '<w:tr ', ((strlen($this->tempDocumentMainPart) - $tagPos) * -1));
+
+        if (!$rowStart) {
+            $rowStart = strrpos($this->tempDocumentMainPart, '<w:tr>', ((strlen($this->tempDocumentMainPart) - $tagPos) * -1));
+        }
+
+        if ($rowStart) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
### Check if macro is inside table

It was added a function to verify if the macro used to clone a table row inside the document is inside a table to avoid the bug 'Can not find the start position of the row to clone.'

It gives to the user of the library a way to avoid the throw of a new exception and continue processing the document without an error caused by a mistake from his client.

Fixes # (improvement)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
