### PR TITLE
Update chart, don't write 'c:overlap' if grouping is 'clustered'

### DIFF
--- a/src/PhpWord/Writer/Word2007/Part/Chart.php
+++ b/src/PhpWord/Writer/Word2007/Part/Chart.php
@@ -188,7 +188,8 @@ class Chart extends AbstractPart
         // Series
         $this->writeSeries($xmlWriter, isset($this->options['scatter']));
 
-        if(!isset($this->options['grouping']) OR $this->options['grouping'] != 'clustered'){
+        // don't overlap if grouping is 'clustered'
+        if (!isset($this->options['grouping']) || $this->options['grouping'] != 'clustered') {
             $xmlWriter->writeElementBlock('c:overlap', 'val', '100');
         }
 

--- a/src/PhpWord/Writer/Word2007/Part/Chart.php
+++ b/src/PhpWord/Writer/Word2007/Part/Chart.php
@@ -188,7 +188,9 @@ class Chart extends AbstractPart
         // Series
         $this->writeSeries($xmlWriter, isset($this->options['scatter']));
 
-        $xmlWriter->writeElementBlock('c:overlap', 'val', '100');
+        if(!isset($this->options['grouping']) OR $this->options['grouping'] != 'clustered'){
+            $xmlWriter->writeElementBlock('c:overlap', 'val', '100');
+        }
 
         // Axes
         if (isset($this->options['axes'])) {


### PR DESCRIPTION
### Description
when bar or column grouping by clustered have c:overlap,the bar will be overlap
Fixes # (issue)
