### PR TITLE
Added support for Garamond font

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "ext-gd": "*",
         "phpunit/phpunit": "^4.8.36 || ^7.0",
         "squizlabs/php_codesniffer": "^2.9 || ^3.5",
-        "friendsofphp/php-cs-fixer": "^2.2",
+        "friendsofphp/php-cs-fixer": "^2.2 || ^3.0",
         "phpmd/phpmd": "2.*",
         "phploc/phploc": "2.* || 3.* || 4.* || 5.* || 6.* || 7.*",
         "dompdf/dompdf":"0.8.* || 1.0.*",

--- a/src/PhpWord/Writer/Word2007/Part/FontTable.php
+++ b/src/PhpWord/Writer/Word2007/Part/FontTable.php
@@ -101,6 +101,15 @@ class FontTable extends AbstractPart
             'w:csb0="0000019F" w:csb1="00000000" />';
         $str .= '</w:font>';
 
+        $str .= '<w:font w:name="Garamond">';
+        $str .= '<w:panose1 w:val="02020404030301010803" />';
+        $str .= '<w:charset w:val="00" />';
+        $str .= '<w:family w:val="roman" />';
+        $str .= '<w:pitch w:val="variable" />';
+        $str .= '<w:sig w:usb0="00000287" w:usb1="00000002" w:usb2="00000000" w:usb3="00000000" ' .
+            'w:csb0="0000009F" w:csb1="00000000" />';
+        $str .= '</w:font>';
+
         $str .= '</w:fonts>';
 
         return $str;


### PR DESCRIPTION
### Description

Looks like Garamond font is missing from a font table. This change adds it there.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
