### PR TITLE
Corrected namespace for Language class in docs.

### DIFF
--- a/docs/general.rst
+++ b/docs/general.rst
@@ -228,7 +228,7 @@ The default language of the document can be change with the following.
     $phpWord->getSettings()->setThemeFontLang(new Language(Language::FR_BE));
 
 ``Language`` has 3 parameters, one for Latin languages, one for East Asian languages and one for Complex (Bi-Directional) languages.
-A couple of language codes are provided in the ``PhpOffice\PhpWord\ComplexType\Language`` class but any valid code/ID can be used.
+A couple of language codes are provided in the ``PhpOffice\PhpWord\Style\Language`` class but any valid code/ID can be used.
 
 In case you are generating an RTF document the language need to be set differently.
 


### PR DESCRIPTION
### Description

The docs referenced the wrong namespace for the Language class. This happens in General usage > Document settings > Document Language.
It refers to ``PhpOffice\PhpWord\ComplexType\Language``, but there's no Language class in the namespace ``PhpOffice\PhpWord\ComplexType``. I searched in the tests to figure out where the Language class has moved to and found in ``PhpOffice\PhpWord\Writer\Word2007\Part\SettingsTest::testLanguage()`` this had to be ``PhpOffice\PhpWord\Style\Language``.

### Checklist:

- [n/a] I have run `composer run-script check --timeout=0` and no errors were reported
- [n/a] The new code is covered by unit tests (check build/coverage for coverage report)
- [n/a] I have updated the documentation to describe the changes
