### PR TITLE
Update elements.rst

### DIFF
--- a/docs/elements.rst
+++ b/docs/elements.rst
@@ -482,7 +482,8 @@ The comment can contain formatted text. Once the comment has been added, it can 
     $textrun->addText('This ');
     $text = $textrun->addText('is');
     // link the comment to the text you just created
-    $text->setCommentStart($comment);
+    $text->setCommentRangeStart($comment);
+    textrun->addText(' a test');
 
 If no end is set for a comment using the ``setCommentEnd``, the comment will be ended automatically at the end of the element it is started on.
 


### PR DESCRIPTION
Fix error on comments code snippet.

### Description

Changed the wrong call `setCommentStart` to `setCommentRangeStart` in the documentation.

Fixes # (issue)

Not working example.

### Checklist:

- [X ] I have updated the documentation to describe the changes

There are no code changes.
- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)

