### PR TITLE
fixed code example

### DIFF
--- a/docs/general.rst
+++ b/docs/general.rst
@@ -192,11 +192,11 @@ You can also specify the status of the spell and grammar checks, marking spellin
 
 .. code-block:: php
 
-    $proofState = new ProofState();
-    $proofState->setGrammar(ProofState::CLEAN);
-    $proofState->setSpelling(ProofState::DIRTY);
+    $proofState = new \PhpOffice\PhpWord\ComplexType\ProofState();
+    $proofState->setGrammar(\PhpOffice\PhpWord\ComplexType\ProofState::CLEAN);
+    $proofState->setSpelling(\PhpOffice\PhpWord\ComplexType\ProofState::DIRTY);
 
-    $phpWord->getSettings()->setProofState(proofState);
+    $phpWord->getSettings()->setProofState($proofState);
 
 Track Revisions
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
classes not found and missing dollar sign

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
