### PR TITLE
Adds support for multiple comments on the same text object.

### DIFF
--- a/src/PhpWord/Element/AbstractElement.php
+++ b/src/PhpWord/Element/AbstractElement.php
@@ -384,7 +384,7 @@ abstract class AbstractElement
             }
         }
         $this->commentsRangeEnd->addItem($value);
-        $this->commentsRangeEnd->getItem($this->commentsRangeEnd->countItems())->setEnd($this);
+        $this->commentsRangeEnd->getItem($this->commentsRangeEnd->countItems())->setEndElement($this);
     }
 
     /**

--- a/src/PhpWord/Element/AbstractElement.php
+++ b/src/PhpWord/Element/AbstractElement.php
@@ -129,18 +129,18 @@ abstract class AbstractElement
     protected $collectionRelation = false;
 
     /**
-     * The start position for the linked comment
+     * The start position for the linked comments
      *
-     * @var Comment
+     * @var \PHPOffice\PHPWord\Collection\Comments
      */
-    protected $commentRangeStart;
+    protected $commentsRangeStart;
 
     /**
-     * The end position for the linked comment
+     * The end position for the linked comments
      *
-     * @var Comment
+     * @var \PHPOffice\PHPWord\Collection\Comments
      */
-    protected $commentRangeEnd;
+    protected $commentsRangeEnd;
 
     /**
      * Get PhpWord
@@ -288,13 +288,27 @@ abstract class AbstractElement
     }
 
     /**
+     * Get comments start
+     *
+     * @return \PhpOffice\PhpWord\Collection\Comments
+     */
+    public function getCommentsRangeStart()
+    {
+        return $this->commentsRangeStart;
+    }
+
+    /**
      * Get comment start
      *
      * @return Comment
      */
     public function getCommentRangeStart()
     {
-        return $this->commentRangeStart;
+        if ($this->commentsRangeStart != null) {
+            return $this->commentsRangeStart->getItem($this->commentsRangeStart->countItems());
+        }
+
+        return null;
     }
 
     /**
@@ -307,8 +321,30 @@ abstract class AbstractElement
         if ($this instanceof Comment) {
             throw new \InvalidArgumentException('Cannot set a Comment on a Comment');
         }
-        $this->commentRangeStart = $value;
-        $this->commentRangeStart->setStartElement($this);
+        if ($this->commentsRangeStart == null) {
+            $this->commentsRangeStart = new \PhpOffice\PhpWord\Collection\Comments();
+        }
+        // Set ID early to avoid duplicates.
+        if ($value->getElementId() == null) {
+            $value->setElementId();
+        }
+        foreach ($this->commentsRangeStart->getItems() as $comment) {
+            if ($value->getElementId() == $comment->getElementId()) {
+                return;
+            }
+        }
+        $this->commentsRangeStart->addItem($value);
+        $this->commentsRangeStart->getItem($this->commentsRangeStart->countItems())->setStartElement($this);
+    }
+
+    /**
+     * Get comments end
+     *
+     * @return \PhpOffice\PhpWord\Collection\Comments
+     */
+    public function getCommentsRangeEnd()
+    {
+        return $this->commentsRangeEnd;
     }
 
     /**
@@ -318,7 +354,11 @@ abstract class AbstractElement
      */
     public function getCommentRangeEnd()
     {
-        return $this->commentRangeEnd;
+        if ($this->commentsRangeEnd != null) {
+            return $this->commentsRangeEnd->getItem($this->commentsRangeEnd->countItems());
+        }
+
+        return null;
     }
 
     /**
@@ -331,8 +371,20 @@ abstract class AbstractElement
         if ($this instanceof Comment) {
             throw new \InvalidArgumentException('Cannot set a Comment on a Comment');
         }
-        $this->commentRangeEnd = $value;
-        $this->commentRangeEnd->setEndElement($this);
+        if ($this->commentsRangeEnd == null) {
+            $this->commentsRangeEnd = new \PhpOffice\PhpWord\Collection\Comments();
+        }
+        // Set ID early to avoid duplicates.
+        if ($value->getElementId() == null) {
+            $value->setElementId();
+        }
+        foreach ($this->commentsRangeEnd->getItems() as $comment) {
+            if ($value->getElementId() == $comment->getElementId()) {
+                return;
+            }
+        }
+        $this->commentsRangeEnd->addItem($value);
+        $this->commentsRangeEnd->getItem($this->commentsRangeEnd->countItems())->setEnd($this);
     }
 
     /**

--- a/src/PhpWord/Element/Comment.php
+++ b/src/PhpWord/Element/Comment.php
@@ -82,9 +82,7 @@ class Comment extends TrackChange
     public function setStartElement(AbstractElement $value)
     {
         $this->startElement = $value;
-        if ($value->getCommentRangeStart() == null) {
-            $value->setCommentRangeStart($this);
-        }
+        $value->setCommentRangeStart($this);
     }
 
     /**
@@ -105,9 +103,7 @@ class Comment extends TrackChange
     public function setEndElement(AbstractElement $value)
     {
         $this->endElement = $value;
-        if ($value->getCommentRangeEnd() == null) {
-            $value->setCommentRangeEnd($this);
-        }
+        $value->setCommentRangeEnd($this);
     }
 
     /**

--- a/src/PhpWord/Writer/Word2007/Element/AbstractElement.php
+++ b/src/PhpWord/Writer/Word2007/Element/AbstractElement.php
@@ -122,14 +122,10 @@ abstract class AbstractElement
      */
     protected function writeCommentRangeStart()
     {
-        if ($this->element->getCommentRangeStart() != null) {
-            $comment = $this->element->getCommentRangeStart();
-            //only set the ID if it is not yet set, otherwise it will overwrite it
-            if ($comment->getElementId() == null) {
-                $comment->setElementId();
+        if ($this->element->getCommentsRangeStart() != null) {
+            foreach ($this->element->getCommentsRangeStart()->getItems() as $comment) {
+                $this->xmlWriter->writeElementBlock('w:commentRangeStart', array('w:id' => $comment->getElementId()));
             }
-
-            $this->xmlWriter->writeElementBlock('w:commentRangeStart', array('w:id' => $comment->getElementId()));
         }
     }
 
@@ -138,28 +134,23 @@ abstract class AbstractElement
      */
     protected function writeCommentRangeEnd()
     {
-        if ($this->element->getCommentRangeEnd() != null) {
-            $comment = $this->element->getCommentRangeEnd();
-            //only set the ID if it is not yet set, otherwise it will overwrite it, this should normally not happen
-            if ($comment->getElementId() == null) {
-                $comment->setElementId(); // @codeCoverageIgnore
-            } // @codeCoverageIgnore
-
-            $this->xmlWriter->writeElementBlock('w:commentRangeEnd', array('w:id' => $comment->getElementId()));
-            $this->xmlWriter->startElement('w:r');
-            $this->xmlWriter->writeElementBlock('w:commentReference', array('w:id' => $comment->getElementId()));
-            $this->xmlWriter->endElement();
-        } elseif ($this->element->getCommentRangeStart() != null && $this->element->getCommentRangeStart()->getEndElement() == null) {
-            $comment = $this->element->getCommentRangeStart();
-            //only set the ID if it is not yet set, otherwise it will overwrite it, this should normally not happen
-            if ($comment->getElementId() == null) {
-                $comment->setElementId(); // @codeCoverageIgnore
-            } // @codeCoverageIgnore
-
-            $this->xmlWriter->writeElementBlock('w:commentRangeEnd', array('w:id' => $comment->getElementId()));
-            $this->xmlWriter->startElement('w:r');
-            $this->xmlWriter->writeElementBlock('w:commentReference', array('w:id' => $comment->getElementId()));
-            $this->xmlWriter->endElement();
+        if ($this->element->getCommentsRangeEnd() != null) {
+            foreach ($this->element->getCommentsRangeEnd()->getItems() as $comment) {
+                $this->xmlWriter->writeElementBlock('w:commentRangeEnd', array('w:id' => $comment->getElementId()));
+                $this->xmlWriter->startElement('w:r');
+                $this->xmlWriter->writeElementBlock('w:commentReference', array('w:id' => $comment->getElementId()));
+                $this->xmlWriter->endElement();
+            }
+        }
+        if ($this->element->getCommentsRangeStart() != null) {
+            foreach ($this->element->getCommentsRangeStart()->getItems() as $comment) {
+                if ($comment->getEndElement() == null) {
+                    $this->xmlWriter->writeElementBlock('w:commentRangeEnd', array('w:id' => $comment->getElementId()));
+                    $this->xmlWriter->startElement('w:r');
+                    $this->xmlWriter->writeElementBlock('w:commentReference', array('w:id' => $comment->getElementId()));
+                    $this->xmlWriter->endElement();
+                }
+            }
         }
     }
 

--- a/tests/PhpWord/Element/CommentTest.php
+++ b/tests/PhpWord/Element/CommentTest.php
@@ -47,6 +47,39 @@ class CommentTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Two comments on same text
+     */
+    public function testTwoCommentsOnSameText()
+    {
+        $section = new Section(0);
+        $text = $section->addText('Text');
+
+        $comment1 = new Comment('Author1', new \DateTime(), 'A1');
+        $comment1->addText('Comment1');
+
+        $comment2 = new Comment('Author2', new \DateTime(), 'A2');
+        $comment2->addText('Comment2');
+
+        $comment1->setStartElement($text);
+        $comment2->setStartElement($text);
+
+        $text->setCommentRangeStart($comment1);
+        $text->setCommentRangeEnd($comment1);
+
+        $text->setCommentRangeStart($comment2);
+        $text->setCommentRangeEnd($comment2);
+
+        $this->assertEquals(2, $text->getCommentsRangeStart()->countItems());
+        $this->assertEquals(2, $text->getCommentsRangeEnd()->countItems());
+
+        $this->assertEquals($text->getCommentsRangeStart()->getItem(1)->getElementId(), $comment1->getElementId());
+        $this->assertEquals($text->getCommentsRangeEnd()->getItem(1)->getElementId(), $comment1->getElementId());
+
+        $this->assertEquals($text->getCommentsRangeStart()->getItem(2)->getElementId(), $comment2->getElementId());
+        $this->assertEquals($text->getCommentsRangeEnd()->getItem(2)->getElementId(), $comment2->getElementId());
+    }
+
+    /**
      * Add text
      */
     public function testAddText()


### PR DESCRIPTION
### Description

Fixes #2109 

Changed `AbstractElement->commentRangeStart` and End for a collection (`commentsRangeStart` and End) that accepts multiple comments for same element.

For consistency in names maybe a rename is due for Word2007 Writer AbstractElement `writeCommentRangeStart` (and End) to `writeCommentsRangeStart`, since it now iterates over the collection, a plural could go, I didn't change it because there were many files and made the pull request more complicated to follow.

### Checklist:

- [ X ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ X ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
