### PR TITLE
Process "font-variant: small-caps" when parsing HTML styles

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -702,6 +702,13 @@ class Html
                     }
                     $styles['italic'] = $tValue;
                     break;
+                case 'font-variant':
+                    $tValue = false;
+                    if (preg_match('#small-caps#', $cValue)) {
+                        $tValue = true;
+                    }
+                    $styles['smallCaps'] = $tValue;
+                    break;
                 case 'margin':
                     $cValue = Converter::cssToTwip($cValue);
                     $styles['spaceBefore'] = $cValue;

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -133,6 +133,21 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
     }
 
     /**
+     * Test font-variant style
+     */
+    public function testParseFontVariant()
+    {
+        $html = '<span style="font-variant: small-caps;">test</span>';
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:rPr/w:smallCaps'));
+        $this->assertEquals('1', $doc->getElementAttribute('/w:document/w:body/w:p/w:r/w:rPr/w:smallCaps', 'w:val'));
+    }
+
+    /**
      * Test font
      */
     public function testParseFont()

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -135,7 +135,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
     /**
      * Test font-variant style
      */
-    public function testParseFontVariant()
+    public function testParseFontVariant(): void
     {
         $html = '<span style="font-variant: small-caps;">test</span>';
         $phpWord = new \PhpOffice\PhpWord\PhpWord();


### PR DESCRIPTION
### Description

When using `Html::addHtml`, the "font-variant" style wasn't being processed to recognize small caps.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes

(I don't think there's anything to do in the docs).
