### PR TITLE
TemplateProcessor can accept a file contents instead of the file path

### DIFF
--- a/docs/templates-processing.rst
+++ b/docs/templates-processing.rst
@@ -6,6 +6,7 @@ Templates processing
 You can create an OOXML document template with included search-patterns (macros) which can be replaced by any value you wish. Only single-line values can be replaced.
 Macros are defined like this: ``${search-pattern}``.
 To load a template file, create a new instance of the TemplateProcessor.
+The constructor can accept the path to the Word Template, or the contents of the file (ie. if you had to load it from AWS S3, http, FTP, etc...)
 
 .. code-block:: php
 

--- a/samples/Sample_42_TemplateWithFileContents.php
+++ b/samples/Sample_42_TemplateWithFileContents.php
@@ -1,0 +1,23 @@
+<?php
+include_once 'Sample_Header.php';
+
+// Template processor instance creation
+echo date('H:i:s') , ' Creating new TemplateProcessor instance from file contents...' , EOL;
+
+// This file could be retrieved from HTTP, FTP, AWS S3 Storage, or other...
+$fileContents = file_get_contents('resources/Sample_23_TemplateBlock.docx');
+$templateProcessor = new \PhpOffice\PhpWord\TemplateProcessor($fileContents);
+
+// Will clone everything between ${tag} and ${/tag}, the number of times. By default, 1.
+$templateProcessor->cloneBlock('CLONEME', 3);
+
+// Everything between ${tag} and ${/tag}, will be deleted/erased.
+$templateProcessor->deleteBlock('DELETEME');
+
+echo date('H:i:s'), ' Saving the result document...', EOL;
+$templateProcessor->saveAs('results/Sample_23_TemplateBlock.docx');
+
+echo getEndingNotes(array('Word2007' => 'docx'), 'Sample_23_TemplateBlock');
+if (!CLI) {
+    include_once 'Sample_Footer.php';
+}

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -95,7 +95,7 @@ class TemplateProcessor
     /**
      * @since 0.12.0 Throws CreateTemporaryFileException and CopyFileException instead of Exception
      *
-     * @param string $documentTemplate The fully qualified template filename
+     * @param string $documentTemplate The fully qualified template filename, or the file contents
      *
      * @throws \PhpOffice\PhpWord\Exception\CreateTemporaryFileException
      * @throws \PhpOffice\PhpWord\Exception\CopyFileException
@@ -108,10 +108,17 @@ class TemplateProcessor
             throw new CreateTemporaryFileException(); // @codeCoverageIgnore
         }
 
-        // Template file cloning
-        if (false === copy($documentTemplate, $this->tempDocumentFilename)) {
-            throw new CopyFileException($documentTemplate, $this->tempDocumentFilename); // @codeCoverageIgnore
+        // If we provided a file name, use it :
+        if (file_exists($documentTemplate)){
+            // Template file cloning
+            if (false === copy($documentTemplate, $this->tempDocumentFilename)) {
+                throw new CopyFileException($documentTemplate, $this->tempDocumentFilename); // @codeCoverageIgnore
+            }
+        }else{
+            // The param is not a file name, so it should be the file contents. Save it to a temp file, and use it.
+            file_put_contents( $this->tempDocumentFilename, $documentTemplate);
         }
+
 
         // Temporary document content extraction
         $this->zipClass = new ZipArchive();
@@ -881,7 +888,7 @@ class TemplateProcessor
     }
 
     /**
-     * Saves the result document.
+     * Saves the result document. Returns the path to the temp document file.
      *
      * @throws \PhpOffice\PhpWord\Exception\Exception
      *

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -109,16 +109,15 @@ class TemplateProcessor
         }
 
         // If we provided a file name, use it :
-        if (@file_exists($documentTemplate)){
+        if (@file_exists($documentTemplate)) {
             // Template file cloning
             if (false === copy($documentTemplate, $this->tempDocumentFilename)) {
                 throw new CopyFileException($documentTemplate, $this->tempDocumentFilename); // @codeCoverageIgnore
             }
-        }else{
+        } else {
             // The param is not a file name, so it should be the file contents. Save it to a temp file, and use it.
-            file_put_contents( $this->tempDocumentFilename, $documentTemplate);
+            file_put_contents($this->tempDocumentFilename, $documentTemplate);
         }
-
 
         // Temporary document content extraction
         $this->zipClass = new ZipArchive();

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -109,7 +109,7 @@ class TemplateProcessor
         }
 
         // If we provided a file name, use it :
-        if (file_exists($documentTemplate)){
+        if (@file_exists($documentTemplate)){
             // Template file cloning
             if (false === copy($documentTemplate, $this->tempDocumentFilename)) {
                 throw new CopyFileException($documentTemplate, $this->tempDocumentFilename); // @codeCoverageIgnore

--- a/tests/PhpWord/TemplateProcessorTest.php
+++ b/tests/PhpWord/TemplateProcessorTest.php
@@ -41,6 +41,20 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Construct test
+     *
+     * @covers ::__construct
+     * @test
+     */
+    public function testTheConstructWithContents()
+    {
+        $contents = file_get_contents(__DIR__ . '/_files/templates/blank.docx');
+        $object = new TemplateProcessor($contents);
+        $this->assertInstanceOf('PhpOffice\\PhpWord\\TemplateProcessor', $object);
+        $this->assertEquals(array(), $object->getVariables());
+    }
+
+    /**
      * Template can be saved in temporary location.
      *
      * @covers ::save


### PR DESCRIPTION
### Description

In many projects, Devs are now using Cloud storage (such as AWS S3). 
So, having a word template in a S3 storage would force the dev to save it to a custom/temporary path and then give the path to the TemplateProcessor constructor.

I submit this PR so the constructor can ALSO accept the file contents. 
If the given parameter is a path to a valid file, then the constructor works as before. Else, we suppose that the parameter contains the file contents, and then we save it to the tempDocumentFilename, and use it as we did before.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
