### PR TITLE
Detect Word Internal Links and add title bookmark

### DIFF
--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -160,6 +160,15 @@ abstract class AbstractPart
                     $this->readRun($xmlReader, $node, $textContent, $docPart, $paragraphStyle);
                 }
             }
+            
+            // Every heading is generaly associated to a bookmark. 
+            // Get the name of the current title bookmark and add a similar bookmark before the title 
+            $bookmarkTitleNodes = $xmlReader->getElements('w:bookmarkStart', $domNode);
+            if ($bookmarkTitleNodes->length) {
+                $bookmarkName = $bookmarkTitleNodes->item(0)->getAttribute('w:name');
+                $parent->addBookmark($bookmarkName);
+            }
+            // Add the title
             $parent->addTitle($textContent, $headingDepth);
         } else {
             // Text and TextRun
@@ -313,7 +322,12 @@ abstract class AbstractPart
                 $rId = $xmlReader->getAttribute('r:id', $runParent);
                 $target = $this->getMediaTarget($docPart, $rId);
                 if (!is_null($target)) {
-                    $parent->addLink($target, $textContent, $fontStyle, $paragraphStyle);
+                    $parent->addLink($target, $textContent, $fontStyle, $paragraphStyle);  
+                // Internal reference found
+                } elseif ($runParent->hasAttribute('w:anchor')) {
+                    $anchorAttribute = $runParent->getAttribute('w:anchor');
+                    $parent->addLink($anchorAttribute, $textContent, $fontStyle, $paragraphStyle, true); 
+                // Otherwise
                 } else {
                     $parent->addText($textContent, $fontStyle, $paragraphStyle);
                 }


### PR DESCRIPTION
### Description

At the moment, PhpWord is not able to read an internal link to an existing heading. 
This is because the anchor is not detected in the reader. Here I create a new (internal) "Link" when this attribute is found.
Moreover, the Headings of the Word document usually contain a "bookmark" (useful for TOC or internal link) but the reader has not created it so that the name (reference of the bookmark) is lost.

Fixes # (issue)

https://github.com/PHPOffice/PHPWord/issues/2121

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
