### PR TITLE
Custom Word title style name (ex: "Titre 1") taken into account

### DIFF
--- a/src/PhpWord/Reader/Word2007/Styles.php
+++ b/src/PhpWord/Reader/Word2007/Styles.php
@@ -65,8 +65,9 @@ class Styles extends AbstractPart
             foreach ($nodes as $node) {
                 $type = $xmlReader->getAttribute('w:type', $node);
                 $name = $xmlReader->getAttribute('w:val', $node, 'w:name');
+                $styleId = $xmlReader->getAttribute('w:styleId', $node);
                 if (is_null($name)) {
-                    $name = $xmlReader->getAttribute('w:styleId', $node);
+                    $name = $styleId;
                 }
                 $headingMatches = array();
                 preg_match('/Heading\s*(\d)/i', $name, $headingMatches);
@@ -75,8 +76,9 @@ class Styles extends AbstractPart
                     case 'paragraph':
                         $paragraphStyle = $this->readParagraphStyle($xmlReader, $node);
                         $fontStyle = $this->readFontStyle($xmlReader, $node);
+
                         if (!empty($headingMatches)) {
-                            $phpWord->addTitleStyle($headingMatches[1], $fontStyle, $paragraphStyle);
+                            $phpWord->addTitleStyle($headingMatches[1], $fontStyle, $paragraphStyle, $styleId);
                         } else {
                             if (empty($fontStyle)) {
                                 if (is_array($paragraphStyle)) {

--- a/src/PhpWord/Style.php
+++ b/src/PhpWord/Style.php
@@ -93,12 +93,14 @@ class Style
      * @param array|\PhpOffice\PhpWord\Style\AbstractStyle $paragraphStyle
      * @return \PhpOffice\PhpWord\Style\Font
      */
-    public static function addTitleStyle($depth, $fontStyle, $paragraphStyle = null)
+    public static function addTitleStyle($depth, $fontStyle, $paragraphStyle = null, $styleName = null)
     {
-        if (empty($depth)) {
-            $styleName = 'Title';
-        } else {
-            $styleName = "Heading_{$depth}";
+        if (is_null($styleName)) {
+            if (empty($depth)) {
+                $styleName = 'Title';
+            } else {
+                $styleName = "Heading_{$depth}";
+            }
         }
 
         return self::setStyleValues($styleName, new Font('title', $paragraphStyle), $fontStyle);

--- a/src/PhpWord/Writer/Word2007/Part/Styles.php
+++ b/src/PhpWord/Writer/Word2007/Part/Styles.php
@@ -179,16 +179,21 @@ class Styles extends AbstractPart
 
         // Heading style
         if ($styleType == 'title') {
-            $arrStyle = explode('_', $styleName);
-            if (count($arrStyle) > 1) {
-                $styleId = 'Heading' . $arrStyle[1];
-                $styleName = 'heading ' . $arrStyle[1];
-                $styleLink = 'Heading' . $arrStyle[1] . 'Char';
+            $styleId = $styleName;
+            $styleLink = $styleName.'Char';
+
+            // Title with the "Title 1" format
+            if (preg_match("/\d$/", $styleName, $match)) {
+                // get the ending number
+                $i = (int) $match[0];
+                if ($i > 0) {
+                    $styleName = 'heading '.$i;
+                }
             } else {
-                $styleId = $styleName;
+                // Title out of the "Title 1" format
                 $styleName = strtolower($styleName);
-                $styleLink = $styleName . 'Char';
             }
+
             $xmlWriter->writeAttribute('w:styleId', $styleId);
 
             $xmlWriter->startElement('w:link');


### PR DESCRIPTION
### Issue / Problem

At the moment, when the heading of document are not named "Heading 1", "Heading 2" in the Word document, then PhpWord does not consider them as heading. When the document is loaded (through a Reader), there is no "Title" element.

It's a common problem for French, Spanish, or other user.  
Indeed, in these countries, the local version of Microsoft Word defines default titles named "Title 1" (in France), "Titulo 1" (in Spanish) ... and it is impossible to replace them into Word ... 

This should not be a problem for PhpWord which has the indication that it is a "heading" via the attribute "w:name" but which should be consistent with the style identifier. See below how a french docx document is generated by Word : 

```
<w:style w:type="paragraph" w:styleId="Titre1">
        <w:link w:val="titre1Char"/>
        <w:name w:val="heading 1"/>
        <w:basedOn w:val="Normal"/>
```


### Description

The solution I propose here is, when creating a heading style, to keep the original name of the style provided in the docx (w:styleId), but to force the "w:name" to a value of the format "heading 1".


This impacts: 
- the Reader: which must now read the specific "w:styleId" from the docx and provide this value to the Style;
- Style.php : which must know how to create a style with the custom name provided ;
- the Writer : which must know how to reuse the custom name of the heading style, but force the "w:name" to indicate that it is a heading;


### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
