### PR TITLE
Add more methods to deal with blocks

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -713,6 +713,20 @@ class TemplateProcessor
     }
 
     /**
+     * Returns array of all variables in template without blocks mentioned in the list
+     *
+     * @return string[]
+     */
+    public function getVariablesWithoutBlocks(): array
+    {
+        $variables = $this->getVariables();
+
+        return array_filter($variables, function ($variable) use ($variables) {
+            return strpos($variable, '/') !== 0 && array_search(\sprintf('/%s', $variable), $variables, true) === false;
+        });
+    }
+
+    /**
      * Clone a table row in a template document.
      *
      * @param string $search
@@ -782,6 +796,19 @@ class TemplateProcessor
                 $this->setValue($macro . '#' . $rowNumber, $replace);
             }
         }
+    }
+
+    /**
+     * Returns array of all blocks in the template
+     *
+     * @return string[]
+     */
+    public function getBlocks(): array
+    {
+        $variables = $this->getVariables();
+        return array_filter($variables, function ($variable) use ($variables) {
+            return array_search(\sprintf('/%s', $variable), $variables, true) !== false;
+        });
     }
 
     /**
@@ -862,6 +889,14 @@ class TemplateProcessor
     public function deleteBlock($blockname)
     {
         $this->replaceBlock($blockname, '');
+    }
+
+    /**
+     * Keep a blocks content without the macro around it.
+     */
+    public function keepBlock(string $blockname): ?string
+    {
+        return $this->cloneBlock($blockname, 1, true);
     }
 
     /**


### PR DESCRIPTION
### Description

Add more methods to deal with blocks
* getVariablesWithoutBlocks - All variables except block macro's
* getBlocks - All block names
* keepBlock - Keep a blocks content without the macro around it

Fixes # (issue)
See #2107 

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
