### PR TITLE
[TemplateProcessor][Image]Support image size with decimal value.

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -412,7 +412,7 @@ class TemplateProcessor
                 } else {
                     $varInlineArgs[strtolower($argName)] = $argValue;
                 }
-            } elseif (preg_match('/^([0-9]*[a-z%]{0,2}|auto)x([0-9]*[a-z%]{0,2}|auto)$/i', $varArg)) { // 60x40
+            } elseif (preg_match('/^([0-9]*(\.[0-9]*)?[a-z%]{0,2}|auto)x([0-9]*(\.[0-9]*)?[a-z%]{0,2}|auto)$/i', $varArg)) { // 60x40
                 list($varInlineArgs['width'], $varInlineArgs['height']) = explode('x', $varArg, 2);
             } else { // :60:40:f
                 switch ($argIdx) {
@@ -438,7 +438,7 @@ class TemplateProcessor
         if (is_null($value) && isset($inlineValue)) {
             $value = $inlineValue;
         }
-        if (!preg_match('/^([0-9]*(cm|mm|in|pt|pc|px|%|em|ex|)|auto)$/i', $value)) {
+        if (!preg_match('/^([0-9]*(\.[0-9]*)?(cm|mm|in|pt|pc|px|%|em|ex|)|auto)$/i', $value)) {
             $value = null;
         }
         if (is_null($value)) {

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -412,7 +412,7 @@ class TemplateProcessor
                 } else {
                     $varInlineArgs[strtolower($argName)] = $argValue;
                 }
-            } elseif (preg_match('/^([0-9]*(\.[0-9]*)?[a-z%]{0,2}|auto)x([0-9]*(\.[0-9]*)?[a-z%]{0,2}|auto)$/i', $varArg)) { // 60x40
+            } elseif (preg_match('/^([0-9]*(\.[0-9]+)?[a-z%]{0,2}|auto)x([0-9]*(\.[0-9]+)?[a-z%]{0,2}|auto)$/i', $varArg)) { // 60x40
                 list($varInlineArgs['width'], $varInlineArgs['height']) = explode('x', $varArg, 2);
             } else { // :60:40:f
                 switch ($argIdx) {
@@ -438,7 +438,7 @@ class TemplateProcessor
         if (is_null($value) && isset($inlineValue)) {
             $value = $inlineValue;
         }
-        if (!preg_match('/^([0-9]*(\.[0-9]*)?(cm|mm|in|pt|pc|px|%|em|ex|)|auto)$/i', $value)) {
+        if (!preg_match('/^([0-9]*(\.[0-9]+)?(cm|mm|in|pt|pc|px|%|em|ex|)|auto)$/i', $value)) {
             $value = null;
         }
         if (is_null($value)) {

--- a/tests/PhpWord/TemplateProcessorTest.php
+++ b/tests/PhpWord/TemplateProcessorTest.php
@@ -465,6 +465,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
 
         $this->assertNotContains('${Test}', $expectedMainPartXml, 'word/document.xml has no image.');
     }
+
     /**
      * @covers ::setImageValue
      * @test

--- a/tests/PhpWord/TemplateProcessorTest.php
+++ b/tests/PhpWord/TemplateProcessorTest.php
@@ -391,7 +391,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
      * @covers ::setImageValue
      * @test
      */
-    public function testSetImageValue()
+    public function testSetImageValueWithIntegerSize()
     {
         $templateProcessor = new TemplateProcessor(__DIR__ . '/_files/templates/header-footer.docx');
         $imagePath = __DIR__ . '/_files/images/earth.jpg';
@@ -401,6 +401,84 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
                                     return $imagePath;
                                 },
                                 'documentContent' => array('path' => $imagePath, 'width' => 500, 'height' => 500),
+                                'footerValue'     => array('path' => $imagePath, 'width' => 100, 'height' => 50, 'ratio' => false),
+        );
+        $templateProcessor->setImageValue(array_keys($variablesReplace), $variablesReplace);
+
+        $docName = 'header-footer-images-test-result.docx';
+        $templateProcessor->saveAs($docName);
+
+        $this->assertFileExists($docName, "Generated file '{$docName}' not found!");
+
+        $expectedDocumentZip = new \ZipArchive();
+        $expectedDocumentZip->open($docName);
+        $expectedContentTypesXml = $expectedDocumentZip->getFromName('[Content_Types].xml');
+        $expectedDocumentRelationsXml = $expectedDocumentZip->getFromName('word/_rels/document.xml.rels');
+        $expectedHeaderRelationsXml = $expectedDocumentZip->getFromName('word/_rels/header1.xml.rels');
+        $expectedFooterRelationsXml = $expectedDocumentZip->getFromName('word/_rels/footer1.xml.rels');
+        $expectedMainPartXml = $expectedDocumentZip->getFromName('word/document.xml');
+        $expectedHeaderPartXml = $expectedDocumentZip->getFromName('word/header1.xml');
+        $expectedFooterPartXml = $expectedDocumentZip->getFromName('word/footer1.xml');
+        $expectedImage = $expectedDocumentZip->getFromName('word/media/image_rId11_document.jpeg');
+        if (false === $expectedDocumentZip->close()) {
+            throw new \Exception("Could not close zip file \"{$docName}\".");
+        }
+
+        $this->assertNotEmpty($expectedImage, 'Embed image doesn\'t found.');
+        $this->assertContains('/word/media/image_rId11_document.jpeg', $expectedContentTypesXml, '[Content_Types].xml missed "/word/media/image5_document.jpeg"');
+        $this->assertContains('/word/_rels/header1.xml.rels', $expectedContentTypesXml, '[Content_Types].xml missed "/word/_rels/header1.xml.rels"');
+        $this->assertContains('/word/_rels/footer1.xml.rels', $expectedContentTypesXml, '[Content_Types].xml missed "/word/_rels/footer1.xml.rels"');
+        $this->assertNotContains('${documentContent}', $expectedMainPartXml, 'word/document.xml has no image.');
+        $this->assertNotContains('${headerValue}', $expectedHeaderPartXml, 'word/header1.xml has no image.');
+        $this->assertNotContains('${footerValue}', $expectedFooterPartXml, 'word/footer1.xml has no image.');
+        $this->assertContains('media/image_rId11_document.jpeg', $expectedDocumentRelationsXml, 'word/_rels/document.xml.rels missed "media/image5_document.jpeg"');
+        $this->assertContains('media/image_rId11_document.jpeg', $expectedHeaderRelationsXml, 'word/_rels/header1.xml.rels missed "media/image5_document.jpeg"');
+        $this->assertContains('media/image_rId11_document.jpeg', $expectedFooterRelationsXml, 'word/_rels/footer1.xml.rels missed "media/image5_document.jpeg"');
+
+        unlink($docName);
+
+        // dynamic generated doc
+        $testFileName = 'images-test-sample.docx';
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $section->addText('${Test:width=100:ratio=true}');
+        $objWriter = \PhpOffice\PhpWord\IOFactory::createWriter($phpWord, 'Word2007');
+        $objWriter->save($testFileName);
+        $this->assertFileExists($testFileName, "Generated file '{$testFileName}' not found!");
+
+        $resultFileName = 'images-test-result.docx';
+        $templateProcessor = new \PhpOffice\PhpWord\TemplateProcessor($testFileName);
+        unlink($testFileName);
+        $templateProcessor->setImageValue('Test', $imagePath);
+        $templateProcessor->setImageValue('Test1', $imagePath);
+        $templateProcessor->setImageValue('Test2', $imagePath);
+        $templateProcessor->saveAs($resultFileName);
+        $this->assertFileExists($resultFileName, "Generated file '{$resultFileName}' not found!");
+
+        $expectedDocumentZip = new \ZipArchive();
+        $expectedDocumentZip->open($resultFileName);
+        $expectedMainPartXml = $expectedDocumentZip->getFromName('word/document.xml');
+        if (false === $expectedDocumentZip->close()) {
+            throw new \Exception("Could not close zip file \"{$resultFileName}\".");
+        }
+        unlink($resultFileName);
+
+        $this->assertNotContains('${Test}', $expectedMainPartXml, 'word/document.xml has no image.');
+    }
+    /**
+     * @covers ::setImageValue
+     * @test
+     */
+    public function testSetImageValueWithDecimalSize()
+    {
+        $templateProcessor = new TemplateProcessor(__DIR__ . '/_files/templates/header-footer.docx');
+        $imagePath = __DIR__ . '/_files/images/earth.jpg';
+
+        $variablesReplace = array(
+                                'headerValue' => function () use ($imagePath) {
+                                    return $imagePath;
+                                },
+                                'documentContent' => array('path' => $imagePath, 'width' => '4.5cm', 'height' => '4.5cm'),
                                 'footerValue'     => array('path' => $imagePath, 'width' => 100, 'height' => 50, 'ratio' => false),
         );
         $templateProcessor->setImageValue(array_keys($variablesReplace), $variablesReplace);


### PR DESCRIPTION
### Description

The PHPWord was not correctly parsing the image attribute when the size has decimal value like 7.4cm/12.5%. 

Fixes # (issue)

The problem was at regular expression which matches the size item at file `TemplateProcessor.php` in function [getImageArgs()](https://github.com/PHPOffice/PHPWord/blob/develop/src/PhpWord/TemplateProcessor.php#L399) and [chooseImageDimension()}(https://github.com/PHPOffice/PHPWord/blob/7fd04895676ed5b46379d6ec697aebce40021356/src/PhpWord/TemplateProcessor.php#L441).
The main part of regular expression was `[0-9]*[a-z%]{0,2}`, which matches an integer with a unit after it, such as `4cm`, `50%`, it doesn't match decimal value like `3.9cm` or `12.5%`.
So I added `(\.[0-9]+)?` in the regular expression to match the dot and number with at lease one digit to avoid the value ending with a single dot like `30.`.
Now the main part of regex is like `[0-9]*(\.[0-9]+)?[a-z%]{0,2}`, it can match both integer value and decimal values.

### Checklist:

- [☑️] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
