### PR TITLE
Add support for comments to reader

### DIFF
--- a/src/PhpWord/PhpWord.php
+++ b/src/PhpWord/PhpWord.php
@@ -17,6 +17,8 @@
 
 namespace PhpOffice\PhpWord;
 
+use InvalidArgumentException;
+use PhpOffice\PhpWord\Element\AbstractElement;
 use PhpOffice\PhpWord\Element\Section;
 use PhpOffice\PhpWord\Exception\Exception;
 
@@ -86,6 +88,14 @@ class PhpWord
      * @since 0.12.0
      */
     private $metadata = array();
+
+    /**
+     * Comment reference cache
+     *
+     * @var array
+     * @since 0.18.3
+     */
+    private $commentReferenceCache = array();
 
     /**
      * Create new instance
@@ -421,5 +431,41 @@ class PhpWord
         $this->metadata['Document'] = $documentProperties;
 
         return $this;
+    }
+
+    /**
+     * Cache commentReference (as well as commentRangeStart and commentRangeEnd) for later use
+     * 
+     * @param 'start'|'end' $type
+     * @param string $id,
+     * @param $element
+     *
+     * @return self
+     */
+    public function cacheCommentReference(string $type, string $id, AbstractElement $element)
+    {
+        //dump('cacheCommentReference', func_get_args(), array_key_exists($id, $this->commentReferenceCache));
+        if (!in_array($type, [ 'start', 'end' ])) {
+            throw new InvalidArgumentException('Type must be "start" or "end"');
+        }
+
+        if (!array_key_exists($id, $this->commentReferenceCache)) {
+            $this->commentReferenceCache[$id] = (object)[
+                "start" => null,
+                "end" => null
+            ];
+        }
+        $this->commentReferenceCache[$id]->{$type} = $element;
+
+        return $this;
+    }
+
+    public function getCommentReference(string $id)
+    {
+        if (!array_key_exists($id, $this->commentReferenceCache)) {
+            //dd($this->commentReferenceCache);
+            throw new InvalidArgumentException('Comment with id '.$id.' isn\'t referenced in document');
+        }
+        return $this->commentReferenceCache[$id];
     }
 }

--- a/src/PhpWord/Reader/Word2007/Comments.php
+++ b/src/PhpWord/Reader/Word2007/Comments.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Library\PhpOffice\PhpWord\Reader\Word2007;
+
+use DateTime;
+use PhpOffice\PhpWord\Element\Comment;
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Reader\Word2007\AbstractPart;
+use PhpOffice\PhpWord\Shared\XMLReader;
+
+class Comments extends AbstractPart
+{
+    /**
+     * Collection name comments
+     *
+     * @var string
+     */
+    protected $collection = 'comments';
+
+    /**
+     * Read settings.xml.
+     *
+     * @param \PhpOffice\PhpWord\PhpWord $phpWord
+     */
+    public function read(PhpWord $phpWord)
+    {
+        $xmlReader = new XMLReader();
+        $xmlReader->getDomFromZip($this->docFile, $this->xmlFile);
+
+        //$xmlReader2 = new XMLReader();
+        //$xmlReader2->getDomFromZip($this->docFile, 'word/document.xml');
+        //dd($xmlReader2);
+
+        $comments = $phpWord->getComments();
+
+        $nodes = $xmlReader->getElements('*');
+        if ($nodes->length > 0) {
+            foreach ($nodes as $node) {
+                $name = str_replace('w:', '', $node->nodeName);
+                $value = $xmlReader->getAttribute('w:author', $node);
+                $author = $xmlReader->getAttribute('w:author', $node);
+                $date = $xmlReader->getAttribute('w:date', $node);
+                $initials = $xmlReader->getAttribute('w:initials', $node);
+                $id = $xmlReader->getAttribute('w:id', $node);
+                $element = new Comment($author, new DateTime($date), $initials);//$this->getElement($phpWord, $id);
+                //$element->set
+                // $range = $xmlReader2->getElements('.//*[("commentRangeStart"=local-name() or "commentRangeEnd"=local-name()) and @*[local-name()="id" and .="'.$id.'"]]');
+                try {
+                    unset($range);
+                    $range = $phpWord->getCommentReference($id);
+                    $range->start->setCommentRangeStart($element);
+                    $range->end->setCommentRangeEnd($element);
+                } catch(\Exception $e) {
+                    //dd('range', [$element, $id, $node, $node->C14N(), $range ?? null, $e]);
+                }
+                //dd($startElement, $endElement, current(current($phpWord->getSections())->getElements()));
+                //dump($element, $range);
+                //dd($element, $node, $id, $node->C14N());
+                $method = 'set' . $name;
+                //dump([$element, $id, $name, $value, $author, $date, $initials, $method, $xmlReader->getElements('w:p/w:r/w:t', $node)]);
+                //dd('dsf');
+                $pNodes = $xmlReader->getElements('w:p/w:r', $node);
+                foreach ($pNodes as $pNode) {
+                    //dump(['>', $xmlReader, $pNode, $node, $this->collection, '<']);
+                    $this->readRun($xmlReader, $pNode, $element, $this->collection);
+                }
+
+                /*if (in_array($name, $this::$booleanProperties)) {
+                    if ($value == 'false') {
+                        $comments->$method(false);
+                    } else {
+                        $comments->$method(true);
+                    }
+                } else*/if (method_exists($this, $method)) {
+                    $this->$method($xmlReader, $phpWord, $node);
+                } elseif (method_exists($comments, $method)) {
+                    $comments->$method($value);
+                } elseif (method_exists($phpWord, $method)) {
+                    $phpWord->$method($value);
+                } elseif (method_exists($comments, 'addItem')) {
+                    $comments->addItem($element);
+                }
+            }
+        }
+	}
+
+    /**
+     * Searches for the element with the given relationId
+     *
+     * @param PhpWord $phpWord
+     * @param int $relationId
+     * @return \PhpOffice\PhpWord\Element\AbstractContainer|null
+     */
+    private function getElement(PhpWord $phpWord, $relationId)
+    {
+        $getMethod = "get{$this->collection}";
+        //$getMethod = "getTrackChange";
+        $collection = $phpWord->$getMethod();//->getItems();
+
+        //not found by key, looping to search by relationId
+        foreach ($collection as $collectionElement) {
+            if ($collectionElement->getRelationId() == $relationId) {
+                return $collectionElement;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/PhpWord/Reader/Word2007/Document.php
+++ b/src/PhpWord/Reader/Word2007/Document.php
@@ -34,7 +34,7 @@ class Document extends AbstractPart
      *
      * @var \PhpOffice\PhpWord\PhpWord
      */
-    private $phpWord;
+    protected $phpWord;
 
     /**
      * Read document.xml.
@@ -179,5 +179,10 @@ class Document extends AbstractPart
         $style = $this->readSectionStyle($xmlReader, $node);
         $section->setStyle($style);
         $this->readHeaderFooter($style, $section);
+    }
+
+    protected function cacheCommentReference(string $type, string $id, $element)
+    {
+        $this->phpWord->cacheCommentReference($type, $id, $element);
     }
 }


### PR DESCRIPTION
### Description
Since comments are part of the OOXML spec and I need to build an application that uses comments, I implemented them into phpWord

Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
