### PR TITLE
Fix rowspans for tables in HTML Writer

### DIFF
--- a/samples/Sample_09_Tables.php
+++ b/samples/Sample_09_Tables.php
@@ -55,46 +55,38 @@ for ($i = 1; $i <= 8; $i++) {
 
 /*
  *  3. colspan (gridSpan) and rowspan (vMerge)
- *  ---------------------
- *  |     |   B    |    |
- *  |  A  |--------|  E |
- *  |     | C |  D |    |
- *  ---------------------
+ *  -------------------------
+ *  |  A  |     B     |  C  |
+ *  |-----|-----------|     |
+ *  |        D        |     |
+ *  ------|-----------|     |
+ *  |  E  |  F  |  G  |     |
+ *  -------------------------
  */
 
 $section->addPageBreak();
 $section->addText('Table with colspan and rowspan', $header);
 
-$fancyTableStyle = array('borderSize' => 6, 'borderColor' => '999999');
-$cellRowSpan = array('vMerge' => 'restart', 'valign' => 'center', 'bgColor' => 'FFFF00');
-$cellRowContinue = array('vMerge' => 'continue');
-$cellColSpan = array('gridSpan' => 2, 'valign' => 'center');
-$cellHCentered = array('alignment' => \PhpOffice\PhpWord\SimpleType\Jc::CENTER);
-$cellVCentered = array('valign' => 'center');
+$styleTable = array('borderSize' => 6, 'borderColor' => '999999');
 
 $spanTableStyleName = 'Colspan Rowspan';
-$phpWord->addTableStyle($spanTableStyleName, $fancyTableStyle);
+$phpWord->addTableStyle($spanTableStyleName, $styleTable);
 $table = $section->addTable($spanTableStyleName);
 
-$table->addRow();
+$row1 = $table->addRow();
+$row1->addCell(500)->addText('A');
+$row1->addCell(1000, array('gridSpan' => 2))->addText('B');
+$row1->addCell(500, array('vMerge' => 'restart'))->addText('C');
 
-$cell1 = $table->addCell(2000, $cellRowSpan);
-$textrun1 = $cell1->addTextRun($cellHCentered);
-$textrun1->addText('A');
-$textrun1->addFootnote()->addText('Row span');
+$row2 = $table->addRow();
+$row2->addCell(1500, array('gridSpan' => 3))->addText('D');
+$row2->addCell(null, array('vMerge' => 'continue'));
 
-$cell2 = $table->addCell(4000, $cellColSpan);
-$textrun2 = $cell2->addTextRun($cellHCentered);
-$textrun2->addText('B');
-$textrun2->addFootnote()->addText('Column span');
-
-$table->addCell(2000, $cellRowSpan)->addText('E', null, $cellHCentered);
-
-$table->addRow();
-$table->addCell(null, $cellRowContinue);
-$table->addCell(2000, $cellVCentered)->addText('C', null, $cellHCentered);
-$table->addCell(2000, $cellVCentered)->addText('D', null, $cellHCentered);
-$table->addCell(null, $cellRowContinue);
+$row3 = $table->addRow();
+$row3->addCell(500)->addText('E');
+$row3->addCell(500)->addText('F');
+$row3->addCell(500)->addText('G');
+$row3->addCell(null, array('vMerge' => 'continue'));
 
 /*
  *  4. colspan (gridSpan) and rowspan (vMerge)

--- a/tests/PhpWord/Writer/HTML/ElementTest.php
+++ b/tests/PhpWord/Writer/HTML/ElementTest.php
@@ -136,6 +136,43 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, $xpath->query('/html/body/table/tr[2]/td')->length);
     }
 
+    /**
+     * Tests writing table with rowspan and colspan
+     */
+    public function testWriteRowSpanAndColSpan()
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $table = $section->addTable();
+
+        $row1 = $table->addRow();
+        $row1->addCell(500)->addText('A');
+        $row1->addCell(1000, array('gridSpan' => 2))->addText('B');
+        $row1->addCell(500, array('vMerge' => 'restart'))->addText('C');
+
+        $row2 = $table->addRow();
+        $row2->addCell(1500, array('gridSpan' => 3))->addText('D');
+        $row2->addCell(null, array('vMerge' => 'continue'));
+
+        $row3 = $table->addRow();
+        $row3->addCell(500)->addText('E');
+        $row3->addCell(500)->addText('F');
+        $row3->addCell(500)->addText('G');
+        $row3->addCell(null, array('vMerge' => 'continue'));
+
+        $dom = $this->getAsHTML($phpWord);
+        $xpath = new \DOMXPath($dom);
+
+        $this->assertEquals(3, $xpath->query('/html/body/table/tr[1]/td')->length);
+        $this->assertEquals('2', $xpath->query('/html/body/table/tr[1]/td[2]')->item(0)->attributes->getNamedItem('colspan')->textContent);
+        $this->assertEquals('3', $xpath->query('/html/body/table/tr[1]/td[3]')->item(0)->attributes->getNamedItem('rowspan')->textContent);
+
+        $this->assertEquals(1, $xpath->query('/html/body/table/tr[2]/td')->length);
+        $this->assertEquals('3', $xpath->query('/html/body/table/tr[2]/td[1]')->item(0)->attributes->getNamedItem('colspan')->textContent);
+
+        $this->assertEquals(3, $xpath->query('/html/body/table/tr[3]/td')->length);
+    }
+
     private function getAsHTML(PhpWord $phpWord)
     {
         $htmlWriter = new HTML($phpWord);


### PR DESCRIPTION
### Description

Considering colspans when calculating rowspans.

Before:

![image](https://user-images.githubusercontent.com/14309343/140740176-257909f5-941f-4297-aaf3-e428971920a1.png)

After:

![image](https://user-images.githubusercontent.com/14309343/140740211-7b181aa0-ead2-4ba7-9567-6efb07db7f24.png)

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
