### PR TITLE
[TemplateProcessor] Clean up temp files

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -132,6 +132,14 @@ class TemplateProcessor
         $this->tempDocumentContentTypes = $this->zipClass->getFromName($this->getDocumentContentTypesName());
     }
 
+    public function __destruct()
+    {
+        // if the temp file still exists, remove it when running destruct
+        if ($this->tempDocumentFilename && file_exists($this->tempDocumentFilename) && is_writable($this->tempDocumentFilename)) {
+            @unlink($this->tempDocumentFilename);
+        }
+    }
+
     /**
      * Expose zip class
      *


### PR DESCRIPTION

### Description

Recently we had to run the template processor 80.000 times, during this processor the /tmp partition become full. After a short investigation we found a lot of files with PhpWord in theire name.
Adding a destrucutor wich clean up the tmp files seems to work.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
