### PR TITLE
Update homepage in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "docx", "OOXML", "OpenXML", "Office Open XML", "ISO IEC 29500", "WordprocessingML",
         "RTF", "Rich Text Format", "doc", "odt", "ODF", "OpenDocument", "PDF", "HTML"
     ],
-    "homepage": "http://phpoffice.github.io",
+    "homepage": "https://phpword.readthedocs.io/",
     "type": "library",
     "license": "LGPL-3.0",
     "authors": [


### PR DESCRIPTION
I found out that the homepage link on packagist.org points to: http://phpoffice.github.io/ but that site doesn't exist. So this PR updates the link to the documentation site.