### PR TITLE
Add manual column breaks in Word2007

### DIFF
--- a/docs/elements.rst
+++ b/docs/elements.rst
@@ -152,6 +152,16 @@ method or using the ``pageBreakBefore`` style of paragraph.
 
     $section->addPageBreak();
 
+Column breaks
+~~~~~~~~~~~~~
+
+Column breaks may be inserted using the ``addColumnBreak`` method.
+
+.. code-block:: php
+
+    $section->addColumnBreak();
+
+
 Lists
 -----
 

--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -34,6 +34,7 @@ namespace PhpOffice\PhpWord\Element;
  * @method Title addTitle(mixed $text, int $depth = 1)
  * @method TOC addTOC(mixed $fontStyle = null, mixed $tocStyle = null, int $minDepth = 1, int $maxDepth = 9)
  * @method PageBreak addPageBreak()
+ * @method ColumnBreak addColumnBreak()
  * @method Table addTable(mixed $style = null)
  * @method Image addImage(string $source, mixed $style = null, bool $isWatermark = false, $name = null)
  * @method OLEObject addOLEObject(string $source, mixed $style = null)
@@ -83,7 +84,7 @@ abstract class AbstractContainer extends AbstractElement
             'Text', 'TextRun', 'Bookmark', 'Link', 'PreserveText', 'TextBreak',
             'ListItem', 'ListItemRun', 'Table', 'Image', 'Object', 'OLEObject',
             'Footnote', 'Endnote', 'CheckBox', 'TextBox', 'Field',
-            'Line', 'Shape', 'Title', 'TOC', 'PageBreak',
+            'Line', 'Shape', 'Title', 'TOC', 'PageBreak', 'ColumnBreak',
             'Chart', 'FormField', 'SDT', 'Comment',
         );
         $functions = array();

--- a/src/PhpWord/Element/ColumnBreak.php
+++ b/src/PhpWord/Element/ColumnBreak.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ * @copyright   2010-2018 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Element;
+
+/**
+ * Page break element
+ */
+class ColumnBreak extends AbstractElement
+{
+    /**
+     * Create new column break
+     */
+    public function __construct()
+    {
+    }
+}

--- a/src/PhpWord/Reader/Word2007/Document.php
+++ b/src/PhpWord/Reader/Word2007/Document.php
@@ -154,6 +154,11 @@ class Document extends AbstractPart
             $section->addPageBreak(); // PageBreak
         }
 
+        // Column break
+        if ($xmlReader->getAttribute('w:type', $node, 'w:br') == 'column') {
+            $section->addColumnBreak(); // ColumnBreak
+        }
+
         // Paragraph
         $this->readParagraph($xmlReader, $node, $section);
 

--- a/src/PhpWord/Writer/Word2007/Element/ColumnBreak.php
+++ b/src/PhpWord/Writer/Word2007/Element/ColumnBreak.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ * @copyright   2010-2018 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+
+/**
+ * ColumnBreak element writer
+ *
+ * @since 0.10.0
+ */
+class ColumnBreak extends AbstractElement
+{
+    /**
+     * Write element.
+     *
+     * @usedby \PhpOffice\PhpWord\Writer\Word2007\Element\AbstractElement::startElementP()
+     */
+    public function write()
+    {
+        $xmlWriter = $this->getXmlWriter();
+
+        $xmlWriter->startElement('w:br');
+        $xmlWriter->writeAttribute('w:type', 'column');
+        $xmlWriter->endElement(); // w:br
+    }
+}

--- a/tests/PhpWord/Element/ColumnBreakTest.php
+++ b/tests/PhpWord/Element/ColumnBreakTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ * @copyright   2010-2018 PHPWord contributors
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Element;
+
+/**
+ * Test class for PhpOffice\PhpWord\Element\ColumnBreak
+ *
+ * @coversDefaultClass \PhpOffice\PhpWord\Element\ColumnBreak
+ * @runTestsInSeparateProcesses
+ */
+class ColumnBreakTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Executed before each method of the class
+     */
+    public function testConstruct()
+    {
+        $oColumnBreak = new ColumnBreak();
+
+        $this->assertInstanceOf('PhpOffice\\PhpWord\\Element\\ColumnBreak', $oColumnBreak);
+    }
+}

--- a/tests/PhpWord/Element/SectionTest.php
+++ b/tests/PhpWord/Element/SectionTest.php
@@ -74,6 +74,7 @@ class SectionTest extends \PHPUnit\Framework\TestCase
         $section->addLink(utf8_decode('http://äää.com'), utf8_decode('ä'));
         $section->addTextBreak();
         $section->addPageBreak();
+        $section->addColumnBreak();
         $section->addTable();
         $section->addListItem(utf8_decode('ä'));
         $section->addObject($objectSource);
@@ -90,6 +91,7 @@ class SectionTest extends \PHPUnit\Framework\TestCase
             'Link',
             'TextBreak',
             'PageBreak',
+            'ColumnBreak',
             'Table',
             'ListItem',
             'OLEObject',


### PR DESCRIPTION
### Description

So far, PHPWord was not able to create a manual column break in multi-column sections (see issue #1053). This PR implements an addColumnBreak() method and corresponding rendering for Word2007 format.

Implements #1053 for Word2007

### Checklist:

- [X] I have run `composer run-script check --timeout=0` and no errors were reported
- [X] The new code is covered by unit tests (check build/coverage for coverage report)
- [X] I have updated the documentation to describe the changes
