### PR TITLE
#2187 Addresses deprecation on PHP 8.1 in ZipArchi

### DIFF
--- a/src/PhpWord/Shared/ZipArchive.php
+++ b/src/PhpWord/Shared/ZipArchive.php
@@ -133,6 +133,13 @@ class ZipArchive
 
         if (!$this->usePclzip) {
             $zip = new \ZipArchive();
+
+            // PHP 8.1 compat - passing null as second arg to \ZipArchive::open() is deprecated
+            // passing 0 achieves the same behaviour
+            if ($flags === null) {
+                $flags = 0;
+            }
+
             $result = $zip->open($this->filename, $flags);
 
             // Scrutizer will report the property numFiles does not exist


### PR DESCRIPTION
### Description

This addresses the deprecation in PHP 8.1 noted in issue #2187.

The fix does not break backwards compatibility because existing code can still pass no second argument (or pass explicitly pass `null`) and existing behaviour will not be affected.

Fixes #2187 

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes

I didn't add any new tests. There is already a test which tests calling `PhpOffice\PhpWord\Shared\ZipArchive::open()` with no second arg passed (i.e. `null` passed). The version of phpunit in the project means I can't run the test suite locally to verify that the 8.1 deprecation has been fixed.

I'm also not able to run the composer script because `composer install` installed an old version of phpunit that won't run on PHP 8.