### PR TITLE
Ref field support

### DIFF
--- a/docs/usage/elements/field.md
+++ b/docs/usage/elements/field.md
@@ -8,6 +8,7 @@ Currently the following fields are supported:
 - XE
 - INDEX
 - FILENAME
+- REF
 
 ``` php
 <?php
@@ -37,4 +38,12 @@ $section->addField('XE', array(), array(), $fieldText);
 
 //this actually adds the index
 $section->addField('INDEX', array(), array('\\e "	" \\h "A" \\c "3"'), 'right click to update index');
+
+//Adding reference to a bookmark
+$fieldText->addField('REF', [
+      'name' => 'bookmark'
+  ], [
+      'InsertParagraphNumberRelativeContext',
+      'CreateHyperLink',
+  ]);
 ```

--- a/src/PhpWord/Element/Field.php
+++ b/src/PhpWord/Element/Field.php
@@ -91,6 +91,10 @@ class Field extends AbstractElement
             ],
             'options' => ['Path', 'PreserveFormat'],
         ],
+        'REF' => array(
+            'properties' => array('name' => ''),
+            'options'    => array('f', 'h', 'n', 'p', 'r', 't', 'w'),
+        ),
     ];
 
     /**

--- a/src/PhpWord/Writer/Word2007/Element/Field.php
+++ b/src/PhpWord/Writer/Word2007/Element/Field.php
@@ -315,7 +315,7 @@ class Field extends Text
             case 'NoTrailingPeriod': return '\\n';
             case 'IncludeAboveOrBelow': return '\\p';
             case 'InsertParagraphNumberRelativeContext': return '\\r';
-            case 'SuppressNonDelimeterNonNumericalText': return '\\t';
+            case 'SuppressNonDelimiterNonNumericalText': return '\\t';
             case 'InsertParagraphNumberFullContext': return '\\w';
             default: return '';
         }

--- a/src/PhpWord/Writer/Word2007/Element/Field.php
+++ b/src/PhpWord/Writer/Word2007/Element/Field.php
@@ -310,14 +310,22 @@ class Field extends Text
         }
 
         switch ($optionValue) {
-            case 'IncrementAndInsertText': return '\\f';
-            case 'CreateHyperLink': return '\\h';
-            case 'NoTrailingPeriod': return '\\n';
-            case 'IncludeAboveOrBelow': return '\\p';
-            case 'InsertParagraphNumberRelativeContext': return '\\r';
-            case 'SuppressNonDelimiterNonNumericalText': return '\\t';
-            case 'InsertParagraphNumberFullContext': return '\\w';
-            default: return '';
+            case 'IncrementAndInsertText':
+                return '\\f';
+            case 'CreateHyperLink':
+                return '\\h';
+            case 'NoTrailingPeriod':
+                return '\\n';
+            case 'IncludeAboveOrBelow':
+                return '\\p';
+            case 'InsertParagraphNumberRelativeContext':
+                return '\\r';
+            case 'SuppressNonDelimiterNonNumericalText':
+                return '\\t';
+            case 'InsertParagraphNumberFullContext':
+                return '\\w';
+            default:
+                return '';
         }
     }
 }

--- a/tests/PhpWord/Writer/Word2007/Element/FieldTest.php
+++ b/tests/PhpWord/Writer/Word2007/Element/FieldTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\TestHelperDOCX;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for PhpOffice\PhpWord\Writer\Word2007\Field
+ */
+class FieldTest extends TestCase
+{
+    /**
+     * Executed before each method of the class
+     */
+    public function tearDown()
+    {
+        TestHelperDOCX::clear();
+    }
+
+    /**
+     * Test Field write
+     */
+    public function testWriteWithRefType()
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $section->addField(
+            'REF',
+            array(
+                'name' => 'my-bookmark',
+            ),
+            array(
+                'InsertParagraphNumberRelativeContext',
+                'CreateHyperLink',
+            )
+        );
+
+        $section->addListItem('line one item');
+        $section->addListItem('line two item');
+        $section->addBookmark('my-bookmark');
+        $section->addListItem('line three item');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $refFieldPath = '/w:document/w:body/w:p[1]/w:r[2]/w:instrText';
+
+        $this->assertTrue($doc->elementExists($refFieldPath));
+
+        $bookMarkElement = $doc->getElement($refFieldPath);
+
+        $this->assertNotNull($bookMarkElement);
+
+        $this->assertEquals(' REF my-bookmark \r \h ', $bookMarkElement->textContent);
+
+        $bookmarkPath = '/w:document/w:body/w:bookmarkStart';
+
+        $this->assertTrue($doc->elementExists($bookmarkPath));
+        $this->assertEquals('my-bookmark', $doc->getElementAttribute("$bookmarkPath", 'w:name'));
+    }
+}


### PR DESCRIPTION
### Description
PHPOffice/PHPWord currently does not support adding the field of type REF. 
I would like to add a field to reference a bookmark

Fixes # (issue)
- Add REF options to $fieldsArray in PhpOffice\PhpWord\Element\Field.php
- Added writeRef method to Handle REF options

```php
$textRun->addField('REF', [
      'name' => 'my-bookmark'
  ], [
      'InsertParagraphNumberRelativeContext',
      'CreateHyperLink',
  ]);

```

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
