### PR TITLE
PHP 8.1 compatability fix for PreserveText and XMLWriter

### DIFF
--- a/src/PhpWord/Element/PreserveText.php
+++ b/src/PhpWord/Element/PreserveText.php
@@ -60,7 +60,7 @@ class PreserveText extends AbstractElement
         $this->paragraphStyle = $this->setNewStyle(new Paragraph(), $paragraphStyle);
 
         $this->text = SharedText::toUTF8($text);
-        $matches = preg_split('/({.*?})/', $this->text, null, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        $matches = preg_split('/({.*?})/', $this->text, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
         if (isset($matches[0])) {
             $this->text = $matches;
         }

--- a/src/PhpWord/Shared/XMLWriter.php
+++ b/src/PhpWord/Shared/XMLWriter.php
@@ -171,6 +171,7 @@ class XMLWriter extends \XMLWriter
      * @param mixed $value
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function writeAttribute($name, $value)
     {
         if (is_float($value)) {


### PR DESCRIPTION
### Description

Fixes two issues with deprecation warnings in PHP 8.1. 

The check script fails with an error in an unrelated file, so I'm guessing that's ok: 
`/application/repos/PHPWord/src/PhpWord/Element/TOC.php:27  CamelCasePropertyName  The property $TOCStyle is not named in camelCase.`

All unit tests still pass on PHP 7.3. 

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
