### PR TITLE
Template processor - improve regex in replace block method

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -840,7 +840,7 @@ class TemplateProcessor
     {
         $matches = array();
         preg_match(
-            '/(<\?xml.*)(<w:p.*>\${' . $blockname . '}<\/w:.*?p>)(.*)(<w:p.*\${\/' . $blockname . '}<\/w:.*?p>)/is',
+            '/(<\?xml.*)(<w:p\b.*>\${' . $blockname . '}<\/w:.*?p>)(.*)(<w:p\b.*\${\/' . $blockname . '}<\/w:.*?p>)/is',
             $this->tempDocumentMainPart,
             $matches
         );


### PR DESCRIPTION
### Description
This pull request improve REGEX used in template processing (`TemplateProcessor` class) in `replaceBlock` method. 
The below example shows a case where a regular expression matches an incorrect piece of document content and after replacing causes an error during opening the file.  

Current REGEX:
```regexp
(<\?xml.*)(<w:p.*>\${blockname}<\/w:.*?p>)(.*)(<w:p.*\${\/blockname}<\/w:.*?p>)
```
![current](https://user-images.githubusercontent.com/11235024/164783813-d9258870-55f1-467f-a101-99713fc49e08.png)

Proposed REGEX:
```regexp
(<\?xml.*)(<w:p\b.*>\${blockname}<\/w:.*?p>)(.*)(<w:p\b.*\${\/blockname}<\/w:.*?p>)
```
![proposed](https://user-images.githubusercontent.com/11235024/164783758-3e0796b2-9de8-49ab-9f42-2467fc9ffd33.png)

Example document content:
```xml
/word/document.xml
...
<w:p>
    <w:pPr>
        <w:pStyle w:val="Normal"/>
        <w:widowControl w:val="false"/>
        <w:rPr></w:rPr>
    </w:pPr>
    <w:r>
        <w:rPr></w:rPr>
        <w:t>${keyQualifications}</w:t>
    </w:r>
</w:p>
<w:p>
    <w:pPr>
        <w:pStyle w:val="Normal"/>
        <w:widowControl w:val="false"/>
        <w:rPr></w:rPr>
    </w:pPr>
    <w:r>
        <w:rPr></w:rPr>
        <w:t>${item}</w:t>
    </w:r>
</w:p>
<w:p>
    <w:pPr>
        <w:pStyle w:val="Normal"/>
        <w:widowControl w:val="false"/>
        <w:rPr></w:rPr>
    </w:pPr>
    <w:r>
        <w:rPr></w:rPr>
        <w:t>${/keyQualifications}</w:t>
    </w:r>
</w:p>
...
```

Current REGEX will result in below matches with is incorrect and lead to the wrong replacement:
```text
<w:pStyle w:val="Normal"> ... </w:p>
```

REGEX proposed in this pull request correctly matches piece of code that should be replaced:
```text
<w:p><w:pPr><w:pStyle w:val="Normal"/> ... </w:p>
```

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
