### PR TITLE
Fix #1970

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -861,7 +861,7 @@ class TemplateProcessor
      */
     public function deleteBlock($blockname)
     {
-        $this->replaceBlock($blockname, '');
+        $this->cloneBlock($blockname, 0);
     }
 
     /**


### PR DESCRIPTION
### Description

Fixes `deleteBlock` by using `cloneBlock` instead of `replaceBlock`, because it has a better regex.

Fixes #1970

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported — I made the change via GitHub UI and hope that the GitHub workflow will run the tests once I make this PR
- [ ] The new code is covered by unit tests (check build/coverage for coverage report) — no new lines were added
- [ ] I have updated the documentation to describe the changes — no features were added or changed, this is a bug fix