### PR TITLE
Permit book-fold printing

### DIFF
--- a/docs/general.rst
+++ b/docs/general.rst
@@ -177,6 +177,28 @@ Use mirror margins to set up facing pages for double-sided documents, such as bo
 
     $phpWord->getSettings()->setMirrorMargins(true);
 
+Note that in order for this to work properly, you need to set both paper size and page size. For example,
+to print a document on A4 paper (landscape) and fold it into A5 pages (portrait), use this section style:
+
+.. code-block:: php
+
+    $phpWord->getSettings()->setMirrorMargins(true);
+    $phpWord->addSection(array(
+        'paperSize' => 'A4',
+        'orientation' => 'landscape',
+        'pageSizeW' => \PhpOffice\PhpWord\Shared\Converter::cmToTwip(14.85),
+        'pageSizeH' => \PhpOffice\PhpWord\Shared\Converter::cmToTwip(21),
+    ));
+
+
+Printing as folded booklet
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use book-fold printing to set up documents to be printed as foldable pages.
+
+.. code-block:: php
+
+    $phpWord->getSettings()->setBookFoldPrinting(true);
+
 Spelling and grammatical checks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/PhpWord/Metadata/Settings.php
+++ b/src/PhpWord/Metadata/Settings.php
@@ -161,6 +161,13 @@ class Settings
     private $doNotHyphenateCaps;
 
     /**
+     * Enable or disable book-folded printing.
+     *
+     * @var null|bool
+     */
+    private $bookFoldPrinting;
+
+    /**
      * @return Protection
      */
     public function getDocumentProtection()
@@ -480,5 +487,21 @@ class Settings
     public function setDoNotHyphenateCaps($doNotHyphenateCaps): void
     {
         $this->doNotHyphenateCaps = (bool) $doNotHyphenateCaps;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasBookFoldPrinting()
+    {
+        return $this->bookFoldPrinting;
+    }
+
+    /**
+     * @param bool $bookFoldPrinting
+     */
+    public function setBookFoldPrinting($bookFoldPrinting): void
+    {
+        $this->bookFoldPrinting = $bookFoldPrinting;
     }
 }

--- a/src/PhpWord/Metadata/Settings.php
+++ b/src/PhpWord/Metadata/Settings.php
@@ -165,7 +165,7 @@ class Settings
      *
      * @var bool
      */
-    private $bookFoldPrinting;
+    private $bookFoldPrinting = false;
 
     /**
      * @return Protection

--- a/src/PhpWord/Metadata/Settings.php
+++ b/src/PhpWord/Metadata/Settings.php
@@ -492,7 +492,7 @@ class Settings
     /**
      * @return bool
      */
-    public function hasBookFoldPrinting()
+    public function hasBookFoldPrinting(): bool
     {
         return $this->bookFoldPrinting;
     }

--- a/src/PhpWord/Metadata/Settings.php
+++ b/src/PhpWord/Metadata/Settings.php
@@ -500,7 +500,7 @@ class Settings
     /**
      * @param bool $bookFoldPrinting
      */
-    public function setBookFoldPrinting($bookFoldPrinting): void
+    public function setBookFoldPrinting(bool $bookFoldPrinting): void
     {
         $this->bookFoldPrinting = $bookFoldPrinting;
     }

--- a/src/PhpWord/Metadata/Settings.php
+++ b/src/PhpWord/Metadata/Settings.php
@@ -163,7 +163,7 @@ class Settings
     /**
      * Enable or disable book-folded printing.
      *
-     * @var null|bool
+     * @var bool
      */
     private $bookFoldPrinting;
 

--- a/src/PhpWord/Writer/Word2007/Part/Settings.php
+++ b/src/PhpWord/Writer/Word2007/Part/Settings.php
@@ -151,6 +151,7 @@ class Settings extends AbstractPart
         $this->setOnOffValue('w:updateFields', $documentSettings->hasUpdateFields());
         $this->setOnOffValue('w:autoHyphenation', $documentSettings->hasAutoHyphenation());
         $this->setOnOffValue('w:doNotHyphenateCaps', $documentSettings->hasDoNotHyphenateCaps());
+        $this->setOnOffValue('w:bookFoldPrinting', $documentSettings->hasBookFoldPrinting());
 
         $this->setThemeFontLang($documentSettings->getThemeFontLang());
         $this->setRevisionView($documentSettings->getRevisionView());

--- a/tests/PhpWordTests/Writer/Word2007/Part/SettingsTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/Part/SettingsTest.php
@@ -468,4 +468,20 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $element = $doc->getElement($path, $file);
         self::assertSame('true', $element->getAttribute('w:val'));
     }
+
+    public function testBookFoldPrinting(): void
+    {
+        $phpWord = new PhpWord();
+        $phpWord->getSettings()->setBookFoldPrinting(true);
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $file = 'word/settings.xml';
+
+        $path = '/w:settings/w:bookFoldPrinting';
+        self::assertTrue($doc->elementExists($path, $file));
+
+        $element = $doc->getElement($path, $file);
+        self::assertSame('true', $element->getAttribute('w:val'));
+    }
 }


### PR DESCRIPTION
### Description

Microsoft Word permits printing documents folded as booklets or books. (See [Create a booklet or book in Word](https://support.microsoft.com/en-us/office/create-a-booklet-or-book-in-word-dfd94694-fa4f-4c71-a1c7-737c31539e4a)). 

![Creating a booklet or book in Word](https://support.content.office.net/en-us/media/ff53cdfe-00f3-4c4e-9d94-2d28ab571c8e.png)

Internally, this is accomplished by simply adding ````<w:bookFoldPrinting/>```` to settings.xml.

This patch adds this functionality to PHPWord.

Note: In order for this to properly work in Microsoft Word, both paperSize/orientation and page dimensions need to be set for the section. For example, to print a document on A4 paper (landscape) and fold it into A5 pages (portrait), use this section style:

    $phpWord->getSettings()->setMirrorMargins(true);
    $phpWord->addSection(array(
        'paperSize' => 'A4',
        'orientation' => 'landscape',
        'pageSizeW' => \PhpOffice\PhpWord\Shared\Converter::cmToTwip(14.85),
        'pageSizeH' => \PhpOffice\PhpWord\Shared\Converter::cmToTwip(21),
    ));


### Checklist:

- [X] I have run `composer run-script check --timeout=0` and no errors were reported
- [X] The new code is covered by unit tests (check build/coverage for coverage report)
- [X] I have updated the documentation to describe the changes
