### PR TITLE
PHP 8.1 support

### DIFF
--- a/src/PhpWord/Element/PreserveText.php
+++ b/src/PhpWord/Element/PreserveText.php
@@ -60,7 +60,7 @@ class PreserveText extends AbstractElement
         $this->paragraphStyle = $this->setNewStyle(new Paragraph(), $paragraphStyle);
 
         $this->text = SharedText::toUTF8($text);
-        $matches = preg_split('/({.*?})/', $this->text, null, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        $matches = preg_split('/({.*?})/', $this->text, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
         if (isset($matches[0])) {
             $this->text = $matches;
         }


### PR DESCRIPTION
Replaced limit null by -1 in preg_split to support PHP 8.1.

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist:

- [x ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
