### PR TITLE
PHP 8.1 support

### DIFF
--- a/src/PhpWord/Shared/XMLWriter.php
+++ b/src/PhpWord/Shared/XMLWriter.php
@@ -171,6 +171,7 @@ class XMLWriter extends \XMLWriter
      * @param mixed $value
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function writeAttribute($name, $value)
     {
         if (is_float($value)) {


### PR DESCRIPTION
Add #[\ReturnTypeWillChange] to writeAttribute method to support PHP 8.1 without need of complete rewrite of this class.

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
