### PR TITLE
Added possibility od defining own Heading detection regular expression in Word2007 document reader

### DIFF
--- a/docs/general.rst
+++ b/docs/general.rst
@@ -151,6 +151,24 @@ default font by using the following two functions:
     $phpWord->setDefaultFontName('Times New Roman');
     $phpWord->setDefaultFontSize(12);
 
+Heading detection regexp
+~~~~~~~~~~~~
+
+You can set now regexp that detects Headings in the document based on style naming convention, which differs among language versions of Microsoft Office for instance.
+As default, ``/Heading(\d)/`` is used.
+
+To set another regexp for whole application, set ``headingDepthRegexp`` value in custom phpword.ini file:
+
+.. code-block:: ini
+
+    headingDepthRegexp    = '/TheHeading(\d)/i'
+
+You may also set/change regexp anywhere in your app run:
+
+.. code-block:: php
+
+    \PhpOffice\PhpWord\Settings::setHeadingDepthRegexp('/TheHeading(\d)/i');
+
 Document settings
 -----------------
 Settings for the generated document can be set using ``$phpWord->getSettings()``

--- a/phpword.ini.dist
+++ b/phpword.ini.dist
@@ -9,6 +9,7 @@ pdfRendererName       = DomPDF
 pdfRendererPath       =
 ; tempDir               = "C:\PhpWordTemp"
 outputEscapingEnabled = false
+headingDepthRegexp    =
 
 [Font]
 

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -22,6 +22,7 @@ use PhpOffice\PhpWord\Element\AbstractContainer;
 use PhpOffice\PhpWord\Element\TextRun;
 use PhpOffice\PhpWord\Element\TrackChange;
 use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\Shared\XMLReader;
 
 /**
@@ -190,7 +191,7 @@ abstract class AbstractPart
             }
 
             $headingMatches = array();
-            preg_match('/Heading(\d)/', $paragraphStyle['styleName'], $headingMatches);
+            preg_match(Settings::getHeadingDepthRegexp(), $paragraphStyle['styleName'], $headingMatches);
             if (!empty($headingMatches)) {
                 return $headingMatches[1];
             }

--- a/src/PhpWord/Settings.php
+++ b/src/PhpWord/Settings.php
@@ -73,6 +73,11 @@ class Settings
     const DEFAULT_PAPER = 'A4';
 
     /**
+     * Default setting of Heading detection regexp
+     */
+    const HEADING_DETECTION_DEFAULT_REGEXP = '/Heading(\d)/';
+
+    /**
      * Compatibility option for XMLWriter
      *
      * @var bool
@@ -140,6 +145,13 @@ class Settings
      * @var bool
      */
     private static $outputEscapingEnabled = false;
+
+    /**
+     * Regexp to use for matching Headings in PhpOffice\PhpWord\Reader\Word2007\AbstractPart::getHeadingDepth().
+     *
+     * @var string
+     */
+    private static $headingDepthRegexp = self::HEADING_DETECTION_DEFAULT_REGEXP;
 
     /**
      * Return the compatibility option used by the XMLWriter
@@ -394,6 +406,24 @@ class Settings
         }
 
         return false;
+    }
+
+    /**
+     * Get regexp to use for matching Headings
+     * @return string
+     */
+    public static function getHeadingDepthRegexp()
+    {
+        return self::$headingDepthRegexp;
+    }
+
+    /**
+     * Set regexp to use for matching Headings
+     * @param string $headingDepthRegexp
+     */
+    public static function setHeadingDepthRegexp($headingDepthRegexp)
+    {
+        self::$headingDepthRegexp = $headingDepthRegexp;
     }
 
     /**

--- a/tests/PhpWord/SettingsTest.php
+++ b/tests/PhpWord/SettingsTest.php
@@ -203,6 +203,17 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test set/get regexp to use for matching Headings
+     */
+    public function testHeadingDepthRegexp()
+    {
+        $this->assertEquals(Settings::HEADING_DETECTION_DEFAULT_REGEXP, Settings::getHeadingDepthRegexp());
+        $newHeadingDepthRegexp = '/Nagwek(\d)';
+        Settings::setHeadingDepthRegexp($newHeadingDepthRegexp);
+        $this->assertEquals($newHeadingDepthRegexp, Settings::getHeadingDepthRegexp());
+    }
+
+    /**
      * Test load config
      */
     public function testLoadConfig()
@@ -215,6 +226,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             'defaultFontName'       => 'Arial',
             'defaultFontSize'       => 10,
             'outputEscapingEnabled' => false,
+            'headingDepthRegexp'    => '',
             'defaultPaper'          => 'A4',
         );
 


### PR DESCRIPTION
### Description

This pull request adds a feature which allows to set own regular expression for Headings detection in ``\PhpOffice\PhpWord\Reader\Word2007\AbstractPart::getHeadingDepth()``. This is useful for Word documents produced in non-English versions of the software where default styling naming convention differs, resulting in all heading-styled elements becoming regular paragraphs in PHPWord. One can set this in php-word.ini file globally or use ``PhpOffice\PhpWord::setHeadingDepthRegexp()`` anywhere in application

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported (there is one complaint on \PhpWord\Element\TOC.php which has already been there)
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
