### PR TITLE
add variable name on row clone exception message

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -726,7 +726,7 @@ class TemplateProcessor
 
         $tagPos = strpos($this->tempDocumentMainPart, $search);
         if (!$tagPos) {
-            throw new Exception('Can not clone row, template variable not found or variable contains markup.');
+            throw new Exception(sprintf('Can not clone row, template variable \'%s\' not found or variable contains markup.', $search));
         }
 
         $rowStart = $this->findRowStart($tagPos);

--- a/tests/PhpWord/TemplateProcessorTest.php
+++ b/tests/PhpWord/TemplateProcessorTest.php
@@ -267,6 +267,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Exception
+     * @expectedExceptionMessage ${fake_search}
      * @test
      */
     public function testCloneNotExistingRowShouldThrowException()


### PR DESCRIPTION
### Description

When `TemplateProcessor::cloneRow` fails to find a variable, the exception message did tell which template variable wasn't found.
This PR add the variable name in the exception message to help debugging template.

### Checklist:

- [+] I have run `composer run-script check --timeout=0` and no errors were reported
- [+] The new code is covered by unit tests (check build/coverage for coverage report)
- [+] I have updated the documentation to describe the changes
