### PR TITLE
fix: <v:vMerge /> The problem caused by line merging in word2007 conversion to html !  now , it's perfect!

### DIFF
--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -659,7 +659,7 @@ abstract class AbstractPart
                 // Use w:val as default if no attribute assigned
                 $attribute = ($attribute === null) ? 'w:val' : $attribute;
                 $attributeValue = $xmlReader->getAttribute($attribute, $node);
-    
+
                 // 2022-06-22 23:58:00 Solve the merge problem caused by the word2007 version vMerge not returning w:val='continue'
                 if ($styleProp === 'vMerge' && $node->nodeName === 'w:vMerge' && !$attributeValue) {
                     $attributeValue = 'continue';


### PR DESCRIPTION
### Description

The problem caused by line merging in word2007 conversion to html can be solved by the current method

Solve the merge problem caused by the word2007 version vMerge not returning w:val='continue'

Fixes # (issue)

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
