### PR TITLE
fix: add table cell style vMerge="continue"

### DIFF
--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -659,7 +659,7 @@ abstract class AbstractPart
                 // Use w:val as default if no attribute assigned
                 $attribute = ($attribute === null) ? 'w:val' : $attribute;
                 $attributeValue = $xmlReader->getAttribute($attribute, $node);
-    
+
                 // 2022-06-22 23:58:00 Solve the merge problem caused by the word2007 version vMerge not returning w:val='continue'
                 if ($styleProp === 'vMerge' && $node->nodeName === 'w:vMerge' && !$attributeValue) {
                     $attributeValue = 'continue';


### PR DESCRIPTION
### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist:

- [ Y] I have run `composer run-script check --timeout=0` and no errors were reported
   

> Checked all files in 0.117 seconds, 14.000 MB memory used
> phpcs --report-width=200 --report-summary --report-full samples/ src/ tests/ --ignore=src/PhpWord/Shared/PCLZip --standard=PSR2 -n
> phpmd src/,tests/ text ./phpmd.xml.dist --exclude pclzip.lib.php
/Users/raybon/Sites/PHPWord/src/PhpWord/Element/TOC.php:27  CamelCasePropertyName  The property $TOCStyle is not named in camelCase.
Script phpmd src/,tests/ text ./phpmd.xml.dist --exclude pclzip.lib.php handling the check event returned with error code 2

- [ N] The new code is covered by unit tests (check build/coverage for coverage report)
- [ N] I have updated the documentation to describe the changes
