### PR TITLE
PHP8.1 Fix issue with passing NULL value for locale into string function

### DIFF
--- a/src/PhpWord/Style/Language.php
+++ b/src/PhpWord/Style/Language.php
@@ -232,7 +232,7 @@ final class Language extends AbstractStyle
             $locale = str_replace('_', '-', $locale);
         }
 
-        if (strlen($locale) === 2) {
+        if ($locale !== null && strlen($locale) === 2) {
             return strtolower($locale) . '-' . strtoupper($locale);
         }
 


### PR DESCRIPTION
### Description

This fixes an issue in PHP8.1 where passing a NULL value to strlen() function is deprecated

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
