### PR TITLE
gracefully handle absent href attribute when parsing links

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -1016,7 +1016,11 @@ class Html
         }
         $styles['font'] = self::parseInlineStyle($node, $styles['font']);
 
-        if (strpos($target, '#') === 0) {
+        if (empty($target)) {
+            $target = '#';
+        }
+
+        if (strpos($target, '#') === 0 && strlen($target) > 1) {
             return $element->addLink(substr($target, 1), $node->textContent, $styles['font'], $styles['paragraph'], true);
         }
 

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -603,6 +603,27 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
         $this->assertEquals('bookmark', $doc->getElement('/w:document/w:body/w:p/w:hyperlink')->getAttribute('w:anchor'));
     }
 
+    public function testParseLinkAllowsAbsenceOfHref()
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<p><a>text of href-less link</a></p>';
+        Html::addHtml($section, $html);
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:hyperlink'));
+        $this->assertEquals('text of href-less link', $doc->getElement('/w:document/w:body/w:p/w:hyperlink/w:r/w:t')->nodeValue);
+
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<p><a href="">text of empty-href link</a></p>';
+        Html::addHtml($section, $html);
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:hyperlink'));
+        $this->assertEquals('text of empty-href link', $doc->getElement('/w:document/w:body/w:p/w:hyperlink/w:r/w:t')->nodeValue);
+    }
+
     public function testParseMalformedStyleIsIgnored()
     {
         $phpWord = new \PhpOffice\PhpWord\PhpWord();


### PR DESCRIPTION
### Description

Previously, an 'Invalid parameters passed' error would be emitted when parsing an "a" element without an "href" attribute. This fix lets href-less links through. Thanks to @santerref of #1562 for this fix.

Fixes #1562

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
    - There were errors, but they are not caused by the changes in this PR and should be fixed separately IMHO
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
    - I could not find a suitable place to document it, and also this is a fix for existing functionality and should not need to be documented.
