### PR TITLE
HTML Reader : Style page-break-after in paragraph

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -257,14 +257,16 @@ class Html
      * @param \DOMNode $node
      * @param \PhpOffice\PhpWord\Element\AbstractContainer $element
      * @param array &$styles
-     * @return \PhpOffice\PhpWord\Element\TextRun
+     * @return \PhpOffice\PhpWord\Element\TextRun|\PhpOffice\PhpWord\Element\PageBreak
      */
     protected static function parseParagraph($node, $element, &$styles)
     {
         $styles['paragraph'] = self::recursiveParseStylesInHierarchy($node, $styles['paragraph']);
-        $newElement = $element->addTextRun($styles['paragraph']);
+        if (isset($styles['paragraph']['isPageBreak']) && $styles['paragraph']['isPageBreak']) {
+            return $element->addPageBreak();
+        }
 
-        return $newElement;
+        return $element->addTextRun($styles['paragraph']);
     }
 
     /**
@@ -769,6 +771,11 @@ class Html
                     // https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align
                     if (preg_match('#(?:top|bottom|middle|sub|baseline)#i', $cValue, $matches)) {
                         $styles['valign'] = self::mapAlignVertical($matches[0]);
+                    }
+                    break;
+                case 'page-break-after':
+                    if ($cValue == 'always') {
+                        $styles['isPageBreak'] = true;
                     }
                     break;
             }

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -292,6 +292,20 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
     }
 
     /**
+     * Test parsing paragraph with `page-break-after` style
+     */
+    public function testParseParagraphWithPageBreak()
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        Html::addHtml($section, '<p style="page-break-after:always;"></p>');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:br'));
+        $this->assertEquals('page', $doc->getElementAttribute('/w:document/w:body/w:p/w:r/w:br', 'w:type'));
+    }
+
+    /**
      * Test parsing table
      */
     public function testParseTable()
@@ -776,7 +790,7 @@ HTML;
     /**
      * Parse horizontal rule
      */
-    public function testParseHorizRule()
+    public function testParseHorizontalRule()
     {
         $phpWord = new \PhpOffice\PhpWord\PhpWord();
         $section = $phpWord->addSection();


### PR DESCRIPTION
### Description

HTML Reader : Style page-break-after in paragraph

Thanks [SITER](https://siter.fr/)

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
