### PR TITLE
HTML Reader : Use `border` attribute for tables

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -372,17 +372,11 @@ class Html
 
         $newElement = $element->addTable($elementStyles);
 
-        // $attributes = $node->attributes;
-        // if ($attributes->getNamedItem('width') !== null) {
-        // $newElement->setWidth($attributes->getNamedItem('width')->value);
-        // }
-
-        // if ($attributes->getNamedItem('height') !== null) {
-        // $newElement->setHeight($attributes->getNamedItem('height')->value);
-        // }
-        // if ($attributes->getNamedItem('width') !== null) {
-        // $newElement=$element->addCell($width=$attributes->getNamedItem('width')->value);
-        // }
+        $attributes = $node->attributes;
+        if ($attributes->getNamedItem('border') !== null) {
+            $border = (int) $attributes->getNamedItem('border')->value;
+            $newElement->getStyle()->setBorderSize(Converter::pixelToTwip($border));
+        }
 
         return $newElement;
     }

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -352,6 +352,35 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
     }
 
     /**
+     * Test parsing table (attribute border)
+     */
+    public function testParseTableAttributeBorder()
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<table border="10">
+                <thead>
+                    <tr>
+                        <th>Header</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr><td>Cell 1</td></tr>
+                    <tr><td>Cell 2</td></tr>
+                </tbody>
+            </table>';
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:tbl'));
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:tbl/w:tblPr'));
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:tbl/w:tblPr/w:tblBorders'));
+        $this->assertTrue($doc->elementExists('/w:document/w:body/w:tbl/w:tblPr/w:tblBorders/w:top'));
+        // 10 pixels = 150 twips
+        $this->assertEquals(150, $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tblPr/w:tblBorders/w:top', 'w:sz'));
+    }
+
+    /**
      * Tests parsing of ul/li
      */
     public function testParseList()


### PR DESCRIPTION
### Description

HTML Reader : Use `border` attribute for tables

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
