### PR TITLE
Drop PHP 7.3 and older

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - '7.2'
-          - "7.3"
           - "7.4"
           - "8.0"
           - "8.1"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Read more about PHPWord:
 
 ## Features
 
-With PHPWord, you can create OOXML, ODF, or RTF documents dynamically using your PHP 5.3.3+ scripts. Below are some of the things that you can do with PHPWord library:
+With PHPWord, you can create OOXML, ODF, or RTF documents dynamically using your PHP scripts. Below are some of the things that you can do with PHPWord library:
 
 - Set document properties, e.g. title, subject, and creator.
 - Create document sections with different settings, e.g. portrait/landscape, page size, and page numbering
@@ -60,7 +60,7 @@ With PHPWord, you can create OOXML, ODF, or RTF documents dynamically using your
 
 PHPWord requires the following:
 
-- PHP 5.3.3+
+- PHP 7.4+
 - [XML Parser extension](http://www.php.net/manual/en/xml.installation.php)
 - [Laminas Escaper component](https://docs.laminas.dev/laminas-escaper/intro/)
 - [Zip extension](http://php.net/manual/en/book.zip.php) (optional, used to write OOXML and ODF)

--- a/composer.json
+++ b/composer.json
@@ -58,9 +58,10 @@
         "fix": "Fixes issues found by PHP-CS"
     },
     "require": {
-        "php": "^5.3.3 || ^7.0 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-xml": "*",
-        "laminas/laminas-escaper": "^2.2"
+        "laminas/laminas-escaper": "^2.2",
+        "symfony/process": "^5.4"
     },
     "require-dev": {
         "ext-zip": "*",
@@ -71,7 +72,7 @@
         "phpmd/phpmd": "2.*",
         "phploc/phploc": "2.* || 3.* || 4.* || 5.* || 6.* || 7.*",
         "dompdf/dompdf":"0.8.* || 1.0.*",
-        "tecnickcom/tcpdf": "6.*",
+        "tecnickcom/tcpdf": "^6.4",
         "mpdf/mpdf": "5.7.4 || 6.* || 7.* || 8.*",
         "php-coveralls/php-coveralls": "1.1.0 || ^2.0"
     },

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -6,19 +6,3 @@ Frequently asked questions
 How contribute to PHPWord?
 --------------------------
 - Improve the documentation (`Sphinx Format <http://documentation-style-guide-sphinx.readthedocs.org/en/latest/index.html>`__)
-
-Is this the same with PHPWord that I found in CodePlex?
--------------------------------------------------------
-
-No. This one is much better with tons of new features that you can’t
-find in PHPWord 0.6.3. The development in CodePlex is halted and
-switched to GitHub to allow more participation from the crowd. The more
-the merrier, right?
-
-I’ve been running PHPWord from CodePlex flawlessly, but I can’t use the latest PHPWord from GitHub. Why?
---------------------------------------------------------------------------------------------------------
-
-PHPWord requires PHP 5.3+ since 0.8, while PHPWord 0.6.3 from CodePlex
-can run with PHP 5.2. There’s a lot of new features that we can get from
-PHP 5.3 and it’s been around since 2009! You should upgrade your PHP
-version to use PHPWord 0.8+.

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -8,9 +8,9 @@ Requirements
 
 Mandatory:
 
-- PHP 5.3.3+
+- composer
+- PHP 7.4+
 - `XML Parser <http://www.php.net/manual/en/xml.installation.php>`__ extension
-- `Laminas Escaper <https://docs.laminas.dev/laminas-escaper/intro/>`__ component
 
 Optional:
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,9 +20,4 @@
             </exclude>
         </whitelist>
     </filter>
-    <logging>
-        <log type="coverage-html" target="./build/coverage" />
-        <log type="coverage-clover" target="./build/logs/clover.xml" />
-        <log type="junit" target="./build/logs/logfile.xml"/>
-    </logging>
 </phpunit>

--- a/samples/index.php
+++ b/samples/index.php
@@ -4,7 +4,7 @@ include_once 'Sample_Header.php';
 use PhpOffice\PhpWord\Settings;
 
 $requirements = array(
-    'php'   => array('PHP 5.3.3', version_compare(PHP_VERSION, '5.3.3', '>=')),
+    'php'   => array('PHP 7.4', version_compare(PHP_VERSION, '7.4', '>=')),
     'xml'   => array('PHP extension XML', extension_loaded('xml')),
     'temp'  => array('Temp folder "<code>' . Settings::getTempDir() . '</code>" is writable', is_writable(Settings::getTempDir())),
     'zip'   => array('PHP extension ZipArchive (optional)', extension_loaded('zip')),

--- a/src/PhpWord/Element/Image.php
+++ b/src/PhpWord/Element/Image.php
@@ -410,7 +410,7 @@ class Image extends AbstractElement
         if ($this->sourceType == self::SOURCE_ARCHIVE) {
             $imageData = $this->getArchiveImageSize($this->source);
         } elseif ($this->sourceType == self::SOURCE_STRING) {
-            $imageData = $this->getStringImageSize($this->source);
+            $imageData = @getimagesizefromstring($this->source);
         } else {
             $imageData = @getimagesize($this->source);
         }
@@ -499,26 +499,6 @@ class Image extends AbstractElement
         }
 
         return $imageData;
-    }
-
-    /**
-     * get image size from string
-     *
-     * @param string $source
-     *
-     * @codeCoverageIgnore this method is just a replacement for getimagesizefromstring which exists only as of PHP 5.4
-     */
-    private function getStringImageSize($source)
-    {
-        $result = false;
-        if (!function_exists('getimagesizefromstring')) {
-            $uri = 'data://application/octet-stream;base64,' . base64_encode($source);
-            $result = @getimagesize($uri);
-        } else {
-            $result = @getimagesizefromstring($source);
-        }
-
-        return $result;
     }
 
     /**

--- a/src/PhpWord/Escaper/Xml.php
+++ b/src/PhpWord/Escaper/Xml.php
@@ -26,7 +26,6 @@ class Xml extends AbstractEscaper
 {
     protected function escapeSingleValue($input)
     {
-        // todo: omit encoding parameter after migration onto PHP 5.4
-        return (!is_null($input)) ? htmlspecialchars($input, ENT_QUOTES, 'UTF-8') : '';
+        return (!is_null($input)) ? htmlspecialchars($input, ENT_QUOTES) : '';
     }
 }

--- a/src/PhpWord/Shared/PCLZip/pclzip.lib.php
+++ b/src/PhpWord/Shared/PCLZip/pclzip.lib.php
@@ -3258,17 +3258,6 @@ class PclZip
                         $v_extract = true;
                     }
                 }
-            // ----- Look for extract by ereg rule
-            // ereg() is deprecated with PHP 5.3
-            /*
-            elseif (   (isset($p_options[PCLZIP_OPT_BY_EREG]))
-            && ($p_options[PCLZIP_OPT_BY_EREG] != "")) {
-
-            if (ereg($p_options[PCLZIP_OPT_BY_EREG], $v_header['stored_filename'])) {
-            $v_extract = true;
-            }
-            }
-            */
 
             // ----- Look for extract by preg rule
             } elseif ((isset($p_options[PCLZIP_OPT_BY_PREG])) && ($p_options[PCLZIP_OPT_BY_PREG] != "")) {
@@ -4544,18 +4533,6 @@ class PclZip
                         $v_found = true;
                     }
                 }
-
-            // ----- Look for extract by ereg rule
-            // ereg() is deprecated with PHP 5.3
-            /*
-            elseif (   (isset($p_options[PCLZIP_OPT_BY_EREG]))
-            && ($p_options[PCLZIP_OPT_BY_EREG] != "")) {
-
-            if (ereg($p_options[PCLZIP_OPT_BY_EREG], $v_header_list[$v_nb_extracted]['stored_filename'])) {
-            $v_found = true;
-            }
-            }
-            */
 
             // ----- Look for extract by preg rule
             } elseif ((isset($p_options[PCLZIP_OPT_BY_PREG])) && ($p_options[PCLZIP_OPT_BY_PREG] != "")) {

--- a/tests/PhpWord/Writer/PDF/TCPDFTest.php
+++ b/tests/PhpWord/Writer/PDF/TCPDFTest.php
@@ -33,18 +33,6 @@ class TCPDFTest extends \PHPUnit\Framework\TestCase
      */
     public function testConstruct()
     {
-        // TCPDF version 6.3.5 doesn't support PHP 5.3, fixed via https://github.com/tecnickcom/TCPDF/pull/197,
-        // pending new release.
-        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
-            return;
-        }
-
-        // TCPDF version 6.3.5 doesn't support PHP 8.0, fixed via https://github.com/tecnickcom/TCPDF/pull/293,
-        // pending new release.
-        if (version_compare(PHP_VERSION, '8.0.0', '>=')) {
-            return;
-        }
-
         $file = __DIR__ . '/../../_files/tcpdf.pdf';
 
         $phpWord = new PhpWord();

--- a/tests/PhpWord/_includes/AbstractWebServerEmbeddedTest.php
+++ b/tests/PhpWord/_includes/AbstractWebServerEmbeddedTest.php
@@ -25,39 +25,18 @@ abstract class AbstractWebServerEmbeddedTest extends \PHPUnit\Framework\TestCase
 
     public static function setUpBeforeClass()
     {
-        if (self::isBuiltinServerSupported()) {
-            $commandLine = 'php -S localhost:8080 -t tests/PhpWord/_files';
+        $commandLine = 'php -S localhost:8080 -t tests/PhpWord/_files';
 
-            /*
-             * Make sure to invoke \Symfony\Component\Process\Process correctly
-             * regardless of PHP version used.
-             *
-             * In Process version >= 5 / PHP >= 7.2.5, the constructor requires
-             * an array, while in version < 3.3 / PHP < 5.5.9 it requires a string.
-             * In between, it can accept both.
-             *
-             * Process::fromShellCommandLine() was introduced in version 4.2.0,
-             * to enable recent versions of Process to parse a command string,
-             * so if it is not available it means it is still possible to pass
-             * a string to the constructor.
-             */
-            if (method_exists('Symfony\Component\Process\Process', 'fromShellCommandLine')) {
-                self::$httpServer = Process::fromShellCommandline($commandLine);
-            } else {
-                self::$httpServer = new Process($commandLine);
-            }
-            self::$httpServer->start();
-            while (!self::$httpServer->isRunning()) {
-                usleep(1000);
-            }
+        self::$httpServer = Process::fromShellCommandline($commandLine);
+        self::$httpServer->start();
+        while (!self::$httpServer->isRunning()) {
+            usleep(1000);
         }
     }
 
     public static function tearDownAfterClass()
     {
-        if (self::isBuiltinServerSupported()) {
-            self::$httpServer->stop();
-        }
+        self::$httpServer->stop();
     }
 
     protected static function getBaseUrl()
@@ -90,10 +69,5 @@ abstract class AbstractWebServerEmbeddedTest extends \PHPUnit\Framework\TestCase
         }
 
         return 'https://samples.libav.org/image-samples/RACECAR.BMP';
-    }
-
-    private static function isBuiltinServerSupported()
-    {
-        return version_compare(PHP_VERSION, '5.4.0', '>=');
     }
 }


### PR DESCRIPTION
This is according to our formal, published, policy to only support
eol PHP after 6 months within PHPOffice organisation.

See https://phpspreadsheet.readthedocs.io/en/latest/#php-version-support