### PR TITLE
Use highest quality for JPEG and PNG images

### DIFF
--- a/src/PhpWord/Element/Image.php
+++ b/src/PhpWord/Element/Image.php
@@ -89,7 +89,7 @@ class Image extends AbstractElement
     /**
      * Image function.
      *
-     * @var string
+     * @var null|callable(resource): void
      */
     private $imageFunc;
 
@@ -99,6 +99,16 @@ class Image extends AbstractElement
      * @var string
      */
     private $imageExtension;
+
+    /**
+     * Image quality.
+     *
+     * Functions imagepng() and imagejpeg() have an optional parameter for
+     * quality.
+     *
+     * @var null|int
+     */
+    private $imageQuality;
 
     /**
      * Is memory image.
@@ -249,11 +259,19 @@ class Image extends AbstractElement
     /**
      * Get image function.
      *
-     * @return string
+     * @return null|callable(resource): void
      */
-    public function getImageFunction()
+    public function getImageFunction(): ?callable
     {
         return $this->imageFunc;
+    }
+
+    /**
+     * Get image quality.
+     */
+    public function getImageQuality(): ?int
+    {
+        return $this->imageQuality;
     }
 
     /**
@@ -317,20 +335,13 @@ class Image extends AbstractElement
     }
 
     /**
-     * Get image string data.
-     *
-     * @param bool $base64
-     *
-     * @return null|string
-     *
-     * @since 0.11.0
+     * Get image string.
      */
-    public function getImageStringData($base64 = false)
+    public function getImageString(): ?string
     {
         $source = $this->source;
         $actualSource = null;
         $imageBinary = null;
-        $imageData = null;
         $isTemp = false;
 
         // Get actual source from archive image or other source
@@ -367,7 +378,8 @@ class Image extends AbstractElement
                 imagesavealpha($imageResource, true);
             }
             ob_start();
-            call_user_func($this->imageFunc, $imageResource);
+            $callback = $this->imageFunc;
+            $callback($imageResource);
             $imageBinary = ob_get_contents();
             ob_end_clean();
         } elseif ($this->sourceType == self::SOURCE_STRING) {
@@ -379,20 +391,36 @@ class Image extends AbstractElement
                 fclose($fileHandle);
             }
         }
-        if ($imageBinary !== null) {
-            if ($base64) {
-                $imageData = chunk_split(base64_encode($imageBinary));
-            } else {
-                $imageData = chunk_split(bin2hex($imageBinary));
-            }
-        }
 
         // Delete temporary file if necessary
         if ($isTemp === true) {
             @unlink($actualSource);
         }
 
-        return $imageData;
+        return $imageBinary;
+    }
+
+    /**
+     * Get image string data.
+     *
+     * @param bool $base64
+     *
+     * @return null|string
+     *
+     * @since 0.11.0
+     */
+    public function getImageStringData($base64 = false)
+    {
+        $imageBinary = $this->getImageString();
+        if ($imageBinary === null) {
+            return null;
+        }
+
+        if ($base64) {
+            return chunk_split(base64_encode($imageBinary));
+        }
+
+        return chunk_split(bin2hex($imageBinary));
     }
 
     /**
@@ -503,31 +531,45 @@ class Image extends AbstractElement
         switch ($this->imageType) {
             case 'image/png':
                 $this->imageCreateFunc = $this->sourceType == self::SOURCE_STRING ? 'imagecreatefromstring' : 'imagecreatefrompng';
-                $this->imageFunc = 'imagepng';
+                $this->imageFunc = function ($resource): void {
+                    imagepng($resource, null, $this->imageQuality);
+                };
                 $this->imageExtension = 'png';
+                $this->imageQuality = -1;
 
                 break;
             case 'image/gif':
                 $this->imageCreateFunc = $this->sourceType == self::SOURCE_STRING ? 'imagecreatefromstring' : 'imagecreatefromgif';
-                $this->imageFunc = 'imagegif';
+                $this->imageFunc = function ($resource): void {
+                    imagegif($resource);
+                };
                 $this->imageExtension = 'gif';
+                $this->imageQuality = null;
 
                 break;
             case 'image/jpeg':
             case 'image/jpg':
                 $this->imageCreateFunc = $this->sourceType == self::SOURCE_STRING ? 'imagecreatefromstring' : 'imagecreatefromjpeg';
-                $this->imageFunc = 'imagejpeg';
+                $this->imageFunc = function ($resource): void {
+                    imagejpeg($resource, null, $this->imageQuality);
+                };
                 $this->imageExtension = 'jpg';
+                $this->imageQuality = 100;
 
                 break;
             case 'image/bmp':
             case 'image/x-ms-bmp':
                 $this->imageType = 'image/bmp';
+                $this->imageFunc = null;
                 $this->imageExtension = 'bmp';
+                $this->imageQuality = null;
 
                 break;
             case 'image/tiff':
+                $this->imageType = 'image/tiff';
+                $this->imageFunc = null;
                 $this->imageExtension = 'tif';
+                $this->imageQuality = null;
 
                 break;
         }

--- a/src/PhpWord/Media.php
+++ b/src/PhpWord/Media.php
@@ -74,8 +74,7 @@ class Media
                     $mediaData['imageType'] = $image->getImageType();
                     if ($isMemImage) {
                         $mediaData['isMemImage'] = true;
-                        $mediaData['createFunction'] = $image->getImageCreateFunction();
-                        $mediaData['imageFunction'] = $image->getImageFunction();
+                        $mediaData['imageString'] = $image->getImageString();
                     }
                     $target = "{$container}_image{$mediaTypeCount}.{$extension}";
                     $image->setTarget($target);

--- a/src/PhpWord/Writer/AbstractWriter.php
+++ b/src/PhpWord/Writer/AbstractWriter.php
@@ -347,17 +347,8 @@ abstract class AbstractWriter implements WriterInterface
 
             // Retrive GD image content or get local media
             if (isset($element['isMemImage']) && $element['isMemImage']) {
-                $image = call_user_func($element['createFunction'], $element['source']);
-                if ($element['imageType'] === 'image/png') {
-                    // PNG images need to preserve alpha channel information
-                    imagesavealpha($image, true);
-                }
-                ob_start();
-                call_user_func($element['imageFunction'], $image);
-                $imageContents = ob_get_contents();
-                ob_end_clean();
+                $imageContents = $element['imageString'];
                 $zip->addFromString($target, $imageContents);
-                imagedestroy($image);
             } else {
                 $this->addFileToPackage($zip, $element['source'], $target);
             }

--- a/tests/PhpWordTests/Element/ImageTest.php
+++ b/tests/PhpWordTests/Element/ImageTest.php
@@ -23,8 +23,6 @@ use PhpOffice\PhpWordTests\AbstractWebServerEmbeddedTest;
 
 /**
  * Test class for PhpOffice\PhpWord\Element\Image.
- *
- * @runTestsInSeparateProcesses
  */
 class ImageTest extends AbstractWebServerEmbeddedTest
 {
@@ -65,33 +63,40 @@ class ImageTest extends AbstractWebServerEmbeddedTest
 
     /**
      * Valid image types.
+     *
+     * @dataProvider providerImages
      */
-    public function testImages(): void
+    public function testImages($source, $type, $extension, $createFunction, $imageFunction, $imageQuality): void
     {
-        $images = [
-            ['mars.jpg', 'image/jpeg', 'jpg', 'imagecreatefromjpeg', 'imagejpeg'],
-            ['mario.gif', 'image/gif', 'gif', 'imagecreatefromgif', 'imagegif'],
-            ['firefox.png', 'image/png', 'png', 'imagecreatefrompng', 'imagepng'],
-            ['duke_nukem.bmp', 'image/bmp', 'bmp', null, null],
-            ['angela_merkel.tif', 'image/tiff', 'tif', null, null],
-        ];
-
-        foreach ($images as $imageData) {
-            [$source, $type, $extension, $createFunction, $imageFunction] = $imageData;
-            $nam = ucfirst(strtok($source, '.'));
-            $source = __DIR__ . "/../_files/images/{$source}";
-            $image = new Image($source, null, null, $nam);
-            self::assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $image);
-            self::assertEquals($source, $image->getSource());
-            self::assertEquals($nam, $image->getName());
-            self::assertEquals(md5($source), $image->getMediaId());
-            self::assertEquals($type, $image->getImageType());
-            self::assertEquals($extension, $image->getImageExtension());
-            self::assertEquals($createFunction, $image->getImageCreateFunction());
-            self::assertEquals($imageFunction, $image->getImageFunction());
-            self::assertFalse($image->isMemImage());
-            self::assertNotNull($image->getImageStringData());
+        $nam = ucfirst(strtok($source, '.'));
+        $source = __DIR__ . "/../_files/images/{$source}";
+        $image = new Image($source, null, null, $nam);
+        self::assertInstanceOf('PhpOffice\\PhpWord\\Element\\Image', $image);
+        self::assertEquals($source, $image->getSource());
+        self::assertEquals($nam, $image->getName());
+        self::assertEquals(md5($source), $image->getMediaId());
+        self::assertEquals($type, $image->getImageType());
+        self::assertEquals($extension, $image->getImageExtension());
+        self::assertEquals($createFunction, $image->getImageCreateFunction());
+        if ($imageFunction) {
+            self::assertNotNull($image->getImageFunction());
+        } else {
+            self::assertNull($image->getImageFunction());
         }
+        self::assertEquals($imageQuality, $image->getImageQuality());
+        self::assertFalse($image->isMemImage());
+        self::assertNotNull($image->getImageStringData());
+    }
+
+    public function providerImages(): array
+    {
+        return [
+            ['mars.jpg', 'image/jpeg', 'jpg', 'imagecreatefromjpeg', true, 100],
+            ['mario.gif', 'image/gif', 'gif', 'imagecreatefromgif', true, null],
+            ['firefox.png', 'image/png', 'png', 'imagecreatefrompng', true, -1],
+            ['duke_nukem.bmp', 'image/bmp', 'bmp', null, false, null],
+            ['angela_merkel.tif', 'image/tiff', 'tif', null, false, null],
+        ];
     }
 
     /**
@@ -204,7 +209,8 @@ class ImageTest extends AbstractWebServerEmbeddedTest
         self::assertEquals('image/jpeg', $image->getImageType());
         self::assertEquals('jpg', $image->getImageExtension());
         self::assertEquals('imagecreatefromstring', $image->getImageCreateFunction());
-        self::assertEquals('imagejpeg', $image->getImageFunction());
+        self::assertNotNull($image->getImageFunction());
+        self::assertEquals(100, $image->getImageQuality());
         self::assertTrue($image->isMemImage());
 
         self::assertNotNull($image->getImageStringData());
@@ -225,7 +231,8 @@ class ImageTest extends AbstractWebServerEmbeddedTest
         self::assertEquals('image/png', $image->getImageType());
         self::assertEquals('png', $image->getImageExtension());
         self::assertEquals('imagecreatefrompng', $image->getImageCreateFunction());
-        self::assertEquals('imagepng', $image->getImageFunction());
+        self::assertNotNull($image->getImageFunction());
+        self::assertEquals(-1, $image->getImageQuality());
         self::assertTrue($image->isMemImage());
 
         self::assertNotNull($image->getImageStringData());


### PR DESCRIPTION
### Description

This sets the quality of JPEG and PNG files to their maximum. It does this by:
- defining a property called `$imageQuality` and a method called `getImageQuality()` to PhpOffice\PhpWord\Element\Image;
- setting the property `$imageQuality` to `100` in case of image/jpeg or image/jpg and set it to `0` in case of image/png;
- PhpOffice\PhpWord\Media and PhpOffice\PhpWord\Writer\AbstractWriter making use of the 'imageQuality' property.

I also added test coverage for PhpOffice\PhpWord\Element\Image::getImageQuality().

Fixes #2317

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [X] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
