### PR TITLE
Drop obsolete coverall references

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,6 @@
         "ext-libxml": "*",
         "dompdf/dompdf": "^2.0",
         "mpdf/mpdf": "^8.1",
-        "php-coveralls/php-coveralls": "^2.5",
         "phpmd/phpmd": "^2.13",
         "phpunit/phpunit": ">=7.0",
         "tecnickcom/tcpdf": "^6.5",


### PR DESCRIPTION
Instead, we've been using Scrutinizer for a while
