### PR TITLE
Improve TemplateProcessor#setValueForPart parameter phpdoc

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -1027,7 +1027,7 @@ class TemplateProcessor
      *
      * @param mixed $search
      * @param mixed $replace
-     * @param string $documentPartXML
+     * @param array<int, string>|string $documentPartXML
      * @param int $limit
      *
      * @return string


### PR DESCRIPTION
The `tempDocumentHeaders` and `tempDocumentFooters` array attributes are passed to this method parameter