### PR TITLE
HTML Writer : Added border-spacing to default styles

### DIFF
--- a/src/PhpWord/Writer/HTML/Part/Head.php
+++ b/src/PhpWord/Writer/HTML/Part/Head.php
@@ -101,6 +101,7 @@ class Head extends AbstractPart
             'table' => [
                 'border' => '1px solid black',
                 'border-spacing' => '0px',
+	            'border-collapse' => 'collapse',
                 'width ' => '100%',
             ],
             'td' => [

--- a/src/PhpWord/Writer/HTML/Part/Head.php
+++ b/src/PhpWord/Writer/HTML/Part/Head.php
@@ -101,7 +101,7 @@ class Head extends AbstractPart
             'table' => [
                 'border' => '1px solid black',
                 'border-spacing' => '0px',
-	            'border-collapse' => 'collapse',
+                'border-collapse' => 'collapse',
                 'width ' => '100%',
             ],
             'td' => [


### PR DESCRIPTION
### Description
add border-spacing to default styles in HTML Writer

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
