### PR TITLE
Read empty vmerge

### DIFF
--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -626,7 +626,7 @@ abstract class AbstractPart
         $styles = [];
 
         foreach ($styleDefs as $styleProp => $styleVal) {
-            [$method, $element, $attribute, $expected] = array_pad($styleVal, 4, null);
+            [$method, $element, $attribute, $expected, $default] = array_pad($styleVal, 5, null);
 
             $element = $this->findPossibleElement($xmlReader, $parentNode, $element);
             if ($element === null) {
@@ -640,7 +640,7 @@ abstract class AbstractPart
 
                 // Use w:val as default if no attribute assigned
                 $attribute = ($attribute === null) ? 'w:val' : $attribute;
-                $attributeValue = $xmlReader->getAttribute($attribute, $node);
+                $attributeValue = $xmlReader->getAttribute($attribute, $node) ?? $default;
 
                 $styleValue = $this->readStyleDef($method, $attributeValue, $expected);
                 if ($styleValue !== null) {

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -558,7 +558,7 @@ abstract class AbstractPart
             'valign' => [self::READ_VALUE, 'w:vAlign'],
             'textDirection' => [self::READ_VALUE, 'w:textDirection'],
             'gridSpan' => [self::READ_VALUE, 'w:gridSpan'],
-            'vMerge' => [self::READ_VALUE, 'w:vMerge'],
+            'vMerge' => [self::READ_VALUE, 'w:vMerge', null, null, 'continue'],
             'bgColor' => [self::READ_VALUE, 'w:shd', 'w:fill'],
         ];
 


### PR DESCRIPTION
### Description
In MS Word 2021 docx files save with empty w:val of w:vMerge when expected value "continue".

I made suggest a solution:
In method readStyleDefs for argument styleDefs add fifth parameter "default value". This will allow default values to be passed for empty attributes. For example in a cells

The problem is described here: https://github.com/PHPOffice/PHPWord/issues/2330

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
