### PR TITLE
HTML Reader : Set style name from the CSS class

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -162,6 +162,7 @@ class Html
             $attributeClass = $attributes->getNamedItem('class');
             if ($attributeClass && self::$css) {
                 $styles = self::parseStyleDeclarations(self::$css->getStyle('.' . $attributeClass->value), $styles);
+                $styles['className'] = $attributeClass->value;
             }
 
             $attributeStyle = $attributes->getNamedItem('style');
@@ -410,6 +411,11 @@ class Html
         $elementStyles = self::parseInlineStyle($node, $styles['table']);
 
         $newElement = $element->addTable($elementStyles);
+
+        // Add style name from CSS Class
+        if (isset($elementStyles['className'])) {
+            $newElement->getStyle()->setStyleName($elementStyles['className']);
+        }
 
         $attributes = $node->attributes;
         if ($attributes->getNamedItem('border') !== null) {

--- a/tests/PhpWordTests/Shared/HtmlTest.php
+++ b/tests/PhpWordTests/Shared/HtmlTest.php
@@ -19,6 +19,7 @@ namespace PhpOffice\PhpWordTests\Shared;
 
 use Exception;
 use PhpOffice\PhpWord\Element\Section;
+use PhpOffice\PhpWord\Element\Table;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Shared\Html;
 use PhpOffice\PhpWord\SimpleType\Jc;
@@ -132,6 +133,17 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
         self::assertTrue($doc->elementExists('/w:document/w:body/w:p[2]/w:r/w:rPr'));
         self::assertTrue($doc->elementExists('/w:document/w:body/w:p[2]/w:r/w:rPr/w:sz'));
         self::assertEquals('22.5', $doc->getElementAttribute('/w:document/w:body/w:p[2]/w:r/w:rPr/w:sz', 'w:val'));
+    }
+
+    public function testParseStyleTableClassName(): void
+    {
+        $html = '<style type="text/css">.pStyle { font-size:15px; }</style><table class="pStyle"><tr><td></td></tr></table>';
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        Html::addHtml($section, $html);
+
+        self::assertInstanceOf(Table::class, $section->getElement(0));
+        self::assertEquals('pStyle', $section->getElement(0)->getStyle()->getStyleName());
     }
 
     /**


### PR DESCRIPTION
### Description

HTML Reader : Set style name from the CSS class

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
