### PR TITLE
HTML Reader : Set style name from the CSS class (and if not CSS is loaded)

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -160,8 +160,10 @@ class Html
             }
 
             $attributeClass = $attributes->getNamedItem('class');
-            if ($attributeClass && self::$css) {
-                $styles = self::parseStyleDeclarations(self::$css->getStyle('.' . $attributeClass->value), $styles);
+            if ($attributeClass) {
+                if (self::$css) {
+                    $styles = self::parseStyleDeclarations(self::$css->getStyle('.' . $attributeClass->value), $styles);
+                }
                 $styles['className'] = $attributeClass->value;
             }
 


### PR DESCRIPTION
### Description

HTML Reader : Set style name from the CSS class (and if not CSS is loaded)

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
