### PR TITLE
Use local install of friendsofphp/php-cs-fixer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,14 +79,11 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Composer Install
-        run: composer global require friendsofphp/php-cs-fixer
-
-      - name: Add environment path
-        run: export PATH="$PATH:$HOME/.composer/vendor/bin"
+      - name: Install dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Code style with PHP-CS-Fixer
-        run: php-cs-fixer fix --dry-run --diff
+        run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
 
   coverage:
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,8 @@
         "phpmd/phpmd": "^2.13",
         "phpunit/phpunit": ">=7.0",
         "tecnickcom/tcpdf": "^6.5",
-        "symfony/process": "^4.4"
+        "symfony/process": "^4.4",
+        "friendsofphp/php-cs-fixer": "^3.3"
     },
     "suggest": {
         "ext-zip": "Allows writing OOXML and ODF",


### PR DESCRIPTION
Otherwise, `composer check` and `composer fix` are broken and contributing because much harder than it should be. Also using the same version everywhere is a benefit to get consistent result locally and on CI.

