### PR TITLE
Update Body.php

### DIFF
--- a/src/PhpWord/Writer/HTML/Part/Body.php
+++ b/src/PhpWord/Writer/HTML/Part/Body.php
@@ -72,8 +72,8 @@ class Body extends AbstractPart
                 $method = 'get' . ($noteType == 'endnote' ? 'Endnotes' : 'Footnotes');
                 $collection = $phpWord->$method()->getItems();
 
-                if (isset($collection[$noteTypeId])) {
-                    $element = $collection[$noteTypeId];
+                if (isset($collection[$noteId])) {
+                    $element = $collection[$noteId];
                     $noteAnchor = "<a name=\"note-{$noteId}\" />";
                     $noteAnchor .= "<a href=\"#{$noteMark}\" class=\"NoteRef\"><sup>{$noteId}</sup></a>";
 


### PR DESCRIPTION
使用 footnote 的 id 可能与下标不匹配，导致footnotes 内容弄缺失     此处我只是将问题代码标记出来，以便你们做更专业的调整。

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
