### PR TITLE
styleid also for other Elements

### DIFF
--- a/src/PhpWord/Writer/Word2007/Part/Styles.php
+++ b/src/PhpWord/Writer/Word2007/Part/Styles.php
@@ -192,8 +192,8 @@ class Styles extends AbstractPart
             $xmlWriter->startElement('w:link');
             $xmlWriter->writeAttribute('w:val', $styleLink);
             $xmlWriter->endElement();
-        } elseif (null !== $paragraphStyle) {
-            // if type is 'paragraph' it should have a styleId
+        } else {
+            //all other types like paragraphs and characters should also receive a styleid. We will set this like the stylename.
             $xmlWriter->writeAttribute('w:styleId', $styleName);
         }
 


### PR DESCRIPTION
### Description

All other types like paragraphs and characters should also receive a styleid. We will set this like the stylename. Otherwise it could be misleading for some converters or readers, which work with the styleid, like for example GemBox. Microsoft Word itself does also set IDs for all other elements like characters.

We had issues when setting fonts via $phpword->addFontStyle() which lead to not producing a styleid in the word\styles.xml and GemBox showed all content of the document in the same default font style.

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
