### PR TITLE
Add support for style objects to the element constructor

### DIFF
--- a/docs/elements.rst
+++ b/docs/elements.rst
@@ -114,8 +114,8 @@ You can add Hyperlinks to the document by using the function addLink:
 
 - ``$linkSrc``. The URL of the link.
 - ``$linkName``. Placeholder of the URL that appears in the document.
-- ``$fontStyle``. Array or Font style object. See :ref:`font-style`.
-- ``$paragraphStyle``. Array or Paragraph style object. See :ref:`paragraph-style`.
+- ``$fontStyle``. Classname, Array or Font style object. See :ref:`font-style`.
+- ``$paragraphStyle``. Classname, Array or Paragraph style object. See :ref:`paragraph-style`.
 
 Preserve texts
 ~~~~~~~~~~~~~~
@@ -139,8 +139,8 @@ Text breaks are empty new lines. To add text breaks, use the following syntax. A
     $section->addTextBreak([$breakCount], [$fontStyle], [$paragraphStyle]);
 
 - ``$breakCount``. How many lines.
-- ``$fontStyle``. Array or Font style object. See :ref:`font-style`.
-- ``$paragraphStyle``. Array or Paragraph style object. See :ref:`paragraph-style`.
+- ``$fontStyle``. Classname, Array or Font style object. See :ref:`font-style`.
+- ``$paragraphStyle``. Classname, Array or Paragraph style object. See :ref:`paragraph-style`.
 
 Page breaks
 ~~~~~~~~~~~
@@ -172,10 +172,10 @@ Parameters:
 
 - ``$text``. Text that appears in the document.
 - ``$depth``. Depth of list item.
-- ``$fontStyle``. Array or Font style object. See :ref:`font-style`.
+- ``$fontStyle``. Classname, Array or Font style object. See :ref:`font-style`.
 - ``$listStyle``. List style of the current element TYPE\_NUMBER,
   TYPE\_ALPHANUM, TYPE\_BULLET\_FILLED, etc. See list of constants in PHPWord\\Style\\ListItem.
-- ``$paragraphStyle``. Array or style Paragraph object. See :ref:`paragraph-style`.
+- ``$paragraphStyle``. Classname, Array or style Paragraph object. See :ref:`paragraph-style`.
 
 See ``Sample_09_Tables.php`` for more code sample.
 
@@ -250,7 +250,7 @@ To add an image, use the ``addImage`` method to sections, headers, footers, text
     $section->addImage($src, [$style]);
 
 - ``$src``. String path to a local image, URL of a remote image or the image data, as a string. Warning: Do not pass user-generated strings here, as that would allow an attacker to read arbitrary files or perform server-side request forgery by passing file paths or URLs instead of image data.
-- ``$style``. Array or Image style object. See :ref:`image-style`.
+- ``$style``. Classname, Array or Image style object. See :ref:`image-style`.
 
 Examples:
 
@@ -382,8 +382,8 @@ Checkbox elements can be added to sections or table cells by using ``addCheckBox
 
 - ``$name``. Name of the check box.
 - ``$text``. Text to be displayed in the document.
-- ``$fontStyle``. Array or Font style object.  See :ref:`font-style`.
-- ``$paragraphStyle``. Array or Paragraph style object.  See :ref:`paragraph-style`.
+- ``$fontStyle``. Classname, Array or Font style object.  See :ref:`font-style`.
+- ``$paragraphStyle``. Classname, Array or Paragraph style object.  See :ref:`paragraph-style`.
 
 Textboxes
 ---------
@@ -405,7 +405,7 @@ Currently the following fields are supported:
 
     $section->addField($fieldType, [$properties], [$options], [$fieldText], [$fontStyle])
 
-- ``$fontStyle``. Array or Font style object See :ref:`font-style`.
+- ``$fontStyle``. Classname, Array or Font style object See :ref:`font-style`.
 
 See ``\PhpOffice\PhpWord\Element\Field`` for list of properties and options available for each field type.
 Options which are not specifically defined can be added. Those must start with a ``\``.

--- a/docs/elements.rst
+++ b/docs/elements.rst
@@ -72,8 +72,8 @@ italics, etc) or other elements, e.g. images or links. The syntaxes are as follo
     $textrun = $section->addTextRun([$paragraphStyle]);
 
 - ``$text``. Text to be displayed in the document.
-- ``$fontStyle``. See :ref:`font-style`.
-- ``$paragraphStyle``. See :ref:`paragraph-style`.
+- ``$fontStyle``. Array or Font style object. See :ref:`font-style`.
+- ``$paragraphStyle``. Array or Paragraph style object. See :ref:`paragraph-style`.
 
 For available styling options see :ref:`font-style` and :ref:`paragraph-style`.
 
@@ -97,8 +97,8 @@ If `depth` is 0, a Title will be inserted, otherwise a Heading1, Heading2, ...
     $section->addTitle($text, [$depth]);
 
 - ``depth``.
-- ``$fontStyle``. See :ref:`font-style`.
-- ``$paragraphStyle``. See :ref:`paragraph-style`.
+- ``$fontStyle``. Array or Font style object. See :ref:`font-style`.
+- ``$paragraphStyle``. Array or Paragraph style object. See :ref:`paragraph-style`.
 - ``$text``. Text to be displayed in the document. This can be `string` or a `\PhpOffice\PhpWord\Element\TextRun`
 
 It's necessary to add a title style to your document because otherwise the title won't be detected as a real title.
@@ -114,8 +114,8 @@ You can add Hyperlinks to the document by using the function addLink:
 
 - ``$linkSrc``. The URL of the link.
 - ``$linkName``. Placeholder of the URL that appears in the document.
-- ``$fontStyle``. See :ref:`font-style`.
-- ``$paragraphStyle``. See :ref:`paragraph-style`.
+- ``$fontStyle``. Array or Font style object. See :ref:`font-style`.
+- ``$paragraphStyle``. Array or Paragraph style object. See :ref:`paragraph-style`.
 
 Preserve texts
 ~~~~~~~~~~~~~~
@@ -139,8 +139,8 @@ Text breaks are empty new lines. To add text breaks, use the following syntax. A
     $section->addTextBreak([$breakCount], [$fontStyle], [$paragraphStyle]);
 
 - ``$breakCount``. How many lines.
-- ``$fontStyle``. See :ref:`font-style`.
-- ``$paragraphStyle``. See :ref:`paragraph-style`.
+- ``$fontStyle``. Array or Font style object. See :ref:`font-style`.
+- ``$paragraphStyle``. Array or Paragraph style object. See :ref:`paragraph-style`.
 
 Page breaks
 ~~~~~~~~~~~
@@ -172,10 +172,10 @@ Parameters:
 
 - ``$text``. Text that appears in the document.
 - ``$depth``. Depth of list item.
-- ``$fontStyle``. See :ref:`font-style`.
+- ``$fontStyle``. Array or Font style object. See :ref:`font-style`.
 - ``$listStyle``. List style of the current element TYPE\_NUMBER,
   TYPE\_ALPHANUM, TYPE\_BULLET\_FILLED, etc. See list of constants in PHPWord\\Style\\ListItem.
-- ``$paragraphStyle``. See :ref:`paragraph-style`.
+- ``$paragraphStyle``. Array or style Paragraph object. See :ref:`paragraph-style`.
 
 See ``Sample_09_Tables.php`` for more code sample.
 
@@ -250,7 +250,7 @@ To add an image, use the ``addImage`` method to sections, headers, footers, text
     $section->addImage($src, [$style]);
 
 - ``$src``. String path to a local image, URL of a remote image or the image data, as a string. Warning: Do not pass user-generated strings here, as that would allow an attacker to read arbitrary files or perform server-side request forgery by passing file paths or URLs instead of image data.
-- ``$style``. See :ref:`image-style`.
+- ``$style``. Array or Image style object. See :ref:`image-style`.
 
 Examples:
 
@@ -382,8 +382,8 @@ Checkbox elements can be added to sections or table cells by using ``addCheckBox
 
 - ``$name``. Name of the check box.
 - ``$text``. Text to be displayed in the document.
-- ``$fontStyle``. See :ref:`font-style`.
-- ``$paragraphStyle``. See :ref:`paragraph-style`.
+- ``$fontStyle``. Array or Font style object.  See :ref:`font-style`.
+- ``$paragraphStyle``. Array or Paragraph style object.  See :ref:`paragraph-style`.
 
 Textboxes
 ---------
@@ -405,7 +405,7 @@ Currently the following fields are supported:
 
     $section->addField($fieldType, [$properties], [$options], [$fieldText], [$fontStyle])
 
-- ``$fontStyle``. See :ref:`font-style`.
+- ``$fontStyle``. Array or Font style object See :ref:`font-style`.
 
 See ``\PhpOffice\PhpWord\Element\Field`` for list of properties and options available for each field type.
 Options which are not specifically defined can be added. Those must start with a ``\``.

--- a/src/PhpWord/Element/AbstractElement.php
+++ b/src/PhpWord/Element/AbstractElement.php
@@ -439,6 +439,10 @@ abstract class AbstractElement
      */
     protected function setNewStyle($styleObject, $styleValue = null, $returnObject = false)
     {
+        if ($styleValue instanceof AbstractStyle) {
+            return $styleValue;
+        }
+        
         if (null !== $styleValue && is_array($styleValue)) {
             $styleObject->setStyleByArray($styleValue);
             $style = $styleObject;

--- a/src/PhpWord/Element/AbstractElement.php
+++ b/src/PhpWord/Element/AbstractElement.php
@@ -2,10 +2,8 @@
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
- *
  * PHPWord is free software distributed under the terms of the GNU Lesser
  * General Public License version 3 as published by the Free Software Foundation.
- *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
@@ -21,6 +19,7 @@ use DateTime;
 use InvalidArgumentException;
 use PhpOffice\PhpWord\Media;
 use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Style\AbstractStyle;
 
 /**
  * Element abstract class.
@@ -32,20 +31,19 @@ abstract class AbstractElement
     /**
      * PhpWord object.
      *
-     * @var \PhpOffice\PhpWord\PhpWord
+     * @var null|PhpWord
      */
     protected $phpWord;
 
     /**
      * Section Id.
      *
-     * @var int
+     * @var null|int
      */
     protected $sectionId;
 
     /**
      * Document part type: Section|Header|Footer|Footnote|Endnote.
-     *
      * Used by textrun and cell container to determine where the element is
      * located because it will affect the availability of other element,
      * e.g. footnote will not be available when $docPart is header or footer.
@@ -56,10 +54,9 @@ abstract class AbstractElement
 
     /**
      * Document part Id.
-     *
      * For header and footer, this will be = ($sectionId - 1) * 3 + $index
      * because the max number of header/footer in every page is 3, i.e.
-     * AUTO, FIRST, and EVEN (AUTO = ODD)
+     * AUTO, FIRST, and EVEN (AUTO = ODD).
      *
      * @var int
      */
@@ -75,23 +72,22 @@ abstract class AbstractElement
     /**
      * Unique Id for element.
      *
-     * @var string
+     * @var null|string
      */
     protected $elementId;
 
     /**
      * Relation Id.
      *
-     * @var int
+     * @var null|int
      */
     protected $relationId;
 
     /**
      * Depth of table container nested level; Primarily used for RTF writer/reader.
-     *
      * 0 = Not in a table; 1 = in a table; 2 = in a table inside another table, etc.
      *
-     * @var int
+     * @var null|int
      */
     private $nestedLevel = 0;
 
@@ -105,16 +101,9 @@ abstract class AbstractElement
     /**
      * changed element info.
      *
-     * @var TrackChange
+     * @var null|TrackChange
      */
     private $trackChange;
-
-    /**
-     * Parent container type.
-     *
-     * @var string
-     */
-    private $parentContainer;
 
     /**
      * Has media relation flag; true for Link, Image, and Object.
@@ -133,31 +122,27 @@ abstract class AbstractElement
     /**
      * The start position for the linked comment.
      *
-     * @var Comment
+     * @var null|Comment
      */
     protected $commentRangeStart;
 
     /**
      * The end position for the linked comment.
      *
-     * @var Comment
+     * @var null|Comment
      */
     protected $commentRangeEnd;
 
     /**
      * Get PhpWord.
-     *
-     * @return \PhpOffice\PhpWord\PhpWord
      */
-    public function getPhpWord()
+    public function getPhpWord(): ?PhpWord
     {
         return $this->phpWord;
     }
 
     /**
      * Set PhpWord as reference.
-     *
-     * @param \PhpOffice\PhpWord\PhpWord $phpWord
      */
     public function setPhpWord(?PhpWord $phpWord = null): void
     {
@@ -166,21 +151,16 @@ abstract class AbstractElement
 
     /**
      * Get section number.
-     *
-     * @return int
      */
-    public function getSectionId()
+    public function getSectionId(): ?int
     {
         return $this->sectionId;
     }
 
     /**
      * Set doc part.
-     *
-     * @param string $docPart
-     * @param int $docPartId
      */
-    public function setDocPart($docPart, $docPartId = 1): void
+    public function setDocPart(string $docPart, int $docPartId = 1): void
     {
         $this->docPart = $docPart;
         $this->docPartId = $docPartId;
@@ -188,20 +168,16 @@ abstract class AbstractElement
 
     /**
      * Get doc part.
-     *
-     * @return string
      */
-    public function getDocPart()
+    public function getDocPart(): ?string
     {
         return $this->docPart;
     }
 
     /**
      * Get doc part Id.
-     *
-     * @return int
      */
-    public function getDocPartId()
+    public function getDocPartId(): ?int
     {
         return $this->docPartId;
     }
@@ -211,7 +187,7 @@ abstract class AbstractElement
      *
      * @return string section|headerx|footerx|footnote|endnote
      */
-    private function getMediaPart()
+    private function getMediaPart(): string
     {
         $mediaPart = $this->docPart;
         if ($mediaPart == 'Header' || $mediaPart == 'Footer') {
@@ -223,30 +199,24 @@ abstract class AbstractElement
 
     /**
      * Get element index.
-     *
-     * @return int
      */
-    public function getElementIndex()
+    public function getElementIndex(): int
     {
         return $this->elementIndex;
     }
 
     /**
      * Set element index.
-     *
-     * @param int $value
      */
-    public function setElementIndex($value): void
+    public function setElementIndex(int $value): void
     {
         $this->elementIndex = $value;
     }
 
     /**
      * Get element unique ID.
-     *
-     * @return string
      */
-    public function getElementId()
+    public function getElementId(): ?string
     {
         return $this->elementId;
     }
@@ -261,40 +231,32 @@ abstract class AbstractElement
 
     /**
      * Get relation Id.
-     *
-     * @return int
      */
-    public function getRelationId()
+    public function getRelationId(): ?int
     {
         return $this->relationId;
     }
 
     /**
      * Set relation Id.
-     *
-     * @param int $value
      */
-    public function setRelationId($value): void
+    public function setRelationId(int $value): void
     {
         $this->relationId = $value;
     }
 
     /**
      * Get nested level.
-     *
-     * @return int
      */
-    public function getNestedLevel()
+    public function getNestedLevel(): int
     {
         return $this->nestedLevel;
     }
 
     /**
      * Get comment start.
-     *
-     * @return Comment
      */
-    public function getCommentRangeStart()
+    public function getCommentRangeStart(): ?Comment
     {
         return $this->commentRangeStart;
     }
@@ -313,10 +275,8 @@ abstract class AbstractElement
 
     /**
      * Get comment end.
-     *
-     * @return Comment
      */
-    public function getCommentRangeEnd()
+    public function getCommentRangeEnd(): ?Comment
     {
         return $this->commentRangeEnd;
     }
@@ -335,29 +295,26 @@ abstract class AbstractElement
 
     /**
      * Get parent element.
-     *
-     * @return null|AbstractElement
      */
-    public function getParent()
+    public function getParent(): ?self
     {
         return $this->parent;
     }
 
     /**
      * Set parent container.
+     * Passed parameter should be a container, except for Table (contain Row) and Row (contain Cell).
      *
-     * Passed parameter should be a container, except for Table (contain Row) and Row (contain Cell)
-     *
-     * @param \PhpOffice\PhpWord\Element\AbstractElement $container
+     * @param AbstractElement $container
      */
     public function setParentContainer(self $container): void
     {
-        $this->parentContainer = substr(get_class($container), strrpos(get_class($container), '\\') + 1);
+        $parentContainer = substr(get_class($container), strrpos(get_class($container), '\\') + 1);
         $this->parent = $container;
 
         // Set nested level
         $this->nestedLevel = $container->getNestedLevel();
-        if ($this->parentContainer == 'Cell') {
+        if ($parentContainer == 'Cell') {
             ++$this->nestedLevel;
         }
 
@@ -375,9 +332,8 @@ abstract class AbstractElement
 
     /**
      * Set relation Id for media elements (link, image, object; legacy of OOXML).
-     *
      * - Image element needs to be passed to Media object
-     * - Icon needs to be set for Object element
+     * - Icon needs to be set for Object element.
      */
     private function setMediaRelation(): void
     {
@@ -420,29 +376,28 @@ abstract class AbstractElement
 
     /**
      * Check if element is located in Section doc part (as opposed to Header/Footer).
-     *
-     * @return bool
      */
-    public function isInSection()
+    public function isInSection(): bool
     {
-        return $this->docPart == 'Section';
+        return $this->docPart === 'Section';
     }
 
     /**
      * Set new style value.
      *
-     * @param mixed $styleObject Style object
-     * @param mixed $styleValue Style value
-     * @param bool $returnObject Always return object
+     * @param mixed $styleObject  Style object
+     * @param mixed $styleValue   Style value
+     * @param bool  $returnObject Always return object
      *
      * @return mixed
      */
-    protected function setNewStyle($styleObject, $styleValue = null, $returnObject = false)
+    protected function setNewStyle($styleObject, $styleValue = null, bool $returnObject = false)
     {
         if ($styleValue instanceof AbstractStyle) {
             return $styleValue;
         }
-        if (null !== $styleValue && is_array($styleValue)) {
+
+        if (is_array($styleValue)) {
             $styleObject->setStyleByArray($styleValue);
             $style = $styleObject;
         } else {
@@ -465,7 +420,7 @@ abstract class AbstractElement
      *
      * @return TrackChange
      */
-    public function getTrackChange()
+    public function getTrackChange(): ?TrackChange
     {
         return $this->trackChange;
     }
@@ -473,11 +428,10 @@ abstract class AbstractElement
     /**
      * Set changed.
      *
-     * @param string $type INSERTED|DELETED
-     * @param string $author
+     * @param string            $type INSERTED|DELETED
      * @param null|DateTime|int $date allways in UTC
      */
-    public function setChangeInfo($type, $author, $date = null): void
+    public function setChangeInfo(string $type, string $author, $date = null): void
     {
         $this->trackChange = new TrackChange($type, $author, $date);
     }
@@ -485,17 +439,11 @@ abstract class AbstractElement
     /**
      * Set enum value.
      *
-     * @param null|string $value
-     * @param string[] $enum
-     * @param null|string $default
-     *
-     * @return null|string
-     *
      * @todo Merge with the same method in AbstractStyle
      */
-    protected function setEnumVal($value = null, $enum = [], $default = null)
+    protected function setEnumVal(?string $value = null, array $enum = [], ?string $default = null): ?string
     {
-        if ($value !== null && trim($value) != '' && !empty($enum) && !in_array($value, $enum)) {
+        if ($value !== null && trim($value) !== '' && !empty($enum) && !in_array($value, $enum)) {
             throw new InvalidArgumentException("Invalid style value: {$value}");
         } elseif ($value === null || trim($value) == '') {
             $value = $default;

--- a/src/PhpWord/Element/AbstractElement.php
+++ b/src/PhpWord/Element/AbstractElement.php
@@ -442,7 +442,6 @@ abstract class AbstractElement
         if ($styleValue instanceof AbstractStyle) {
             return $styleValue;
         }
-        
         if (null !== $styleValue && is_array($styleValue)) {
             $styleObject->setStyleByArray($styleValue);
             $style = $styleObject;

--- a/tests/PhpWordTests/Element/CellTest.php
+++ b/tests/PhpWordTests/Element/CellTest.php
@@ -19,6 +19,9 @@ namespace PhpOffice\PhpWordTests\Element;
 
 use BadMethodCallException;
 use PhpOffice\PhpWord\Element\Cell;
+use PhpOffice\PhpWord\Element\Text;
+use PhpOffice\PhpWord\Style\Cell as CellStyle;
+use PhpOffice\PhpWord\Style\Paragraph;
 use PhpOffice\PhpWordTests\AbstractWebServerEmbeddedTest;
 
 /**
@@ -269,5 +272,36 @@ class CellTest extends AbstractWebServerEmbeddedTest
         $oCell = new Cell();
 
         self::assertIsArray($oCell->getElements());
+    }
+
+    /**
+     * Test that the via constructor passed style objects and their values remain unchanged.
+     */
+    public function testPassingStyleObjectsToConstructor(): void
+    {
+        $cellStyle = new CellStyle();
+        $cellStyle->setBorderTopColor('red');
+        $cell = new Cell(150, $cellStyle);
+
+        // Test Paragraph style
+        self::assertInstanceOf(CellStyle::class, $cell->getStyle());
+        self::assertSame($cell->getStyle(), $cellStyle);
+        self::assertEquals('red', $cell->getStyle()->getBorderTopColor());
+    }
+
+    /**
+     * Test that the via constructor passed style objects and their values remain unchanged.
+     */
+    public function testPassingStyleArrayToConstructor(): void
+    {
+        $cellStyle = [
+            'borderTopColor' => 'red',
+        ];
+
+        $cell = new Cell(150, $cellStyle);
+
+        // Test Paragraph style
+        self::assertInstanceOf(CellStyle::class, $cell->getStyle());
+        self::assertEquals('red', $cell->getStyle()->getBorderTopColor());
     }
 }

--- a/tests/PhpWordTests/Element/TextTest.php
+++ b/tests/PhpWordTests/Element/TextTest.php
@@ -99,12 +99,12 @@ class TextTest extends TestCase
 
         // Test Paragraph style
         self::assertInstanceOf(Paragraph::class, $text->getParagraphStyle());
-        self::assertEquals($text->getParagraphStyle(), $paragraphStyle);
+        self::assertSame($text->getParagraphStyle(), $paragraphStyle);
         self::assertEquals(100, $paragraphStyle->getSpaceBefore());
 
         // test Font style
         self::assertInstanceOf(Font::class, $text->getFontStyle());
-        self::assertEquals($text->getFontStyle(), $fontStyle);
+        self::assertSame($text->getFontStyle(), $fontStyle);
         self::assertEquals(10, $fontStyle->getSize());
     }
 

--- a/tests/PhpWordTests/Element/TextTest.php
+++ b/tests/PhpWordTests/Element/TextTest.php
@@ -2,10 +2,8 @@
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
- *
  * PHPWord is free software distributed under the terms of the GNU Lesser
  * General Public License version 3 as published by the Free Software Foundation.
- *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
@@ -20,13 +18,15 @@ namespace PhpOffice\PhpWordTests\Element;
 use PhpOffice\PhpWord\Element\Text;
 use PhpOffice\PhpWord\SimpleType\Jc;
 use PhpOffice\PhpWord\Style\Font;
+use PhpOffice\PhpWord\Style\Paragraph;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpOffice\PhpWord\Element\Text.
  *
  * @runTestsInSeparateProcesses
  */
-class TextTest extends \PHPUnit\Framework\TestCase
+class TextTest extends TestCase
 {
     /**
      * New instance.
@@ -83,5 +83,52 @@ class TextTest extends \PHPUnit\Framework\TestCase
 
         $oText->setParagraphStyle(['alignment' => Jc::CENTER, 'spaceAfter' => 100]);
         self::assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $oText->getParagraphStyle());
+    }
+
+    /**
+     * Test that the via constructor passed style objects and their values remain unchanged.
+     */
+    public function testPassingStyleObjectsToConstructor(): void
+    {
+        $paragraphStyle = new Paragraph();
+        $paragraphStyle->setSpaceBefore(100);
+        $fontStyle = new Font();
+        $fontStyle->setSize(10);
+
+        $text = new Text('test', $fontStyle, $paragraphStyle);
+
+        // Test Paragraph style
+        self::assertInstanceOf(Paragraph::class, $text->getParagraphStyle());
+        self::assertEquals($text->getParagraphStyle(), $paragraphStyle);
+        self::assertEquals(100, $paragraphStyle->getSpaceBefore());
+
+        // test Font style
+        self::assertInstanceOf(Font::class, $text->getFontStyle());
+        self::assertEquals($text->getFontStyle(), $fontStyle);
+        self::assertEquals(10, $fontStyle->getSize());
+    }
+
+    /**
+     * Test that the via constructor passed style objects and their values remain unchanged.
+     */
+    public function testPassingStyleArrayToConstructor(): void
+    {
+        $paragraphStyle = [
+            'spaceBefore' => 100,
+        ];
+
+        $fontStyle = [
+            'size' => 10,
+        ];
+
+        $text = new Text('test', $fontStyle, $paragraphStyle);
+
+        // Test Paragraph style
+        self::assertInstanceOf(Paragraph::class, $text->getParagraphStyle());
+        self::assertEquals(100, $text->getParagraphStyle()->getSpaceBefore());
+
+        // Test font style
+        self::assertInstanceOf(Font::class, $text->getFontStyle());
+        self::assertEquals(10, $text->getFontStyle()->getSize());
     }
 }

--- a/tests/PhpWordTests/Writer/Word2007/Part/DocumentTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/Part/DocumentTest.php
@@ -23,14 +23,16 @@ use PhpOffice\PhpWord\SimpleType\Jc;
 use PhpOffice\PhpWord\SimpleType\NumberFormat;
 use PhpOffice\PhpWord\Style\Cell;
 use PhpOffice\PhpWord\Style\Font;
+use PhpOffice\PhpWord\Style\Tab;
 use PhpOffice\PhpWordTests\TestHelperDOCX;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpOffice\PhpWord\Writer\Word2007\Part\Document.
  *
  * @runTestsInSeparateProcesses
  */
-class DocumentTest extends \PHPUnit\Framework\TestCase
+class DocumentTest extends TestCase
 {
     /**
      * Executed before each method of the class.
@@ -131,10 +133,10 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $section->addTOC();
         $section->addPageBreak();
         $section->addText('After page break.');
-        $section->addTitle('Title 1', 1);
-        $section->addListItem('List Item 1', 0);
-        $section->addListItem('List Item 2', 0);
-        $section->addListItem('List Item 3', 0);
+        $section->addTitle('Title 1');
+        $section->addListItem('List Item 1');
+        $section->addListItem('List Item 2');
+        $section->addListItem('List Item 3');
 
         $section = $phpWord->addSection();
         $section->addTitle('Title 2', 2);
@@ -213,7 +215,7 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
     {
         $objectSrc = __DIR__ . '/../../../_files/documents/sheet.xls';
 
-        $tabs = [new \PhpOffice\PhpWord\Style\Tab('right', 9090)];
+        $tabs = [new Tab('right', 9090)];
         $phpWord = new PhpWord();
         $phpWord->addParagraphStyle(
             'pStyle',
@@ -243,7 +245,7 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $section->addListItem('List Item', 0, null, null, 'pStyle'); // Style #5
         $section->addObject($objectSrc, ['alignment' => Jc::CENTER]);
         $section->addTOC($fontStyle);
-        $section->addTitle('Title 1', 1);
+        $section->addTitle('Title 1');
         $section->addTOC('fStyle');
         $table = $section->addTable('tStyle');
         $table->setWidth(100);
@@ -407,11 +409,12 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $element = $doc->getElement('/w:document/w:body/w:p[2]/w:r/w:pict/v:shape');
         $style = $element->getAttribute('style');
 
-        // Try to address CI coverage issue for PHP 7.1 and 7.2 when using regex match assertions
-        if (method_exists(static::class, 'assertRegExp')) {
-            self::assertRegExp('/z\-index:\-[0-9]*/', $style);
-        } else {
+        // Address CI coverage issue for PHP 7.1 and 7.2 when using regex match assertions
+        // Prefer not using the deprecated method!
+        if (method_exists(static::class, 'assertMatchesRegularExpression')) {
             self::assertMatchesRegularExpression('/z\-index:\-[0-9]*/', $style);
+        } else {
+            self::assertRegExp('/z\-index:\-[0-9]*/', $style);
         }
 
         // square
@@ -443,7 +446,7 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
     {
         $phpWord = new PhpWord();
         $phpWord->addTitleStyle(1, ['bold' => true], ['spaceAfter' => 240]);
-        $phpWord->addSection()->addTitle('Test', 1);
+        $phpWord->addSection()->addTitle('Test');
         $doc = TestHelperDOCX::getDocument($phpWord);
 
         $element = '/w:document/w:body/w:p/w:pPr/w:pStyle';
@@ -610,8 +613,6 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $textrun->addText('Test');
 
         $doc = TestHelperDOCX::getDocument($phpWord);
-
-        $parent = '/w:document/w:body/w:tbl/w:tblPr/w:tblCellMar';
 
         $parent = '/w:document/w:body/w:tbl/w:tr/w:trPr';
         self::assertEquals($rHeight, $doc->getElementAttribute("{$parent}/w:trHeight", 'w:val'));


### PR DESCRIPTION
### Description

The current version does not support passing style objects to the constructor of an element. Only arrays are supported. But for a full OOP approach the element constructor should also or only support style objects. As the setNewStyle method is only used internally, the returnObject param can be ignored when passing a style element instance as styleValue via constructor.

Fixes # (issue)

Elements do not support style objects via constructor.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
