### PR TITLE
Add support for fractional font sizes

### DIFF
--- a/src/PhpWord/Settings.php
+++ b/src/PhpWord/Settings.php
@@ -2,10 +2,8 @@
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
- *
  * PHPWord is free software distributed under the terms of the GNU Lesser
  * General Public License version 3 as published by the Free Software Foundation.
- *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
@@ -29,48 +27,46 @@ class Settings
      *
      * @const string
      */
-    const ZIPARCHIVE = 'ZipArchive';
-    const PCLZIP = 'PclZip';
-    const OLD_LIB = \PhpOffice\PhpWord\Shared\ZipArchive::class; // @deprecated 0.11
+    public const ZIPARCHIVE = 'ZipArchive';
+    public const PCLZIP = 'PclZip';
+    public const OLD_LIB = \PhpOffice\PhpWord\Shared\ZipArchive::class; // @deprecated 0.11
 
     /**
      * PDF rendering libraries.
      *
      * @const string
      */
-    const PDF_RENDERER_DOMPDF = 'DomPDF';
-    const PDF_RENDERER_TCPDF = 'TCPDF';
-    const PDF_RENDERER_MPDF = 'MPDF';
+    public const PDF_RENDERER_DOMPDF = 'DomPDF';
+    public const PDF_RENDERER_TCPDF = 'TCPDF';
+    public const PDF_RENDERER_MPDF = 'MPDF';
 
     /**
      * Measurement units multiplication factor.
-     *
      * Applied to:
      * - Section: margins, header/footer height, gutter, column spacing
      * - Tab: position
      * - Indentation: left, right, firstLine, hanging
-     * - Spacing: before, after
+     * - Spacing: before, after.
      *
      * @const string
      */
-    const UNIT_TWIP = 'twip'; // = 1/20 point
-    const UNIT_CM = 'cm';
-    const UNIT_MM = 'mm';
-    const UNIT_INCH = 'inch';
-    const UNIT_POINT = 'point'; // = 1/72 inch
-    const UNIT_PICA = 'pica'; // = 1/6 inch = 12 points
+    public const UNIT_TWIP = 'twip'; // = 1/20 point
+    public const UNIT_CM = 'cm';
+    public const UNIT_MM = 'mm';
+    public const UNIT_INCH = 'inch';
+    public const UNIT_POINT = 'point'; // = 1/72 inch
+    public const UNIT_PICA = 'pica'; // = 1/6 inch = 12 points
 
     /**
      * Default font settings.
-     *
      * OOXML defined font size values in halfpoints, i.e. twice of what PhpWord
      * use, and the conversion will be conducted during XML writing.
      */
-    const DEFAULT_FONT_NAME = 'Arial';
-    const DEFAULT_FONT_SIZE = 10;
-    const DEFAULT_FONT_COLOR = '000000';
-    const DEFAULT_FONT_CONTENT_TYPE = 'default'; // default|eastAsia|cs
-    const DEFAULT_PAPER = 'A4';
+    public const DEFAULT_FONT_NAME = 'Arial';
+    public const DEFAULT_FONT_SIZE = 10;
+    public const DEFAULT_FONT_COLOR = '000000';
+    public const DEFAULT_FONT_CONTENT_TYPE = 'default'; // default|eastAsia|cs
+    public const DEFAULT_PAPER = 'A4';
 
     /**
      * Compatibility option for XMLWriter.
@@ -89,21 +85,21 @@ class Settings
     /**
      * Name of the external Library used for rendering PDF files.
      *
-     * @var string
+     * @var null|string
      */
     private static $pdfRendererName;
 
     /**
      * Directory Path to the external Library used for rendering PDF files.
      *
-     * @var string
+     * @var null|string
      */
     private static $pdfRendererPath;
 
     /**
      * Measurement unit.
      *
-     * @var float|int
+     * @var string
      */
     private static $measurementUnit = self::UNIT_TWIP;
 
@@ -117,7 +113,7 @@ class Settings
     /**
      * Default font size.
      *
-     * @var int
+     * @var float|int
      */
     private static $defaultFontSize = self::DEFAULT_FONT_SIZE;
 
@@ -148,23 +144,17 @@ class Settings
      *
      * @return bool Compatibility
      */
-    public static function hasCompatibility()
+    public static function hasCompatibility(): bool
     {
         return self::$xmlWriterCompatibility;
     }
 
     /**
      * Set the compatibility option used by the XMLWriter.
-     *
-     * This sets the setIndent and setIndentString for better compatibility
-     *
-     * @param bool $compatibility
-     *
-     * @return bool
+     * This sets the setIndent and setIndentString for better compatibility.
      */
-    public static function setCompatibility($compatibility)
+    public static function setCompatibility(bool $compatibility): bool
     {
-        $compatibility = (bool) $compatibility;
         self::$xmlWriterCompatibility = $compatibility;
 
         return true;
@@ -172,22 +162,16 @@ class Settings
 
     /**
      * Get zip handler class.
-     *
-     * @return string
      */
-    public static function getZipClass()
+    public static function getZipClass(): string
     {
         return self::$zipClass;
     }
 
     /**
      * Set zip handler class.
-     *
-     * @param  string $zipClass
-     *
-     * @return bool
      */
-    public static function setZipClass($zipClass)
+    public static function setZipClass(string $zipClass): bool
     {
         if (in_array($zipClass, [self::PCLZIP, self::ZIPARCHIVE, self::OLD_LIB])) {
             self::$zipClass = $zipClass;
@@ -201,12 +185,9 @@ class Settings
     /**
      * Set details of the external library for rendering PDF files.
      *
-     * @param string $libraryName
-     * @param string $libraryBaseDir
-     *
      * @return bool Success or failure
      */
-    public static function setPdfRenderer($libraryName, $libraryBaseDir)
+    public static function setPdfRenderer(string $libraryName, string $libraryBaseDir): bool
     {
         if (!self::setPdfRendererName($libraryName)) {
             return false;
@@ -217,22 +198,16 @@ class Settings
 
     /**
      * Return the PDF Rendering Library.
-     *
-     * @return string
      */
-    public static function getPdfRendererName()
+    public static function getPdfRendererName(): ?string
     {
         return self::$pdfRendererName;
     }
 
     /**
      * Identify the external library to use for rendering PDF files.
-     *
-     * @param string $libraryName
-     *
-     * @return bool
      */
-    public static function setPdfRendererName($libraryName)
+    public static function setPdfRendererName(?string $libraryName): bool
     {
         $pdfRenderers = [self::PDF_RENDERER_DOMPDF, self::PDF_RENDERER_TCPDF, self::PDF_RENDERER_MPDF];
         if (!in_array($libraryName, $pdfRenderers)) {
@@ -245,10 +220,8 @@ class Settings
 
     /**
      * Return the directory path to the PDF Rendering Library.
-     *
-     * @return string
      */
-    public static function getPdfRendererPath()
+    public static function getPdfRendererPath(): ?string
     {
         return self::$pdfRendererPath;
     }
@@ -256,11 +229,11 @@ class Settings
     /**
      * Location of external library to use for rendering PDF files.
      *
-     * @param string $libraryBaseDir Directory path to the library's base folder
+     * @param null|string $libraryBaseDir Directory path to the library's base folder
      *
      * @return bool Success or failure
      */
-    public static function setPdfRendererPath($libraryBaseDir)
+    public static function setPdfRendererPath(?string $libraryBaseDir): bool
     {
         if (!$libraryBaseDir || false === file_exists($libraryBaseDir) || false === is_readable($libraryBaseDir)) {
             return false;
@@ -272,25 +245,25 @@ class Settings
 
     /**
      * Get measurement unit.
-     *
-     * @return string
      */
-    public static function getMeasurementUnit()
+    public static function getMeasurementUnit(): string
     {
         return self::$measurementUnit;
     }
 
     /**
      * Set measurement unit.
-     *
-     * @param string $value
-     *
-     * @return bool
      */
-    public static function setMeasurementUnit($value)
+    public static function setMeasurementUnit(string $value): bool
     {
-        $units = [self::UNIT_TWIP, self::UNIT_CM, self::UNIT_MM, self::UNIT_INCH,
-            self::UNIT_POINT, self::UNIT_PICA, ];
+        $units = [
+            self::UNIT_TWIP,
+            self::UNIT_CM,
+            self::UNIT_MM,
+            self::UNIT_INCH,
+            self::UNIT_POINT,
+            self::UNIT_PICA,
+        ];
         if (!in_array($value, $units)) {
             return false;
         }
@@ -302,11 +275,11 @@ class Settings
     /**
      * Sets the user defined path to temporary directory.
      *
-     * @since 0.12.0
-     *
      * @param string $tempDir The user defined path to temporary directory
+     *
+     * @since 0.12.0
      */
-    public static function setTempDir($tempDir): void
+    public static function setTempDir(string $tempDir): void
     {
         self::$tempDir = $tempDir;
     }
@@ -315,10 +288,8 @@ class Settings
      * Returns path to temporary directory.
      *
      * @since 0.12.0
-     *
-     * @return string
      */
-    public static function getTempDir()
+    public static function getTempDir(): string
     {
         if (!empty(self::$tempDir)) {
             $tempDir = self::$tempDir;
@@ -331,44 +302,34 @@ class Settings
 
     /**
      * @since 0.13.0
-     *
-     * @return bool
      */
-    public static function isOutputEscapingEnabled()
+    public static function isOutputEscapingEnabled(): bool
     {
         return self::$outputEscapingEnabled;
     }
 
     /**
      * @since 0.13.0
-     *
-     * @param bool $outputEscapingEnabled
      */
-    public static function setOutputEscapingEnabled($outputEscapingEnabled): void
+    public static function setOutputEscapingEnabled(bool $outputEscapingEnabled): void
     {
         self::$outputEscapingEnabled = $outputEscapingEnabled;
     }
 
     /**
      * Get default font name.
-     *
-     * @return string
      */
-    public static function getDefaultFontName()
+    public static function getDefaultFontName(): string
     {
         return self::$defaultFontName;
     }
 
     /**
      * Set default font name.
-     *
-     * @param string $value
-     *
-     * @return bool
      */
-    public static function setDefaultFontName($value)
+    public static function setDefaultFontName(string $value): bool
     {
-        if (is_string($value) && trim($value) !== '') {
+        if (trim($value) !== '') {
             self::$defaultFontName = $value;
 
             return true;
@@ -380,7 +341,7 @@ class Settings
     /**
      * Get default font size.
      *
-     * @return int
+     * @return float|int
      */
     public static function getDefaultFontSize()
     {
@@ -390,14 +351,11 @@ class Settings
     /**
      * Set default font size.
      *
-     * @param int $value
-     *
-     * @return bool
+     * @param null|float|int $value
      */
-    public static function setDefaultFontSize($value)
+    public static function setDefaultFontSize($value): bool
     {
-        $value = (int) $value;
-        if ($value > 0) {
+        if ((is_int($value) || is_float($value)) && (int) $value > 0) {
             self::$defaultFontSize = $value;
 
             return true;
@@ -408,12 +366,8 @@ class Settings
 
     /**
      * Load setting from phpword.yml or phpword.yml.dist.
-     *
-     * @param string $filename
-     *
-     * @return array
      */
-    public static function loadConfig($filename = null)
+    public static function loadConfig(?string $filename = null): array
     {
         // Get config file
         $configFile = null;
@@ -455,24 +409,18 @@ class Settings
 
     /**
      * Get default paper.
-     *
-     * @return string
      */
-    public static function getDefaultPaper()
+    public static function getDefaultPaper(): string
     {
         return self::$defaultPaper;
     }
 
     /**
      * Set default paper.
-     *
-     * @param string $value
-     *
-     * @return bool
      */
-    public static function setDefaultPaper($value)
+    public static function setDefaultPaper(string $value): bool
     {
-        if (is_string($value) && trim($value) !== '') {
+        if (trim($value) !== '') {
             self::$defaultPaper = $value;
 
             return true;

--- a/src/PhpWord/Settings.php
+++ b/src/PhpWord/Settings.php
@@ -396,7 +396,7 @@ class Settings
      */
     public static function setDefaultFontSize($value)
     {
-        $value = (int) $value;
+        $value = (float) $value;
         if ($value > 0) {
             self::$defaultFontSize = $value;
 

--- a/src/PhpWord/Settings.php
+++ b/src/PhpWord/Settings.php
@@ -2,8 +2,10 @@
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
+ *
  * PHPWord is free software distributed under the terms of the GNU Lesser
  * General Public License version 3 as published by the Free Software Foundation.
+ *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
@@ -27,46 +29,48 @@ class Settings
      *
      * @const string
      */
-    public const ZIPARCHIVE = 'ZipArchive';
-    public const PCLZIP = 'PclZip';
-    public const OLD_LIB = \PhpOffice\PhpWord\Shared\ZipArchive::class; // @deprecated 0.11
+    const ZIPARCHIVE = 'ZipArchive';
+    const PCLZIP = 'PclZip';
+    const OLD_LIB = \PhpOffice\PhpWord\Shared\ZipArchive::class; // @deprecated 0.11
 
     /**
      * PDF rendering libraries.
      *
      * @const string
      */
-    public const PDF_RENDERER_DOMPDF = 'DomPDF';
-    public const PDF_RENDERER_TCPDF = 'TCPDF';
-    public const PDF_RENDERER_MPDF = 'MPDF';
+    const PDF_RENDERER_DOMPDF = 'DomPDF';
+    const PDF_RENDERER_TCPDF = 'TCPDF';
+    const PDF_RENDERER_MPDF = 'MPDF';
 
     /**
      * Measurement units multiplication factor.
+     *
      * Applied to:
      * - Section: margins, header/footer height, gutter, column spacing
      * - Tab: position
      * - Indentation: left, right, firstLine, hanging
-     * - Spacing: before, after.
+     * - Spacing: before, after
      *
      * @const string
      */
-    public const UNIT_TWIP = 'twip'; // = 1/20 point
-    public const UNIT_CM = 'cm';
-    public const UNIT_MM = 'mm';
-    public const UNIT_INCH = 'inch';
-    public const UNIT_POINT = 'point'; // = 1/72 inch
-    public const UNIT_PICA = 'pica'; // = 1/6 inch = 12 points
+    const UNIT_TWIP = 'twip'; // = 1/20 point
+    const UNIT_CM = 'cm';
+    const UNIT_MM = 'mm';
+    const UNIT_INCH = 'inch';
+    const UNIT_POINT = 'point'; // = 1/72 inch
+    const UNIT_PICA = 'pica'; // = 1/6 inch = 12 points
 
     /**
      * Default font settings.
+     *
      * OOXML defined font size values in halfpoints, i.e. twice of what PhpWord
      * use, and the conversion will be conducted during XML writing.
      */
-    public const DEFAULT_FONT_NAME = 'Arial';
-    public const DEFAULT_FONT_SIZE = 10;
-    public const DEFAULT_FONT_COLOR = '000000';
-    public const DEFAULT_FONT_CONTENT_TYPE = 'default'; // default|eastAsia|cs
-    public const DEFAULT_PAPER = 'A4';
+    const DEFAULT_FONT_NAME = 'Arial';
+    const DEFAULT_FONT_SIZE = 10;
+    const DEFAULT_FONT_COLOR = '000000';
+    const DEFAULT_FONT_CONTENT_TYPE = 'default'; // default|eastAsia|cs
+    const DEFAULT_PAPER = 'A4';
 
     /**
      * Compatibility option for XMLWriter.
@@ -85,21 +89,21 @@ class Settings
     /**
      * Name of the external Library used for rendering PDF files.
      *
-     * @var null|string
+     * @var string
      */
     private static $pdfRendererName;
 
     /**
      * Directory Path to the external Library used for rendering PDF files.
      *
-     * @var null|string
+     * @var string
      */
     private static $pdfRendererPath;
 
     /**
      * Measurement unit.
      *
-     * @var string
+     * @var float|int
      */
     private static $measurementUnit = self::UNIT_TWIP;
 
@@ -113,7 +117,7 @@ class Settings
     /**
      * Default font size.
      *
-     * @var float|int
+     * @var int
      */
     private static $defaultFontSize = self::DEFAULT_FONT_SIZE;
 
@@ -144,17 +148,23 @@ class Settings
      *
      * @return bool Compatibility
      */
-    public static function hasCompatibility(): bool
+    public static function hasCompatibility()
     {
         return self::$xmlWriterCompatibility;
     }
 
     /**
      * Set the compatibility option used by the XMLWriter.
-     * This sets the setIndent and setIndentString for better compatibility.
+     *
+     * This sets the setIndent and setIndentString for better compatibility
+     *
+     * @param bool $compatibility
+     *
+     * @return bool
      */
-    public static function setCompatibility(bool $compatibility): bool
+    public static function setCompatibility($compatibility)
     {
+        $compatibility = (bool) $compatibility;
         self::$xmlWriterCompatibility = $compatibility;
 
         return true;
@@ -162,16 +172,22 @@ class Settings
 
     /**
      * Get zip handler class.
+     *
+     * @return string
      */
-    public static function getZipClass(): string
+    public static function getZipClass()
     {
         return self::$zipClass;
     }
 
     /**
      * Set zip handler class.
+     *
+     * @param  string $zipClass
+     *
+     * @return bool
      */
-    public static function setZipClass(string $zipClass): bool
+    public static function setZipClass($zipClass)
     {
         if (in_array($zipClass, [self::PCLZIP, self::ZIPARCHIVE, self::OLD_LIB])) {
             self::$zipClass = $zipClass;
@@ -185,9 +201,12 @@ class Settings
     /**
      * Set details of the external library for rendering PDF files.
      *
+     * @param string $libraryName
+     * @param string $libraryBaseDir
+     *
      * @return bool Success or failure
      */
-    public static function setPdfRenderer(string $libraryName, string $libraryBaseDir): bool
+    public static function setPdfRenderer($libraryName, $libraryBaseDir)
     {
         if (!self::setPdfRendererName($libraryName)) {
             return false;
@@ -198,16 +217,22 @@ class Settings
 
     /**
      * Return the PDF Rendering Library.
+     *
+     * @return string
      */
-    public static function getPdfRendererName(): ?string
+    public static function getPdfRendererName()
     {
         return self::$pdfRendererName;
     }
 
     /**
      * Identify the external library to use for rendering PDF files.
+     *
+     * @param string $libraryName
+     *
+     * @return bool
      */
-    public static function setPdfRendererName(?string $libraryName): bool
+    public static function setPdfRendererName($libraryName)
     {
         $pdfRenderers = [self::PDF_RENDERER_DOMPDF, self::PDF_RENDERER_TCPDF, self::PDF_RENDERER_MPDF];
         if (!in_array($libraryName, $pdfRenderers)) {
@@ -220,8 +245,10 @@ class Settings
 
     /**
      * Return the directory path to the PDF Rendering Library.
+     *
+     * @return string
      */
-    public static function getPdfRendererPath(): ?string
+    public static function getPdfRendererPath()
     {
         return self::$pdfRendererPath;
     }
@@ -229,11 +256,11 @@ class Settings
     /**
      * Location of external library to use for rendering PDF files.
      *
-     * @param null|string $libraryBaseDir Directory path to the library's base folder
+     * @param string $libraryBaseDir Directory path to the library's base folder
      *
      * @return bool Success or failure
      */
-    public static function setPdfRendererPath(?string $libraryBaseDir): bool
+    public static function setPdfRendererPath($libraryBaseDir)
     {
         if (!$libraryBaseDir || false === file_exists($libraryBaseDir) || false === is_readable($libraryBaseDir)) {
             return false;
@@ -245,25 +272,25 @@ class Settings
 
     /**
      * Get measurement unit.
+     *
+     * @return string
      */
-    public static function getMeasurementUnit(): string
+    public static function getMeasurementUnit()
     {
         return self::$measurementUnit;
     }
 
     /**
      * Set measurement unit.
+     *
+     * @param string $value
+     *
+     * @return bool
      */
-    public static function setMeasurementUnit(string $value): bool
+    public static function setMeasurementUnit($value)
     {
-        $units = [
-            self::UNIT_TWIP,
-            self::UNIT_CM,
-            self::UNIT_MM,
-            self::UNIT_INCH,
-            self::UNIT_POINT,
-            self::UNIT_PICA,
-        ];
+        $units = [self::UNIT_TWIP, self::UNIT_CM, self::UNIT_MM, self::UNIT_INCH,
+            self::UNIT_POINT, self::UNIT_PICA, ];
         if (!in_array($value, $units)) {
             return false;
         }
@@ -275,11 +302,11 @@ class Settings
     /**
      * Sets the user defined path to temporary directory.
      *
-     * @param string $tempDir The user defined path to temporary directory
-     *
      * @since 0.12.0
+     *
+     * @param string $tempDir The user defined path to temporary directory
      */
-    public static function setTempDir(string $tempDir): void
+    public static function setTempDir($tempDir): void
     {
         self::$tempDir = $tempDir;
     }
@@ -288,8 +315,10 @@ class Settings
      * Returns path to temporary directory.
      *
      * @since 0.12.0
+     *
+     * @return string
      */
-    public static function getTempDir(): string
+    public static function getTempDir()
     {
         if (!empty(self::$tempDir)) {
             $tempDir = self::$tempDir;
@@ -302,34 +331,44 @@ class Settings
 
     /**
      * @since 0.13.0
+     *
+     * @return bool
      */
-    public static function isOutputEscapingEnabled(): bool
+    public static function isOutputEscapingEnabled()
     {
         return self::$outputEscapingEnabled;
     }
 
     /**
      * @since 0.13.0
+     *
+     * @param bool $outputEscapingEnabled
      */
-    public static function setOutputEscapingEnabled(bool $outputEscapingEnabled): void
+    public static function setOutputEscapingEnabled($outputEscapingEnabled): void
     {
         self::$outputEscapingEnabled = $outputEscapingEnabled;
     }
 
     /**
      * Get default font name.
+     *
+     * @return string
      */
-    public static function getDefaultFontName(): string
+    public static function getDefaultFontName()
     {
         return self::$defaultFontName;
     }
 
     /**
      * Set default font name.
+     *
+     * @param string $value
+     *
+     * @return bool
      */
-    public static function setDefaultFontName(string $value): bool
+    public static function setDefaultFontName($value)
     {
-        if (trim($value) !== '') {
+        if (is_string($value) && trim($value) !== '') {
             self::$defaultFontName = $value;
 
             return true;
@@ -341,7 +380,7 @@ class Settings
     /**
      * Get default font size.
      *
-     * @return float|int
+     * @return int
      */
     public static function getDefaultFontSize()
     {
@@ -351,11 +390,14 @@ class Settings
     /**
      * Set default font size.
      *
-     * @param null|float|int $value
+     * @param int $value
+     *
+     * @return bool
      */
-    public static function setDefaultFontSize($value): bool
+    public static function setDefaultFontSize($value)
     {
-        if ((is_int($value) || is_float($value)) && (int) $value > 0) {
+        $value = (int) $value;
+        if ($value > 0) {
             self::$defaultFontSize = $value;
 
             return true;
@@ -366,8 +408,12 @@ class Settings
 
     /**
      * Load setting from phpword.yml or phpword.yml.dist.
+     *
+     * @param string $filename
+     *
+     * @return array
      */
-    public static function loadConfig(?string $filename = null): array
+    public static function loadConfig($filename = null)
     {
         // Get config file
         $configFile = null;
@@ -409,18 +455,24 @@ class Settings
 
     /**
      * Get default paper.
+     *
+     * @return string
      */
-    public static function getDefaultPaper(): string
+    public static function getDefaultPaper()
     {
         return self::$defaultPaper;
     }
 
     /**
      * Set default paper.
+     *
+     * @param string $value
+     *
+     * @return bool
      */
-    public static function setDefaultPaper(string $value): bool
+    public static function setDefaultPaper($value)
     {
-        if (trim($value) !== '') {
+        if (is_string($value) && trim($value) !== '') {
             self::$defaultPaper = $value;
 
             return true;

--- a/src/PhpWord/Settings.php
+++ b/src/PhpWord/Settings.php
@@ -2,10 +2,8 @@
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
- *
  * PHPWord is free software distributed under the terms of the GNU Lesser
  * General Public License version 3 as published by the Free Software Foundation.
- *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
@@ -29,48 +27,46 @@ class Settings
      *
      * @const string
      */
-    const ZIPARCHIVE = 'ZipArchive';
-    const PCLZIP = 'PclZip';
-    const OLD_LIB = \PhpOffice\PhpWord\Shared\ZipArchive::class; // @deprecated 0.11
+    public const ZIPARCHIVE = 'ZipArchive';
+    public const PCLZIP = 'PclZip';
+    public const OLD_LIB = \PhpOffice\PhpWord\Shared\ZipArchive::class; // @deprecated 0.11
 
     /**
      * PDF rendering libraries.
      *
      * @const string
      */
-    const PDF_RENDERER_DOMPDF = 'DomPDF';
-    const PDF_RENDERER_TCPDF = 'TCPDF';
-    const PDF_RENDERER_MPDF = 'MPDF';
+    public const PDF_RENDERER_DOMPDF = 'DomPDF';
+    public const PDF_RENDERER_TCPDF = 'TCPDF';
+    public const PDF_RENDERER_MPDF = 'MPDF';
 
     /**
      * Measurement units multiplication factor.
-     *
      * Applied to:
      * - Section: margins, header/footer height, gutter, column spacing
      * - Tab: position
      * - Indentation: left, right, firstLine, hanging
-     * - Spacing: before, after
+     * - Spacing: before, after.
      *
      * @const string
      */
-    const UNIT_TWIP = 'twip'; // = 1/20 point
-    const UNIT_CM = 'cm';
-    const UNIT_MM = 'mm';
-    const UNIT_INCH = 'inch';
-    const UNIT_POINT = 'point'; // = 1/72 inch
-    const UNIT_PICA = 'pica'; // = 1/6 inch = 12 points
+    public const UNIT_TWIP = 'twip'; // = 1/20 point
+    public const UNIT_CM = 'cm';
+    public const UNIT_MM = 'mm';
+    public const UNIT_INCH = 'inch';
+    public const UNIT_POINT = 'point'; // = 1/72 inch
+    public const UNIT_PICA = 'pica'; // = 1/6 inch = 12 points
 
     /**
      * Default font settings.
-     *
      * OOXML defined font size values in halfpoints, i.e. twice of what PhpWord
      * use, and the conversion will be conducted during XML writing.
      */
-    const DEFAULT_FONT_NAME = 'Arial';
-    const DEFAULT_FONT_SIZE = 10;
-    const DEFAULT_FONT_COLOR = '000000';
-    const DEFAULT_FONT_CONTENT_TYPE = 'default'; // default|eastAsia|cs
-    const DEFAULT_PAPER = 'A4';
+    public const DEFAULT_FONT_NAME = 'Arial';
+    public const DEFAULT_FONT_SIZE = 10;
+    public const DEFAULT_FONT_COLOR = '000000';
+    public const DEFAULT_FONT_CONTENT_TYPE = 'default'; // default|eastAsia|cs
+    public const DEFAULT_PAPER = 'A4';
 
     /**
      * Compatibility option for XMLWriter.
@@ -89,21 +85,21 @@ class Settings
     /**
      * Name of the external Library used for rendering PDF files.
      *
-     * @var string
+     * @var null|string
      */
     private static $pdfRendererName;
 
     /**
      * Directory Path to the external Library used for rendering PDF files.
      *
-     * @var string
+     * @var null|string
      */
     private static $pdfRendererPath;
 
     /**
      * Measurement unit.
      *
-     * @var float|int
+     * @var string
      */
     private static $measurementUnit = self::UNIT_TWIP;
 
@@ -117,7 +113,7 @@ class Settings
     /**
      * Default font size.
      *
-     * @var int
+     * @var float|int
      */
     private static $defaultFontSize = self::DEFAULT_FONT_SIZE;
 
@@ -148,23 +144,17 @@ class Settings
      *
      * @return bool Compatibility
      */
-    public static function hasCompatibility()
+    public static function hasCompatibility(): bool
     {
         return self::$xmlWriterCompatibility;
     }
 
     /**
      * Set the compatibility option used by the XMLWriter.
-     *
-     * This sets the setIndent and setIndentString for better compatibility
-     *
-     * @param bool $compatibility
-     *
-     * @return bool
+     * This sets the setIndent and setIndentString for better compatibility.
      */
-    public static function setCompatibility($compatibility)
+    public static function setCompatibility(bool $compatibility): bool
     {
-        $compatibility = (bool) $compatibility;
         self::$xmlWriterCompatibility = $compatibility;
 
         return true;
@@ -172,22 +162,16 @@ class Settings
 
     /**
      * Get zip handler class.
-     *
-     * @return string
      */
-    public static function getZipClass()
+    public static function getZipClass(): string
     {
         return self::$zipClass;
     }
 
     /**
      * Set zip handler class.
-     *
-     * @param  string $zipClass
-     *
-     * @return bool
      */
-    public static function setZipClass($zipClass)
+    public static function setZipClass(string $zipClass): bool
     {
         if (in_array($zipClass, [self::PCLZIP, self::ZIPARCHIVE, self::OLD_LIB])) {
             self::$zipClass = $zipClass;
@@ -201,12 +185,9 @@ class Settings
     /**
      * Set details of the external library for rendering PDF files.
      *
-     * @param string $libraryName
-     * @param string $libraryBaseDir
-     *
      * @return bool Success or failure
      */
-    public static function setPdfRenderer($libraryName, $libraryBaseDir)
+    public static function setPdfRenderer(string $libraryName, string $libraryBaseDir): bool
     {
         if (!self::setPdfRendererName($libraryName)) {
             return false;
@@ -217,22 +198,16 @@ class Settings
 
     /**
      * Return the PDF Rendering Library.
-     *
-     * @return string
      */
-    public static function getPdfRendererName()
+    public static function getPdfRendererName(): ?string
     {
         return self::$pdfRendererName;
     }
 
     /**
      * Identify the external library to use for rendering PDF files.
-     *
-     * @param string $libraryName
-     *
-     * @return bool
      */
-    public static function setPdfRendererName($libraryName)
+    public static function setPdfRendererName(?string $libraryName): bool
     {
         $pdfRenderers = [self::PDF_RENDERER_DOMPDF, self::PDF_RENDERER_TCPDF, self::PDF_RENDERER_MPDF];
         if (!in_array($libraryName, $pdfRenderers)) {
@@ -245,10 +220,8 @@ class Settings
 
     /**
      * Return the directory path to the PDF Rendering Library.
-     *
-     * @return string
      */
-    public static function getPdfRendererPath()
+    public static function getPdfRendererPath(): ?string
     {
         return self::$pdfRendererPath;
     }
@@ -256,11 +229,11 @@ class Settings
     /**
      * Location of external library to use for rendering PDF files.
      *
-     * @param string $libraryBaseDir Directory path to the library's base folder
+     * @param null|string $libraryBaseDir Directory path to the library's base folder
      *
      * @return bool Success or failure
      */
-    public static function setPdfRendererPath($libraryBaseDir)
+    public static function setPdfRendererPath(?string $libraryBaseDir): bool
     {
         if (!$libraryBaseDir || false === file_exists($libraryBaseDir) || false === is_readable($libraryBaseDir)) {
             return false;
@@ -272,25 +245,25 @@ class Settings
 
     /**
      * Get measurement unit.
-     *
-     * @return string
      */
-    public static function getMeasurementUnit()
+    public static function getMeasurementUnit(): string
     {
         return self::$measurementUnit;
     }
 
     /**
      * Set measurement unit.
-     *
-     * @param string $value
-     *
-     * @return bool
      */
-    public static function setMeasurementUnit($value)
+    public static function setMeasurementUnit(string $value): bool
     {
-        $units = [self::UNIT_TWIP, self::UNIT_CM, self::UNIT_MM, self::UNIT_INCH,
-            self::UNIT_POINT, self::UNIT_PICA, ];
+        $units = [
+            self::UNIT_TWIP,
+            self::UNIT_CM,
+            self::UNIT_MM,
+            self::UNIT_INCH,
+            self::UNIT_POINT,
+            self::UNIT_PICA,
+        ];
         if (!in_array($value, $units)) {
             return false;
         }
@@ -302,11 +275,11 @@ class Settings
     /**
      * Sets the user defined path to temporary directory.
      *
-     * @since 0.12.0
-     *
      * @param string $tempDir The user defined path to temporary directory
+     *
+     * @since 0.12.0
      */
-    public static function setTempDir($tempDir): void
+    public static function setTempDir(string $tempDir): void
     {
         self::$tempDir = $tempDir;
     }
@@ -315,10 +288,8 @@ class Settings
      * Returns path to temporary directory.
      *
      * @since 0.12.0
-     *
-     * @return string
      */
-    public static function getTempDir()
+    public static function getTempDir(): string
     {
         if (!empty(self::$tempDir)) {
             $tempDir = self::$tempDir;
@@ -331,44 +302,34 @@ class Settings
 
     /**
      * @since 0.13.0
-     *
-     * @return bool
      */
-    public static function isOutputEscapingEnabled()
+    public static function isOutputEscapingEnabled(): bool
     {
         return self::$outputEscapingEnabled;
     }
 
     /**
      * @since 0.13.0
-     *
-     * @param bool $outputEscapingEnabled
      */
-    public static function setOutputEscapingEnabled($outputEscapingEnabled): void
+    public static function setOutputEscapingEnabled(bool $outputEscapingEnabled): void
     {
         self::$outputEscapingEnabled = $outputEscapingEnabled;
     }
 
     /**
      * Get default font name.
-     *
-     * @return string
      */
-    public static function getDefaultFontName()
+    public static function getDefaultFontName(): string
     {
         return self::$defaultFontName;
     }
 
     /**
      * Set default font name.
-     *
-     * @param string $value
-     *
-     * @return bool
      */
-    public static function setDefaultFontName($value)
+    public static function setDefaultFontName(string $value): bool
     {
-        if (is_string($value) && trim($value) !== '') {
+        if (trim($value) !== '') {
             self::$defaultFontName = $value;
 
             return true;
@@ -380,7 +341,7 @@ class Settings
     /**
      * Get default font size.
      *
-     * @return int
+     * @return float|int
      */
     public static function getDefaultFontSize()
     {
@@ -390,14 +351,11 @@ class Settings
     /**
      * Set default font size.
      *
-     * @param int $value
-     *
-     * @return bool
+     * @param null|float|int $value
      */
-    public static function setDefaultFontSize($value)
+    public static function setDefaultFontSize($value): bool
     {
-        $value = (float) $value;
-        if ($value > 0) {
+        if ((is_int($value) || is_float($value)) && (int) $value > 0) {
             self::$defaultFontSize = $value;
 
             return true;
@@ -408,12 +366,8 @@ class Settings
 
     /**
      * Load setting from phpword.yml or phpword.yml.dist.
-     *
-     * @param string $filename
-     *
-     * @return array
      */
-    public static function loadConfig($filename = null)
+    public static function loadConfig(?string $filename = null): array
     {
         // Get config file
         $configFile = null;
@@ -455,24 +409,18 @@ class Settings
 
     /**
      * Get default paper.
-     *
-     * @return string
      */
-    public static function getDefaultPaper()
+    public static function getDefaultPaper(): string
     {
         return self::$defaultPaper;
     }
 
     /**
      * Set default paper.
-     *
-     * @param string $value
-     *
-     * @return bool
      */
-    public static function setDefaultPaper($value)
+    public static function setDefaultPaper(string $value): bool
     {
-        if (is_string($value) && trim($value) !== '') {
+        if (trim($value) !== '') {
             self::$defaultPaper = $value;
 
             return true;

--- a/src/PhpWord/Style/TextBox.php
+++ b/src/PhpWord/Style/TextBox.php
@@ -2,10 +2,8 @@
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
- *
  * PHPWord is free software distributed under the terms of the GNU Lesser
  * General Public License version 3 as published by the Free Software Foundation.
- *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
@@ -27,121 +25,128 @@ class TextBox extends Image
     /**
      * margin top.
      *
-     * @var int
+     * @var null|int
      */
     private $innerMarginTop;
 
     /**
      * margin left.
      *
-     * @var int
+     * @var null|int
      */
     private $innerMarginLeft;
 
     /**
      * margin right.
      *
-     * @var int
+     * @var null|int
      */
     private $innerMarginRight;
 
     /**
      * Cell margin bottom.
      *
-     * @var int
+     * @var null|int
      */
     private $innerMarginBottom;
 
     /**
      * border size.
      *
-     * @var int
+     * @var null|int
      */
     private $borderSize;
 
     /**
      * border color.
      *
-     * @var string
+     * @var null|string
      */
     private $borderColor;
 
     /**
-     * Set margin top.
+     * background color.
      *
-     * @param int $value
+     * @var null|string
      */
-    public function setInnerMarginTop($value = null): void
+    private $bgColor;
+
+    /**
+     * Set background color.
+     */
+    public function setBgColor(?string $value = null): void
+    {
+        $this->bgColor = $value;
+    }
+
+    /**
+     * Get background color.
+     */
+    public function getBgColor(): ?string
+    {
+        return $this->bgColor;
+    }
+
+    /**
+     * Set margin top.
+     */
+    public function setInnerMarginTop(?int $value = null): void
     {
         $this->innerMarginTop = $value;
     }
 
     /**
      * Get margin top.
-     *
-     * @return int
      */
-    public function getInnerMarginTop()
+    public function getInnerMarginTop(): ?int
     {
         return $this->innerMarginTop;
     }
 
     /**
      * Set margin left.
-     *
-     * @param int $value
      */
-    public function setInnerMarginLeft($value = null): void
+    public function setInnerMarginLeft(?int $value = null): void
     {
         $this->innerMarginLeft = $value;
     }
 
     /**
      * Get margin left.
-     *
-     * @return int
      */
-    public function getInnerMarginLeft()
+    public function getInnerMarginLeft(): ?int
     {
         return $this->innerMarginLeft;
     }
 
     /**
      * Set margin right.
-     *
-     * @param int $value
      */
-    public function setInnerMarginRight($value = null): void
+    public function setInnerMarginRight(?int $value = null): void
     {
         $this->innerMarginRight = $value;
     }
 
     /**
      * Get margin right.
-     *
-     * @return int
      */
-    public function getInnerMarginRight()
+    public function getInnerMarginRight(): ?int
     {
         return $this->innerMarginRight;
     }
 
     /**
      * Set margin bottom.
-     *
-     * @param int $value
      */
-    public function setInnerMarginBottom($value = null): void
+    public function setInnerMarginBottom(?int $value = null): void
     {
         $this->innerMarginBottom = $value;
     }
 
     /**
      * Get margin bottom.
-     *
-     * @return int
      */
-    public function getInnerMarginBottom()
+    public function getInnerMarginBottom(): ?int
     {
         return $this->innerMarginBottom;
     }
@@ -149,9 +154,9 @@ class TextBox extends Image
     /**
      * Set TLRB cell margin.
      *
-     * @param int $value Margin in twips
+     * @param null|int $value Margin in twips
      */
-    public function setInnerMargin($value = null): void
+    public function setInnerMargin(?int $value = null): void
     {
         $this->setInnerMarginTop($value);
         $this->setInnerMarginLeft($value);
@@ -164,17 +169,15 @@ class TextBox extends Image
      *
      * @return int[]
      */
-    public function getInnerMargin()
+    public function getInnerMargin(): array
     {
         return [$this->innerMarginLeft, $this->innerMarginTop, $this->innerMarginRight, $this->innerMarginBottom];
     }
 
     /**
      * Has inner margin?
-     *
-     * @return bool
      */
-    public function hasInnerMargins()
+    public function hasInnerMargins(): bool
     {
         $hasInnerMargins = false;
         $margins = $this->getInnerMargin();
@@ -191,39 +194,33 @@ class TextBox extends Image
     /**
      * Set border size.
      *
-     * @param int $value Size in points
+     * @param null|int $value Size in points
      */
-    public function setBorderSize($value = null): void
+    public function setBorderSize(?int $value = null): void
     {
         $this->borderSize = $value;
     }
 
     /**
      * Get border size.
-     *
-     * @return int
      */
-    public function getBorderSize()
+    public function getBorderSize(): ?int
     {
         return $this->borderSize;
     }
 
     /**
      * Set border color.
-     *
-     * @param string $value
      */
-    public function setBorderColor($value = null): void
+    public function setBorderColor(?string $value = null): void
     {
         $this->borderColor = $value;
     }
 
     /**
      * Get border color.
-     *
-     * @return string
      */
-    public function getBorderColor()
+    public function getBorderColor(): ?string
     {
         return $this->borderColor;
     }

--- a/src/PhpWord/Writer/Word2007/Element/TextBox.php
+++ b/src/PhpWord/Writer/Word2007/Element/TextBox.php
@@ -2,10 +2,8 @@
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
- *
  * PHPWord is free software distributed under the terms of the GNU Lesser
  * General Public License version 3 as published by the Free Software Foundation.
- *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
@@ -49,6 +47,10 @@ class TextBox extends Image
         $xmlWriter->startElement('w:pict');
         $xmlWriter->startElement('v:shape');
         $xmlWriter->writeAttribute('type', '#_x0000_t0202');
+
+        if ($style->getBgColor()) {
+            $xmlWriter->writeAttribute('fillcolor', $style->getBgColor());
+        }
 
         $styleWriter->write();
         $styleWriter->writeBorder();

--- a/src/PhpWord/Writer/Word2007/Style/TextBox.php
+++ b/src/PhpWord/Writer/Word2007/Style/TextBox.php
@@ -2,10 +2,8 @@
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
- *
  * PHPWord is free software distributed under the terms of the GNU Lesser
  * General Public License version 3 as published by the Free Software Foundation.
- *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.

--- a/tests/PhpWordTests/SettingsTest.php
+++ b/tests/PhpWordTests/SettingsTest.php
@@ -2,10 +2,8 @@
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
- *
  * PHPWord is free software distributed under the terms of the GNU Lesser
  * General Public License version 3 as published by the Free Software Foundation.
- *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
@@ -19,15 +17,15 @@ namespace PhpOffice\PhpWordTests;
 
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Settings;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpOffice\PhpWord\Settings.
  *
  * @coversDefaultClass \PhpOffice\PhpWord\Settings
- *
  * @runTestsInSeparateProcesses
  */
-class SettingsTest extends \PHPUnit\Framework\TestCase
+class SettingsTest extends TestCase
 {
     private $compatibility;
 
@@ -151,7 +149,6 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::getTempDir
      * @covers ::setTempDir
-     *
      * @depends testPhpTempDirIsUsedByDefault
      */
     public function testTempDirCanBeSet(): void
@@ -189,6 +186,12 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         self::assertEquals(12, Settings::getDefaultFontSize());
         self::assertFalse(Settings::setDefaultFontSize(null));
         self::assertEquals(12, Settings::getDefaultFontSize());
+        self::assertTrue(Settings::setDefaultFontSize(12.5));
+        self::assertEquals(12.5, Settings::getDefaultFontSize());
+        self::assertFalse(Settings::setDefaultFontSize(0.5));
+        self::assertEquals(12.5, Settings::getDefaultFontSize());
+        self::assertFalse(Settings::setDefaultFontSize(0));
+        self::assertEquals(12.5, Settings::getDefaultFontSize());
     }
 
     /**

--- a/tests/PhpWordTests/Style/TextBoxTest.php
+++ b/tests/PhpWordTests/Style/TextBoxTest.php
@@ -2,10 +2,8 @@
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
- *
  * PHPWord is free software distributed under the terms of the GNU Lesser
  * General Public License version 3 as published by the Free Software Foundation.
- *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
@@ -20,15 +18,15 @@ namespace PhpOffice\PhpWordTests\Style;
 use InvalidArgumentException;
 use PhpOffice\PhpWord\SimpleType\Jc;
 use PhpOffice\PhpWord\Style\TextBox;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpOffice\PhpWord\Style\Image.
  *
  * @coversDefaultClass \PhpOffice\PhpWord\Style\Image
- *
  * @runTestsInSeparateProcesses
  */
-class TextBoxTest extends \PHPUnit\Framework\TestCase
+class TextBoxTest extends TestCase
 {
     /**
      * Test setting style with normal value.
@@ -55,6 +53,7 @@ class TextBoxTest extends \PHPUnit\Framework\TestCase
             'innerMarginLeft' => '5',
             'borderSize' => '2',
             'borderColor' => 'red',
+            'bgColor' => 'blue',
         ];
         foreach ($properties as $key => $value) {
             $set = "set{$key}";
@@ -89,6 +88,7 @@ class TextBoxTest extends \PHPUnit\Framework\TestCase
             'innerMarginLeft' => '5',
             'borderSize' => '2',
             'borderColor' => 'red',
+            'bgColor' => 'blue',
         ];
         foreach ($properties as $key => $value) {
             $get = "get{$key}";
@@ -304,5 +304,16 @@ class TextBoxTest extends \PHPUnit\Framework\TestCase
         $object = new TextBox();
         $object->setBorderColor($expected);
         self::assertEquals($expected, $object->getBorderColor());
+    }
+
+    /**
+     * Test set/get bgColor.
+     */
+    public function testSetGetBgColor(): void
+    {
+        $expected = 'blue';
+        $object = new TextBox();
+        $object->setBgColor($expected);
+        self::assertEquals($expected, $object->getBgColor());
     }
 }

--- a/tests/PhpWordTests/Writer/Word2007/Part/DocumentTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/Part/DocumentTest.php
@@ -2,10 +2,8 @@
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
- *
  * PHPWord is free software distributed under the terms of the GNU Lesser
  * General Public License version 3 as published by the Free Software Foundation.
- *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
@@ -61,11 +59,11 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $doc = TestHelperDOCX::getDocument($phpWord);
         self::assertNotNull($doc);
 
-//         $this->assertTrue($doc->elementExists('/Properties/property[name="key1"]/vt:lpwstr'));
-//         $this->assertTrue($doc->elementExists('/Properties/property[name="key2"]/vt:bool'));
-//         $this->assertTrue($doc->elementExists('/Properties/property[name="key3"]/vt:i4'));
-//         $this->assertTrue($doc->elementExists('/Properties/property[name="key4"]/vt:r8'));
-//         $this->assertTrue($doc->elementExists('/Properties/property[name="key5"]/vt:lpwstr'));
+        //         $this->assertTrue($doc->elementExists('/Properties/property[name="key1"]/vt:lpwstr'));
+        //         $this->assertTrue($doc->elementExists('/Properties/property[name="key2"]/vt:bool'));
+        //         $this->assertTrue($doc->elementExists('/Properties/property[name="key3"]/vt:i4'));
+        //         $this->assertTrue($doc->elementExists('/Properties/property[name="key4"]/vt:r8'));
+        //         $this->assertTrue($doc->elementExists('/Properties/property[name="key5"]/vt:lpwstr'));
     }
 
     /**
@@ -408,7 +406,13 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         // behind
         $element = $doc->getElement('/w:document/w:body/w:p[2]/w:r/w:pict/v:shape');
         $style = $element->getAttribute('style');
-        self::assertRegExp('/z\-index:\-[0-9]*/', $style);
+
+        // Try to address CI coverage issue for PHP 7.1 and 7.2 when using regex match assertions
+        if (method_exists(static::class, 'assertRegExp')) {
+            self::assertRegExp('/z\-index:\-[0-9]*/', $style);
+        } else {
+            self::assertMatchesRegularExpression('/z\-index:\-[0-9]*/', $style);
+        }
 
         // square
         $element = $doc->getElement('/w:document/w:body/w:p[4]/w:r/w:pict/v:shape/w10:wrap');
@@ -551,7 +555,13 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $cell->addText('Test');
 
         $doc = TestHelperDOCX::getDocument($phpWord);
-        self::assertEquals(Cell::DEFAULT_BORDER_COLOR, $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc/w:tcPr/w:tcBorders/w:top', 'w:color'));
+        self::assertEquals(
+            Cell::DEFAULT_BORDER_COLOR,
+            $doc->getElementAttribute(
+                '/w:document/w:body/w:tbl/w:tr/w:tc/w:tcPr/w:tcBorders/w:top',
+                'w:color'
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
### Description

Word supports fractional font sizes like 8.5pt, but PHPWord doesn't.

Fixes # (issue)

That fractional font size ist not supported as default font size, while font style elements support fractional font size.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
