### PR TITLE
Add background color support for text box element for Word writer

### DIFF
--- a/src/PhpWord/Style/TextBox.php
+++ b/src/PhpWord/Style/TextBox.php
@@ -65,6 +65,33 @@ class TextBox extends Image
      * @var string
      */
     private $borderColor;
+    
+    /**
+     * background color
+     *
+     * @var string
+     */
+    private $bgColor;
+
+    /**
+     * Set background color
+     *
+     * @param string $value
+     */
+    public function setBgColor($value = null)
+    {
+        $this->bgColor = $value;
+    }
+
+    /**
+     * Get background color
+     *
+     * @return string
+     */
+    public function getBgColor()
+    {
+        return $this->bgColor;
+    }
 
     /**
      * Set margin top.

--- a/src/PhpWord/Style/TextBox.php
+++ b/src/PhpWord/Style/TextBox.php
@@ -65,7 +65,7 @@ class TextBox extends Image
      * @var string
      */
     private $borderColor;
-    
+
     /**
      * background color.
      *
@@ -78,7 +78,7 @@ class TextBox extends Image
      *
      * @param string $value
      */
-    public function setBgColor($value = null)
+    public function setBgColor($value = null): void
     {
         $this->bgColor = $value;
     }

--- a/src/PhpWord/Style/TextBox.php
+++ b/src/PhpWord/Style/TextBox.php
@@ -9,6 +9,7 @@
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
  *
  * @see         https://github.com/PHPOffice/PHPWord
+ *
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
@@ -72,19 +73,14 @@ class TextBox extends Image
 
     /**
      * Set background color.
-     *
-     * @param null|string $value
-     * @return void
      */
-    public function setBgColor(string $value = null): void
+    public function setBgColor(?string $value = null): void
     {
         $this->bgColor = $value;
     }
 
     /**
      * Get background color.
-     *
-     * @return null|string
      */
     public function getBgColor(): ?string
     {
@@ -93,19 +89,14 @@ class TextBox extends Image
 
     /**
      * Set margin top.
-     *
-     * @param null|int $value
-     * @return void
      */
-    public function setInnerMarginTop(int $value = null): void
+    public function setInnerMarginTop(?int $value = null): void
     {
         $this->innerMarginTop = $value;
     }
 
     /**
      * Get margin top.
-     *
-     * @return null|int
      */
     public function getInnerMarginTop(): ?int
     {
@@ -114,19 +105,14 @@ class TextBox extends Image
 
     /**
      * Set margin left.
-     *
-     * @param null|int $value
-     * @return void
      */
-    public function setInnerMarginLeft(int $value = null): void
+    public function setInnerMarginLeft(?int $value = null): void
     {
         $this->innerMarginLeft = $value;
     }
 
     /**
      * Get margin left.
-     *
-     * @return null|int
      */
     public function getInnerMarginLeft(): ?int
     {
@@ -135,19 +121,14 @@ class TextBox extends Image
 
     /**
      * Set margin right.
-     *
-     * @param null|int $value
-     * @return void
      */
-    public function setInnerMarginRight(int $value = null): void
+    public function setInnerMarginRight(?int $value = null): void
     {
         $this->innerMarginRight = $value;
     }
 
     /**
      * Get margin right.
-     *
-     * @return null|int
      */
     public function getInnerMarginRight(): ?int
     {
@@ -156,19 +137,14 @@ class TextBox extends Image
 
     /**
      * Set margin bottom.
-     *
-     * @param null|int $value
-     * @return void
      */
-    public function setInnerMarginBottom(int $value = null): void
+    public function setInnerMarginBottom(?int $value = null): void
     {
         $this->innerMarginBottom = $value;
     }
 
     /**
      * Get margin bottom.
-     *
-     * @return null|int
      */
     public function getInnerMarginBottom(): ?int
     {
@@ -179,9 +155,8 @@ class TextBox extends Image
      * Set TLRB cell margin.
      *
      * @param null|int $value Margin in twips
-     * @return void
      */
-    public function setInnerMargin(int $value = null): void
+    public function setInnerMargin(?int $value = null): void
     {
         $this->setInnerMarginTop($value);
         $this->setInnerMarginLeft($value);
@@ -201,8 +176,6 @@ class TextBox extends Image
 
     /**
      * Has inner margin?
-     *
-     * @return bool
      */
     public function hasInnerMargins(): bool
     {
@@ -222,38 +195,30 @@ class TextBox extends Image
      * Set border size.
      *
      * @param null|int $value Size in points
-     * @return void
      */
-    public function setBorderSize(int $value = null): void
+    public function setBorderSize(?int $value = null): void
     {
         $this->borderSize = $value;
     }
 
     /**
      * Get border size.
-     *
-     * @return int
      */
-    public function getBorderSize(): int
+    public function getBorderSize(): ?int
     {
         return $this->borderSize;
     }
 
     /**
      * Set border color.
-     *
-     * @param null|string $value
-     * @return void
      */
-    public function setBorderColor(string $value = null): void
+    public function setBorderColor(?string $value = null): void
     {
         $this->borderColor = $value;
     }
 
     /**
      * Get border color.
-     *
-     * @return null|string
      */
     public function getBorderColor(): ?string
     {

--- a/src/PhpWord/Style/TextBox.php
+++ b/src/PhpWord/Style/TextBox.php
@@ -2,16 +2,13 @@
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
- *
  * PHPWord is free software distributed under the terms of the GNU Lesser
  * General Public License version 3 as published by the Free Software Foundation.
- *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
  *
  * @see         https://github.com/PHPOffice/PHPWord
- *
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
@@ -27,58 +24,59 @@ class TextBox extends Image
     /**
      * margin top.
      *
-     * @var int
+     * @var null|int
      */
     private $innerMarginTop;
 
     /**
      * margin left.
      *
-     * @var int
+     * @var null|int
      */
     private $innerMarginLeft;
 
     /**
      * margin right.
      *
-     * @var int
+     * @var null|int
      */
     private $innerMarginRight;
 
     /**
      * Cell margin bottom.
      *
-     * @var int
+     * @var null|int
      */
     private $innerMarginBottom;
 
     /**
      * border size.
      *
-     * @var int
+     * @var null|int
      */
     private $borderSize;
 
     /**
      * border color.
      *
-     * @var string
+     * @var null|string
      */
     private $borderColor;
 
     /**
      * background color.
      *
-     * @var string
+     * @var null|string
      */
     private $bgColor;
 
     /**
      * Set background color.
      *
-     * @param string $value
+     * @param null|string $value
+     * @return void
      */
-    public function setBgColor($value = null): void
+    public function setBgColor(string $value = null): void
     {
         $this->bgColor = $value;
     }
@@ -86,9 +84,9 @@ class TextBox extends Image
     /**
      * Get background color.
      *
-     * @return string
+     * @return null|string
      */
-    public function getBgColor()
+    public function getBgColor(): ?string
     {
         return $this->bgColor;
     }
@@ -96,9 +94,10 @@ class TextBox extends Image
     /**
      * Set margin top.
      *
-     * @param int $value
+     * @param null|int $value
+     * @return void
      */
-    public function setInnerMarginTop($value = null): void
+    public function setInnerMarginTop(int $value = null): void
     {
         $this->innerMarginTop = $value;
     }
@@ -106,9 +105,9 @@ class TextBox extends Image
     /**
      * Get margin top.
      *
-     * @return int
+     * @return null|int
      */
-    public function getInnerMarginTop()
+    public function getInnerMarginTop(): ?int
     {
         return $this->innerMarginTop;
     }
@@ -116,9 +115,10 @@ class TextBox extends Image
     /**
      * Set margin left.
      *
-     * @param int $value
+     * @param null|int $value
+     * @return void
      */
-    public function setInnerMarginLeft($value = null): void
+    public function setInnerMarginLeft(int $value = null): void
     {
         $this->innerMarginLeft = $value;
     }
@@ -126,9 +126,9 @@ class TextBox extends Image
     /**
      * Get margin left.
      *
-     * @return int
+     * @return null|int
      */
-    public function getInnerMarginLeft()
+    public function getInnerMarginLeft(): ?int
     {
         return $this->innerMarginLeft;
     }
@@ -136,9 +136,10 @@ class TextBox extends Image
     /**
      * Set margin right.
      *
-     * @param int $value
+     * @param null|int $value
+     * @return void
      */
-    public function setInnerMarginRight($value = null): void
+    public function setInnerMarginRight(int $value = null): void
     {
         $this->innerMarginRight = $value;
     }
@@ -146,9 +147,9 @@ class TextBox extends Image
     /**
      * Get margin right.
      *
-     * @return int
+     * @return null|int
      */
-    public function getInnerMarginRight()
+    public function getInnerMarginRight(): ?int
     {
         return $this->innerMarginRight;
     }
@@ -156,9 +157,10 @@ class TextBox extends Image
     /**
      * Set margin bottom.
      *
-     * @param int $value
+     * @param null|int $value
+     * @return void
      */
-    public function setInnerMarginBottom($value = null): void
+    public function setInnerMarginBottom(int $value = null): void
     {
         $this->innerMarginBottom = $value;
     }
@@ -166,9 +168,9 @@ class TextBox extends Image
     /**
      * Get margin bottom.
      *
-     * @return int
+     * @return null|int
      */
-    public function getInnerMarginBottom()
+    public function getInnerMarginBottom(): ?int
     {
         return $this->innerMarginBottom;
     }
@@ -176,9 +178,10 @@ class TextBox extends Image
     /**
      * Set TLRB cell margin.
      *
-     * @param int $value Margin in twips
+     * @param null|int $value Margin in twips
+     * @return void
      */
-    public function setInnerMargin($value = null): void
+    public function setInnerMargin(int $value = null): void
     {
         $this->setInnerMarginTop($value);
         $this->setInnerMarginLeft($value);
@@ -191,7 +194,7 @@ class TextBox extends Image
      *
      * @return int[]
      */
-    public function getInnerMargin()
+    public function getInnerMargin(): array
     {
         return [$this->innerMarginLeft, $this->innerMarginTop, $this->innerMarginRight, $this->innerMarginBottom];
     }
@@ -201,7 +204,7 @@ class TextBox extends Image
      *
      * @return bool
      */
-    public function hasInnerMargins()
+    public function hasInnerMargins(): bool
     {
         $hasInnerMargins = false;
         $margins = $this->getInnerMargin();
@@ -218,9 +221,10 @@ class TextBox extends Image
     /**
      * Set border size.
      *
-     * @param int $value Size in points
+     * @param null|int $value Size in points
+     * @return void
      */
-    public function setBorderSize($value = null): void
+    public function setBorderSize(int $value = null): void
     {
         $this->borderSize = $value;
     }
@@ -230,7 +234,7 @@ class TextBox extends Image
      *
      * @return int
      */
-    public function getBorderSize()
+    public function getBorderSize(): int
     {
         return $this->borderSize;
     }
@@ -238,9 +242,10 @@ class TextBox extends Image
     /**
      * Set border color.
      *
-     * @param string $value
+     * @param null|string $value
+     * @return void
      */
-    public function setBorderColor($value = null): void
+    public function setBorderColor(string $value = null): void
     {
         $this->borderColor = $value;
     }
@@ -248,9 +253,9 @@ class TextBox extends Image
     /**
      * Get border color.
      *
-     * @return string
+     * @return null|string
      */
-    public function getBorderColor()
+    public function getBorderColor(): ?string
     {
         return $this->borderColor;
     }

--- a/src/PhpWord/Style/TextBox.php
+++ b/src/PhpWord/Style/TextBox.php
@@ -67,14 +67,14 @@ class TextBox extends Image
     private $borderColor;
     
     /**
-     * background color
+     * background color.
      *
      * @var string
      */
     private $bgColor;
 
     /**
-     * Set background color
+     * Set background color.
      *
      * @param string $value
      */
@@ -84,7 +84,7 @@ class TextBox extends Image
     }
 
     /**
-     * Get background color
+     * Get background color.
      *
      * @return string
      */

--- a/src/PhpWord/Writer/Word2007/Element/TextBox.php
+++ b/src/PhpWord/Writer/Word2007/Element/TextBox.php
@@ -25,8 +25,6 @@ class TextBox extends Image
 {
     /**
      * Write element.
-     *
-     * @return void
      */
     public function write(): void
     {

--- a/src/PhpWord/Writer/Word2007/Element/TextBox.php
+++ b/src/PhpWord/Writer/Word2007/Element/TextBox.php
@@ -50,6 +50,9 @@ class TextBox extends Image
         $xmlWriter->startElement('v:shape');
         $xmlWriter->writeAttribute('type', '#_x0000_t0202');
 
+        if ($style->getBgColor()) {
+            $xmlWriter->writeAttribute('fillcolor', $style->getBgColor());
+        }
         $styleWriter->write();
         $styleWriter->writeBorder();
 

--- a/src/PhpWord/Writer/Word2007/Element/TextBox.php
+++ b/src/PhpWord/Writer/Word2007/Element/TextBox.php
@@ -9,6 +9,7 @@
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
  *
  * @see         https://github.com/PHPOffice/PHPWord
+ *
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
@@ -30,13 +31,13 @@ class TextBox extends Image
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (! $element instanceof \PhpOffice\PhpWord\Element\TextBox) {
+        if (!$element instanceof \PhpOffice\PhpWord\Element\TextBox) {
             return;
         }
         $style = $element->getStyle();
         $styleWriter = new TextBoxStyleWriter($xmlWriter, $style);
 
-        if (! $this->withoutP) {
+        if (!$this->withoutP) {
             $xmlWriter->startElement('w:p');
             $styleWriter->writeAlignment();
         }

--- a/src/PhpWord/Writer/Word2007/Element/TextBox.php
+++ b/src/PhpWord/Writer/Word2007/Element/TextBox.php
@@ -2,16 +2,13 @@
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
- *
  * PHPWord is free software distributed under the terms of the GNU Lesser
  * General Public License version 3 as published by the Free Software Foundation.
- *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
  *
  * @see         https://github.com/PHPOffice/PHPWord
- *
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
@@ -28,18 +25,20 @@ class TextBox extends Image
 {
     /**
      * Write element.
+     *
+     * @return void
      */
     public function write(): void
     {
         $xmlWriter = $this->getXmlWriter();
         $element = $this->getElement();
-        if (!$element instanceof \PhpOffice\PhpWord\Element\TextBox) {
+        if (! $element instanceof \PhpOffice\PhpWord\Element\TextBox) {
             return;
         }
         $style = $element->getStyle();
         $styleWriter = new TextBoxStyleWriter($xmlWriter, $style);
 
-        if (!$this->withoutP) {
+        if (! $this->withoutP) {
             $xmlWriter->startElement('w:p');
             $styleWriter->writeAlignment();
         }
@@ -53,6 +52,7 @@ class TextBox extends Image
         if ($style->getBgColor()) {
             $xmlWriter->writeAttribute('fillcolor', $style->getBgColor());
         }
+
         $styleWriter->write();
         $styleWriter->writeBorder();
 

--- a/src/PhpWord/Writer/Word2007/Style/TextBox.php
+++ b/src/PhpWord/Writer/Word2007/Style/TextBox.php
@@ -28,6 +28,7 @@ class TextBox extends Frame
 {
     /**
      * Writer inner margin.
+     * @return void
      */
     public function writeInnerMargin(): void
     {
@@ -44,6 +45,7 @@ class TextBox extends Frame
 
     /**
      * Writer border.
+     * @return void
      */
     public function writeBorder(): void
     {

--- a/src/PhpWord/Writer/Word2007/Style/TextBox.php
+++ b/src/PhpWord/Writer/Word2007/Style/TextBox.php
@@ -9,6 +9,7 @@
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
  *
  * @see         https://github.com/PHPOffice/PHPWord
+ *
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
@@ -29,7 +30,7 @@ class TextBox extends Frame
     public function writeInnerMargin(): void
     {
         $style = $this->getStyle();
-        if (! $style instanceof TextBoxStyle || ! $style->hasInnerMargins()) {
+        if (!$style instanceof TextBoxStyle || !$style->hasInnerMargins()) {
             return;
         }
 
@@ -45,7 +46,7 @@ class TextBox extends Frame
     public function writeBorder(): void
     {
         $style = $this->getStyle();
-        if (! $style instanceof TextBoxStyle) {
+        if (!$style instanceof TextBoxStyle) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();

--- a/src/PhpWord/Writer/Word2007/Style/TextBox.php
+++ b/src/PhpWord/Writer/Word2007/Style/TextBox.php
@@ -2,16 +2,13 @@
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
- *
  * PHPWord is free software distributed under the terms of the GNU Lesser
  * General Public License version 3 as published by the Free Software Foundation.
- *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
  *
  * @see         https://github.com/PHPOffice/PHPWord
- *
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
@@ -28,12 +25,11 @@ class TextBox extends Frame
 {
     /**
      * Writer inner margin.
-     * @return void
      */
     public function writeInnerMargin(): void
     {
         $style = $this->getStyle();
-        if (!$style instanceof TextBoxStyle || !$style->hasInnerMargins()) {
+        if (! $style instanceof TextBoxStyle || ! $style->hasInnerMargins()) {
             return;
         }
 
@@ -45,12 +41,11 @@ class TextBox extends Frame
 
     /**
      * Writer border.
-     * @return void
      */
     public function writeBorder(): void
     {
         $style = $this->getStyle();
-        if (!$style instanceof TextBoxStyle) {
+        if (! $style instanceof TextBoxStyle) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();

--- a/tests/PhpWordTests/Style/TextBoxTest.php
+++ b/tests/PhpWordTests/Style/TextBoxTest.php
@@ -2,16 +2,13 @@
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
- *
  * PHPWord is free software distributed under the terms of the GNU Lesser
  * General Public License version 3 as published by the Free Software Foundation.
- *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
  *
  * @see         https://github.com/PHPOffice/PHPWord
- *
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
@@ -20,15 +17,15 @@ namespace PhpOffice\PhpWordTests\Style;
 use InvalidArgumentException;
 use PhpOffice\PhpWord\SimpleType\Jc;
 use PhpOffice\PhpWord\Style\TextBox;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpOffice\PhpWord\Style\Image.
  *
  * @coversDefaultClass \PhpOffice\PhpWord\Style\Image
- *
  * @runTestsInSeparateProcesses
  */
-class TextBoxTest extends \PHPUnit\Framework\TestCase
+class TextBoxTest extends TestCase
 {
     /**
      * Test setting style with normal value.
@@ -38,23 +35,24 @@ class TextBoxTest extends \PHPUnit\Framework\TestCase
         $object = new TextBox();
 
         $properties = [
-            'width' => 200,
-            'height' => 200,
-            'alignment' => Jc::START,
-            'marginTop' => 240,
-            'marginLeft' => 240,
-            'wrappingStyle' => 'inline',
-            'positioning' => 'absolute',
-            'posHorizontal' => 'center',
-            'posVertical' => 'top',
-            'posHorizontalRel' => 'margin',
-            'posVerticalRel' => 'page',
-            'innerMarginTop' => '5',
-            'innerMarginRight' => '5',
+            'width'             => 200,
+            'height'            => 200,
+            'alignment'         => Jc::START,
+            'marginTop'         => 240,
+            'marginLeft'        => 240,
+            'wrappingStyle'     => 'inline',
+            'positioning'       => 'absolute',
+            'posHorizontal'     => 'center',
+            'posVertical'       => 'top',
+            'posHorizontalRel'  => 'margin',
+            'posVerticalRel'    => 'page',
+            'innerMarginTop'    => '5',
+            'innerMarginRight'  => '5',
             'innerMarginBottom' => '5',
-            'innerMarginLeft' => '5',
-            'borderSize' => '2',
-            'borderColor' => 'red',
+            'innerMarginLeft'   => '5',
+            'borderSize'        => '2',
+            'borderColor'       => 'red',
+            'bgColor'           => 'blue',
         ];
         foreach ($properties as $key => $value) {
             $set = "set{$key}";
@@ -72,23 +70,24 @@ class TextBoxTest extends \PHPUnit\Framework\TestCase
         $object = new TextBox();
 
         $properties = [
-            'width' => 200,
-            'height' => 200,
-            'alignment' => Jc::START,
-            'marginTop' => 240,
-            'marginLeft' => 240,
-            'wrappingStyle' => 'inline',
-            'positioning' => 'absolute',
-            'posHorizontal' => 'center',
-            'posVertical' => 'top',
-            'posHorizontalRel' => 'margin',
-            'posVerticalRel' => 'page',
-            'innerMarginTop' => '5',
-            'innerMarginRight' => '5',
+            'width'             => 200,
+            'height'            => 200,
+            'alignment'         => Jc::START,
+            'marginTop'         => 240,
+            'marginLeft'        => 240,
+            'wrappingStyle'     => 'inline',
+            'positioning'       => 'absolute',
+            'posHorizontal'     => 'center',
+            'posVertical'       => 'top',
+            'posHorizontalRel'  => 'margin',
+            'posVerticalRel'    => 'page',
+            'innerMarginTop'    => '5',
+            'innerMarginRight'  => '5',
             'innerMarginBottom' => '5',
-            'innerMarginLeft' => '5',
-            'borderSize' => '2',
-            'borderColor' => 'red',
+            'innerMarginLeft'   => '5',
+            'borderSize'        => '2',
+            'borderColor'       => 'red',
+            'bgColor'           => 'blue',
         ];
         foreach ($properties as $key => $value) {
             $get = "get{$key}";
@@ -304,5 +303,16 @@ class TextBoxTest extends \PHPUnit\Framework\TestCase
         $object = new TextBox();
         $object->setBorderColor($expected);
         self::assertEquals($expected, $object->getBorderColor());
+    }
+
+    /**
+     * Test set/get bgColor.
+     */
+    public function testSetGetBgColor(): void
+    {
+        $expected = 'blue';
+        $object = new TextBox();
+        $object->setBgColor($expected);
+        self::assertEquals($expected, $object->getBgColor());
     }
 }

--- a/tests/PhpWordTests/Style/TextBoxTest.php
+++ b/tests/PhpWordTests/Style/TextBoxTest.php
@@ -9,6 +9,7 @@
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
  *
  * @see         https://github.com/PHPOffice/PHPWord
+ *
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
@@ -35,24 +36,24 @@ class TextBoxTest extends TestCase
         $object = new TextBox();
 
         $properties = [
-            'width'             => 200,
-            'height'            => 200,
-            'alignment'         => Jc::START,
-            'marginTop'         => 240,
-            'marginLeft'        => 240,
-            'wrappingStyle'     => 'inline',
-            'positioning'       => 'absolute',
-            'posHorizontal'     => 'center',
-            'posVertical'       => 'top',
-            'posHorizontalRel'  => 'margin',
-            'posVerticalRel'    => 'page',
-            'innerMarginTop'    => '5',
-            'innerMarginRight'  => '5',
+            'width' => 200,
+            'height' => 200,
+            'alignment' => Jc::START,
+            'marginTop' => 240,
+            'marginLeft' => 240,
+            'wrappingStyle' => 'inline',
+            'positioning' => 'absolute',
+            'posHorizontal' => 'center',
+            'posVertical' => 'top',
+            'posHorizontalRel' => 'margin',
+            'posVerticalRel' => 'page',
+            'innerMarginTop' => '5',
+            'innerMarginRight' => '5',
             'innerMarginBottom' => '5',
-            'innerMarginLeft'   => '5',
-            'borderSize'        => '2',
-            'borderColor'       => 'red',
-            'bgColor'           => 'blue',
+            'innerMarginLeft' => '5',
+            'borderSize' => '2',
+            'borderColor' => 'red',
+            'bgColor' => 'blue',
         ];
         foreach ($properties as $key => $value) {
             $set = "set{$key}";
@@ -70,24 +71,24 @@ class TextBoxTest extends TestCase
         $object = new TextBox();
 
         $properties = [
-            'width'             => 200,
-            'height'            => 200,
-            'alignment'         => Jc::START,
-            'marginTop'         => 240,
-            'marginLeft'        => 240,
-            'wrappingStyle'     => 'inline',
-            'positioning'       => 'absolute',
-            'posHorizontal'     => 'center',
-            'posVertical'       => 'top',
-            'posHorizontalRel'  => 'margin',
-            'posVerticalRel'    => 'page',
-            'innerMarginTop'    => '5',
-            'innerMarginRight'  => '5',
+            'width' => 200,
+            'height' => 200,
+            'alignment' => Jc::START,
+            'marginTop' => 240,
+            'marginLeft' => 240,
+            'wrappingStyle' => 'inline',
+            'positioning' => 'absolute',
+            'posHorizontal' => 'center',
+            'posVertical' => 'top',
+            'posHorizontalRel' => 'margin',
+            'posVerticalRel' => 'page',
+            'innerMarginTop' => '5',
+            'innerMarginRight' => '5',
             'innerMarginBottom' => '5',
-            'innerMarginLeft'   => '5',
-            'borderSize'        => '2',
-            'borderColor'       => 'red',
-            'bgColor'           => 'blue',
+            'innerMarginLeft' => '5',
+            'borderSize' => '2',
+            'borderColor' => 'red',
+            'bgColor' => 'blue',
         ];
         foreach ($properties as $key => $value) {
             $get = "get{$key}";

--- a/tests/PhpWordTests/Writer/Word2007/Part/DocumentTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/Part/DocumentTest.php
@@ -2,10 +2,8 @@
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
- *
  * PHPWord is free software distributed under the terms of the GNU Lesser
  * General Public License version 3 as published by the Free Software Foundation.
- *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
@@ -61,11 +59,11 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $doc = TestHelperDOCX::getDocument($phpWord);
         self::assertNotNull($doc);
 
-//         $this->assertTrue($doc->elementExists('/Properties/property[name="key1"]/vt:lpwstr'));
-//         $this->assertTrue($doc->elementExists('/Properties/property[name="key2"]/vt:bool'));
-//         $this->assertTrue($doc->elementExists('/Properties/property[name="key3"]/vt:i4'));
-//         $this->assertTrue($doc->elementExists('/Properties/property[name="key4"]/vt:r8'));
-//         $this->assertTrue($doc->elementExists('/Properties/property[name="key5"]/vt:lpwstr'));
+        //         $this->assertTrue($doc->elementExists('/Properties/property[name="key1"]/vt:lpwstr'));
+        //         $this->assertTrue($doc->elementExists('/Properties/property[name="key2"]/vt:bool'));
+        //         $this->assertTrue($doc->elementExists('/Properties/property[name="key3"]/vt:i4'));
+        //         $this->assertTrue($doc->elementExists('/Properties/property[name="key4"]/vt:r8'));
+        //         $this->assertTrue($doc->elementExists('/Properties/property[name="key5"]/vt:lpwstr'));
     }
 
     /**
@@ -408,7 +406,13 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         // behind
         $element = $doc->getElement('/w:document/w:body/w:p[2]/w:r/w:pict/v:shape');
         $style = $element->getAttribute('style');
-        self::assertMatchesRegularExpression('/z\-index:\-[0-9]*/', $style);
+
+        // Try to address CI coverage issue for PHP 7.1 and 7.2 when using regex match assertions
+        if (method_exists(static::class, 'assertRegExp')) {
+            self::assertRegExp('/z\-index:\-[0-9]*/', $style);
+        } else {
+            self::assertMatchesRegularExpression('/z\-index:\-[0-9]*/', $style);
+        }
 
         // square
         $element = $doc->getElement('/w:document/w:body/w:p[4]/w:r/w:pict/v:shape/w10:wrap');
@@ -551,7 +555,13 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $cell->addText('Test');
 
         $doc = TestHelperDOCX::getDocument($phpWord);
-        self::assertEquals(Cell::DEFAULT_BORDER_COLOR, $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc/w:tcPr/w:tcBorders/w:top', 'w:color'));
+        self::assertEquals(
+            Cell::DEFAULT_BORDER_COLOR,
+            $doc->getElementAttribute(
+                '/w:document/w:body/w:tbl/w:tr/w:tc/w:tcPr/w:tcBorders/w:top',
+                'w:color'
+            )
+        );
     }
 
     /**

--- a/tests/PhpWordTests/Writer/Word2007/Part/DocumentTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/Part/DocumentTest.php
@@ -408,7 +408,7 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         // behind
         $element = $doc->getElement('/w:document/w:body/w:p[2]/w:r/w:pict/v:shape');
         $style = $element->getAttribute('style');
-        self::assertRegExp('/z\-index:\-[0-9]*/', $style);
+        self::assertMatchesRegularExpression('/z\-index:\-[0-9]*/', $style);
 
         // square
         $element = $doc->getElement('/w:document/w:body/w:p[4]/w:r/w:pict/v:shape/w10:wrap');


### PR DESCRIPTION
### Description

It is now possible to fill the background color of text box elements (only Word2007 writer!). There is no documentation for the Textbox element, so I can't add the changes.

Fixes # (issue)

No bugfix.

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
