### PR TITLE
Update Settings.php

### DIFF
--- a/src/PhpWord/Settings.php
+++ b/src/PhpWord/Settings.php
@@ -80,7 +80,7 @@ class Settings
      *
      * @var string
      */
-    private static $zipClass = self::ZIPARCHIVE;
+    private static $zipClass = self::PCLZIP;
 
     /**
      * Name of the external Library used for rendering PDF files.


### PR DESCRIPTION
### Description

When trying to run the class the file did not open, displaying the zip error. To avoid future inconveniences, resolve help in the project, correcting this small flaw. During the research I discovered that it was necessary to change the constant ZIPARCHIVE to PCLZIP.
Fixes # (issue)

### Checklist:

- [ X] I have run `composer run-script check --timeout=0` and no errors were reported
- [ X] The new code is covered by unit tests (check build/coverage for coverage report)
- [ X] I have updated the documentation to describe the changes
