### PR TITLE
Update Html.php to enable choice of leading method.

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -60,7 +60,7 @@ class Html
      * @param bool $fullHTML If it's a full HTML, no need to add 'body' tag
      * @param bool $preserveWhiteSpace If false, the whitespaces between nodes will be removed
      */
-    public static function addHtml($element, $html, $fullHTML = false, $preserveWhiteSpace = true, $options = null): void
+    public static function addHtml($element, $html, $fullHTML = false, $preserveWhiteSpace = true, $options = null, $loadHtml = false): void
     {
         /*
          * @todo parse $stylesheet for default styles.  Should result in an array based on id, class and element,
@@ -86,7 +86,7 @@ class Html
         }
         $dom = new DOMDocument();
         $dom->preserveWhiteSpace = $preserveWhiteSpace;
-        $dom->loadXML($html);
+        $loadHtml ? $dom->loadHTML($html) : $dom->loadXML($html);
         static::$xpath = new DOMXPath($dom);
         $node = $dom->getElementsByTagName('body');
 


### PR DESCRIPTION
The current loadXML() rejects valid self-closing elements from HTML. The problem can be fixed in a backwards compatible way by adding a new boolean argument to choose which loading method to use.

### Description

Self-closing tags like <br> and <img> are valid in HTML but not in XML. Loading the DOM via loadHTML() solves the current problem with the static function addHtml(). Since the loading method is a choice that depends on the caller, a new boolean argument is added to control which method will be used, defaulting to the current behaviour which is to use loadXML().

Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
