### PR TITLE
= Fix images when doing word to pdf

### DIFF
--- a/src/PhpWord/Shared/ZipArchive.php
+++ b/src/PhpWord/Shared/ZipArchive.php
@@ -142,6 +142,15 @@ class ZipArchive
             if ($flags === null) {
                 $flags = 0;
             }
+            
+            // when doing word to PDF for some reason phpword deletes the file it's using before finishing and makes images explode
+            $fileSize = filesize($this->filename);
+
+            if ($fileSize == 0 && file_exists($this->filename . "_fallback")) {
+                $this->filename = $this->filename . "_fallback";
+            } else if (str_contains($this->filename, "pdf_") && $fileSize > 0) {
+                copy($this->filename, $this->filename . "_fallback");
+            }
 
             $result = $zip->open($this->filename, $flags);
 


### PR DESCRIPTION
### Description

This is a bit stupid because i fixed it a while ago and now i don't have the example file to demo it:

The problem that i had was that PHPWord exploded for some docx files that had images, saying that the image was missing. Opening the docx like a zip showed that the image was in fact there, it was PHPWord the one deleting it. Maybe the file was using the image several times and PHPWord deletes it after applying it once or something.

I wasn't able to make a proper fix, so i made this work around that makes a copy of the file and restores it if it detects it's missing.

I don't expect it to be merged, just hoping someone had the same issue and may be able to use it on it's own or provide a demo file so the real error can be traced and fixed.
