### PR TITLE
Fix wrong mimetype for docx files

### DIFF
--- a/src/PhpWord/Writer/Word2007.php
+++ b/src/PhpWord/Writer/Word2007.php
@@ -52,14 +52,15 @@ class Word2007 extends AbstractWriter implements WriterInterface
         $this->setPhpWord($phpWord);
 
         // Create parts
+        // The first four files need to be in this order for Mimetype detection to work
         $this->parts = [
             'ContentTypes' => '[Content_Types].xml',
             'Rels' => '_rels/.rels',
+            'RelsDocument' => 'word/_rels/document.xml.rels',
+            'Document' => 'word/document.xml',
             'DocPropsApp' => 'docProps/app.xml',
             'DocPropsCore' => 'docProps/core.xml',
             'DocPropsCustom' => 'docProps/custom.xml',
-            'RelsDocument' => 'word/_rels/document.xml.rels',
-            'Document' => 'word/document.xml',
             'Comments' => 'word/comments.xml',
             'Styles' => 'word/styles.xml',
             'Numbering' => 'word/numbering.xml',

--- a/tests/PhpWordTests/Writer/Word2007Test.php
+++ b/tests/PhpWordTests/Writer/Word2007Test.php
@@ -17,6 +17,7 @@
 
 namespace PhpOffice\PhpWordTests\Writer;
 
+use finfo;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\SimpleType\Jc;
 use PhpOffice\PhpWord\Writer\Word2007;
@@ -191,5 +192,26 @@ class Word2007Test extends AbstractWebServerEmbeddedTest
 
         $object = new Word2007();
         $object->setUseDiskCaching(true, $dir);
+    }
+
+    /**
+     * File is detected as Word 2007.
+     */
+    public function testMime(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $section->addText('Test 1');
+
+        $writer = new Word2007($phpWord);
+        $file = __DIR__ . '/../_files/temp.docx';
+        $writer->save($file);
+
+        $finfo = new finfo(FILEINFO_MIME_TYPE);
+        $mime = $finfo->file($file);
+
+        self::assertEquals('application/vnd.openxmlformats-officedocument.wordprocessingml.document', $mime);
+
+        unlink($file);
     }
 }


### PR DESCRIPTION
### Description

This PR seeks to resolve #1753, allowing files created by the word2007 writer to be detected as word files and not `application/octet-stream`. I ran into this issue while working on file upload using Laravel's build-in file validation.

Based on [this magic file](https://github.com/file/file/blob/50713f02b46825baf243bc5ae0a167f2b2b323f1/magic/Magdir/msooxml), I've deduced how the word file mimetype is detected.

The file needs to be a zip, inside the first two filenames need to match a regex, then the 3rd and 4th filenames are inspected to see what path they start with. When either matches `word/` the file is determined to be a word 2007 file.  
Before this process would find _docProps/_, which does pass the regex, but not match an office mimetype, causing the file to get the type MSOOXML `application/octet-stream`.

I've added a passing test to ensure this does not pop up again.  
I am unsure what documentation needs to be updated for a bugfix.

Fixes #1753 

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
