### PR TITLE
Hotfix: In headings hyperlinks are ignored. Added w:hyperlink to xpath filter

### DIFF
--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -151,7 +151,11 @@ abstract class AbstractPart
         } elseif ($headingDepth !== null) {
             // Heading or Title
             $textContent = null;
-            $nodes = $xmlReader->getElements('w:r', $domNode);
+            // 2023-08-02 hannes@dorn.cc
+            // $nodes = $xmlReader->getElements('w:r', $domNode);
+            // delivers only text paragraphs, but no hyperlinks
+            // I extended xpath with w:hyperlink
+            $nodes = $xmlReader->getElements('w:r|w:hyperlink', $domNode);
             if ($nodes->length === 1) {
                 $textContent = htmlspecialchars($xmlReader->getValue('w:t', $nodes->item(0)), ENT_QUOTES, 'UTF-8');
             } else {

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -151,10 +151,6 @@ abstract class AbstractPart
         } elseif ($headingDepth !== null) {
             // Heading or Title
             $textContent = null;
-            // 2023-08-02 hannes@dorn.cc
-            // $nodes = $xmlReader->getElements('w:r', $domNode);
-            // delivers only text paragraphs, but no hyperlinks
-            // I extended xpath with w:hyperlink
             $nodes = $xmlReader->getElements('w:r|w:hyperlink', $domNode);
             if ($nodes->length === 1) {
                 $textContent = htmlspecialchars($xmlReader->getValue('w:t', $nodes->item(0)), ENT_QUOTES, 'UTF-8');


### PR DESCRIPTION
### Description

PHPWord is ignoring hyperlinks in headings.
In src\PhpWord\Reader\Word2007\AbstractPart.php only w:r elements are read.

Fixes #1792

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
