### PR TITLE
 Fix PHP 8.2 deprecated about Allow access to an undefined property

### DIFF
--- a/src/PhpWord/Reader/MsDoc.php
+++ b/src/PhpWord/Reader/MsDoc.php
@@ -58,6 +58,16 @@ class MsDoc extends AbstractReader implements ReaderInterface
     private $dataObjectPool;
 
     /**
+     * Object Stream.
+     */
+    private $_SummaryInformation;
+
+    /**
+     * Object Stream.
+     */
+    private $_DocumentSummaryInformation;
+
+    /**
      * @var stdClass[]
      */
     private $arrayCharacters = [];

--- a/src/PhpWord/Shared/OLERead.php
+++ b/src/PhpWord/Shared/OLERead.php
@@ -61,6 +61,17 @@ class OLERead
     public $wrkObjectPool = null;
     public $summaryInformation = null;
     public $docSummaryInfos = null;
+    public $numBigBlockDepotBlocks = null;
+    public $rootStartBlock = null;
+    public $sbdStartBlock = null;
+    public $extensionBlock = null;
+    public $numExtensionBlocks = null;
+    public $bigBlockChain = null;
+    public $smallBlockChain = null;	
+    public $entry = null;	
+    public $rootentry = null;
+    public $wrkObjectPoolelseif = null;
+    public $props = array();	
 
     /**
      * Read the file


### PR DESCRIPTION
### Description
Since PHP 8.2 release Access to an undefined property into an object raise deprecated 

### Checklist:

- [x] php bin/phpstan analyse phpoffice -l 7 --error-format=raw
- [x] The new code is passed

