### PR TITLE
Support for PHP 8.2

### DIFF
--- a/src/PhpWord/Shared/Text.php
+++ b/src/PhpWord/Shared/Text.php
@@ -64,7 +64,7 @@ class Text
             self::buildControlCharacters();
         }
 
-        return str_replace(array_values(self::$controlCharacters), array_keys(self::$controlCharacters), $value);
+        return ($value==null) ? '' : str_replace(array_values(self::$controlCharacters), array_keys(self::$controlCharacters), $value);
     }
 
     /**
@@ -145,7 +145,7 @@ class Text
     public static function toUTF8($value = '')
     {
         if (null !== $value && !self::isUTF8($value)) {
-            $value = utf8_encode($value);
+            $value = mb_convert_encoding($value,'UTF-8',mb_detect_encoding($value,'UTF-8'));
         }
 
         return $value;

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -257,7 +257,7 @@ class TemplateProcessor
     protected static function ensureUtf8Encoded($subject)
     {
         if (!Text::isUTF8($subject) && null !== $subject) {
-            $subject = utf8_encode($subject);
+            $subject = mb_convert_encoding($subject,'UTF-8',mb_detect_encoding($subject,'UTF-8'));
         }
 
         return (null !== $subject) ? $subject : '';


### PR DESCRIPTION
### Description

Fixes for calls to **utf8_encode** and calls to PhpOffice\PhpWord\Shared\Text function **controlCharacterPHP2OOXML** so as to support PHP 8.2.

Fixes # (issue)

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
