### PR TITLE
TemplateProcessor : Fixed choose dimention for Float Value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Word2007 Reader : Read hyperlingks in headings by @hannesdorn in #2433
 - PclZip : strtr using empty string by @spl1nes in #2432
 - Fixed PHP 8.2 deprecated about Allow access to an undefined property by @DAdq26 in #2440
+- Template Processor : Fixed choose dimention for Float Value by @gdevilbat in #2449
 
 ### Miscellaneous
 

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -437,7 +437,7 @@ class TemplateProcessor
         if (null === $value && isset($inlineValue)) {
             $value = $inlineValue;
         }
-        if (!preg_match('/^([0-9]*(cm|mm|in|pt|pc|px|%|em|ex|)|auto)$/i', $value ?? '')) {
+        if (!preg_match('/^([0-9.]*(cm|mm|in|pt|pc|px|%|em|ex|)|auto)$/i', $value ?? '')) {
             $value = null;
         }
         if (null === $value) {


### PR DESCRIPTION
### Description

When Set Value Image into Float value, regex cant find dot character.

Initial PR : #2415 by @gdevilbat 

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
