### PR TITLE
Word2007 Reader : Added option to disable loading images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Word2007 Reader/Writer : Added noWrap table cell property by @kernusr in #2359
 - HTML Reader : Support for `font-variant: small-caps` by @cambraca in #2117
 - Improved TextDirection for styling a cell by @terryzwt in #2429
+- Word2007 Reader : Added option to disable loading images by @aelliott1485 in #2450
 ### Bug fixes
 
 - Fixed wrong mimetype for docx files by @gamerlv in #2416

--- a/src/PhpWord/Reader/AbstractReader.php
+++ b/src/PhpWord/Reader/AbstractReader.php
@@ -43,6 +43,13 @@ abstract class AbstractReader implements ReaderInterface
     protected $fileHandle;
 
     /**
+     * Load images.
+     *
+     * @var bool
+     */
+    protected $imageLoading = true;
+
+    /**
      * Read data only?
      *
      * @return bool
@@ -63,6 +70,18 @@ abstract class AbstractReader implements ReaderInterface
     public function setReadDataOnly($value = true)
     {
         $this->readDataOnly = $value;
+
+        return $this;
+    }
+
+    public function hasImageLoading(): bool
+    {
+        return $this->imageLoading;
+    }
+
+    public function setImageLoading(bool $value): self
+    {
+        $this->imageLoading = $value;
 
         return $this;
     }

--- a/src/PhpWord/Reader/Word2007.php
+++ b/src/PhpWord/Reader/Word2007.php
@@ -94,6 +94,7 @@ class Word2007 extends AbstractReader implements ReaderInterface
         if (class_exists($partClass)) {
             /** @var \PhpOffice\PhpWord\Reader\Word2007\AbstractPart $part Type hint */
             $part = new $partClass($docFile, $xmlFile);
+            $part->setImageLoading($this->hasImageLoading());
             $part->setRels($relationships);
             $part->read($phpWord);
         }

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -68,6 +68,13 @@ abstract class AbstractPart
     protected $rels = [];
 
     /**
+     * Image Loading.
+     *
+     * @var bool
+     */
+    protected $imageLoading = true;
+
+    /**
      * Read part.
      */
     abstract public function read(PhpWord $phpWord);
@@ -92,6 +99,18 @@ abstract class AbstractPart
     public function setRels($value): void
     {
         $this->rels = $value;
+    }
+
+    public function setImageLoading(bool $value): self
+    {
+        $this->imageLoading = $value;
+
+        return $this;
+    }
+
+    public function hasImageLoading(): bool
+    {
+        return $this->imageLoading;
     }
 
     /**
@@ -249,7 +268,7 @@ abstract class AbstractPart
             // Image
             $rId = $xmlReader->getAttribute('r:id', $node, 'v:shape/v:imagedata');
             $target = $this->getMediaTarget($docPart, $rId);
-            if (null !== $target) {
+            if ($this->hasImageLoading() && null !== $target) {
                 if ('External' == $this->getTargetMode($docPart, $rId)) {
                     $imageSource = $target;
                 } else {
@@ -271,7 +290,7 @@ abstract class AbstractPart
                 $embedId = $xmlReader->getAttribute('r:embed', $node, 'wp:anchor/a:graphic/a:graphicData/pic:pic/pic:blipFill/a:blip');
             }
             $target = $this->getMediaTarget($docPart, $embedId);
-            if (null !== $target) {
+            if ($this->hasImageLoading() && null !== $target) {
                 $imageSource = "zip://{$this->docFile}#{$target}";
                 $parent->addImage($imageSource, null, false, $name);
             }

--- a/src/PhpWord/Style/Language.php
+++ b/src/PhpWord/Style/Language.php
@@ -256,7 +256,9 @@ final class Language extends AbstractStyle
         if ($locale !== null && strlen($locale) === 2) {
             return strtolower($locale) . '-' . strtoupper($locale);
         }
-
+        if ($locale === 'und') {
+            return 'en-EN';
+        }
         if ($locale !== null && $locale !== 'zxx' && strstr($locale, '-') === false) {
             throw new InvalidArgumentException($locale . ' is not a valid language code');
         }


### PR DESCRIPTION
### Description

Word2007 Reader : Added option to disable loading images

Based on PR #2369 by @aelliott1485 

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
