### PR TITLE
HTML Writer : Added border-spacing to default styles for table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - HTML Reader : Support for `font-variant: small-caps` by @cambraca in #2117
 - Improved TextDirection for styling a cell by @terryzwt in #2429
 - Word2007 Reader : Added option to disable loading images by @aelliott1485 in #2450
+- HTML Writer : Added border-spacing to default styles for table by @kernusr in #2451
+
 ### Bug fixes
 
 - Fixed wrong mimetype for docx files by @gamerlv in #2416

--- a/src/PhpWord/Writer/HTML/Part/Head.php
+++ b/src/PhpWord/Writer/HTML/Part/Head.php
@@ -101,6 +101,7 @@ class Head extends AbstractPart
             'table' => [
                 'border' => '1px solid black',
                 'border-spacing' => '0px',
+	            'border-collapse' => 'collapse',
                 'width ' => '100%',
             ],
             'td' => [

--- a/src/PhpWord/Writer/HTML/Part/Head.php
+++ b/src/PhpWord/Writer/HTML/Part/Head.php
@@ -101,7 +101,7 @@ class Head extends AbstractPart
             'table' => [
                 'border' => '1px solid black',
                 'border-spacing' => '0px',
-	            'border-collapse' => 'collapse',
+                'border-collapse' => 'collapse',
                 'width ' => '100%',
             ],
             'td' => [


### PR DESCRIPTION
### Description

Added border-spacing to default styles in HTML Writer

Based on PR #2335 by @kernusr 

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
