### PR TITLE
Word2007 Reader : Support for table cell borders and margins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Improved TextDirection for styling a cell by @terryzwt in #2429
 - Word2007 Reader : Added option to disable loading images by @aelliott1485 in #2450
 - HTML Writer : Added border-spacing to default styles for table by @kernusr in #2451
+- Word2007 Reader : Support for table cell borders and margins by @kernusr in #2454
 
 ### Bug fixes
 

--- a/src/PhpWord/Style/Border.php
+++ b/src/PhpWord/Style/Border.php
@@ -22,6 +22,8 @@ namespace PhpOffice\PhpWord\Style;
  */
 class Border extends AbstractStyle
 {
+    const DEFAULT_MARGIN = 1440;           // In twips.
+
     /**
      * Border Top Size.
      *
@@ -105,6 +107,34 @@ class Border extends AbstractStyle
      * @var string
      */
     protected $borderBottomStyle;
+
+    /**
+     * Top margin spacing.
+     *
+     * @var float|int
+     */
+    protected $marginTop = self::DEFAULT_MARGIN;
+
+    /**
+     * Left margin spacing.
+     *
+     * @var float|int
+     */
+    protected $marginLeft = self::DEFAULT_MARGIN;
+
+    /**
+     * Right margin spacing.
+     *
+     * @var float|int
+     */
+    protected $marginRight = self::DEFAULT_MARGIN;
+
+    /**
+     * Bottom margin spacing.
+     *
+     * @var float|int
+     */
+    protected $marginBottom = self::DEFAULT_MARGIN;
 
     /**
      * Get border size.
@@ -500,5 +530,101 @@ class Border extends AbstractStyle
         $borders = $this->getBorderSize();
 
         return $borders !== array_filter($borders, 'is_null');
+    }
+
+    /**
+     * Get Margin Top.
+     *
+     * @return float|int
+     */
+    public function getMarginTop()
+    {
+        return $this->marginTop;
+    }
+
+    /**
+     * Set Margin Top.
+     *
+     * @param float|int $value
+     *
+     * @return self
+     */
+    public function setMarginTop($value = null)
+    {
+        $this->marginTop = $this->setNumericVal($value, self::DEFAULT_MARGIN);
+
+        return $this;
+    }
+
+    /**
+     * Get Margin Left.
+     *
+     * @return float|int
+     */
+    public function getMarginLeft()
+    {
+        return $this->marginLeft;
+    }
+
+    /**
+     * Set Margin Left.
+     *
+     * @param float|int $value
+     *
+     * @return self
+     */
+    public function setMarginLeft($value = null)
+    {
+        $this->marginLeft = $this->setNumericVal($value, self::DEFAULT_MARGIN);
+
+        return $this;
+    }
+
+    /**
+     * Get Margin Right.
+     *
+     * @return float|int
+     */
+    public function getMarginRight()
+    {
+        return $this->marginRight;
+    }
+
+    /**
+     * Set Margin Right.
+     *
+     * @param float|int $value
+     *
+     * @return self
+     */
+    public function setMarginRight($value = null)
+    {
+        $this->marginRight = $this->setNumericVal($value, self::DEFAULT_MARGIN);
+
+        return $this;
+    }
+
+    /**
+     * Get Margin Bottom.
+     *
+     * @return float|int
+     */
+    public function getMarginBottom()
+    {
+        return $this->marginBottom;
+    }
+
+    /**
+     * Set Margin Bottom.
+     *
+     * @param float|int $value
+     *
+     * @return self
+     */
+    public function setMarginBottom($value = null)
+    {
+        $this->marginBottom = $this->setNumericVal($value, self::DEFAULT_MARGIN);
+
+        return $this;
     }
 }

--- a/src/PhpWord/Style/Section.php
+++ b/src/PhpWord/Style/Section.php
@@ -40,7 +40,6 @@ class Section extends Border
      */
     const DEFAULT_WIDTH = 11905.511811024; // In twips.
     const DEFAULT_HEIGHT = 16837.79527559; // In twips.
-    const DEFAULT_MARGIN = 1440;           // In twips.
     const DEFAULT_GUTTER = 0;              // In twips.
     const DEFAULT_HEADER_HEIGHT = 720;     // In twips.
     const DEFAULT_FOOTER_HEIGHT = 720;     // In twips.
@@ -76,34 +75,6 @@ class Section extends Border
      * @var float|int
      */
     private $pageSizeH = self::DEFAULT_HEIGHT;
-
-    /**
-     * Top margin spacing.
-     *
-     * @var float|int
-     */
-    private $marginTop = self::DEFAULT_MARGIN;
-
-    /**
-     * Left margin spacing.
-     *
-     * @var float|int
-     */
-    private $marginLeft = self::DEFAULT_MARGIN;
-
-    /**
-     * Right margin spacing.
-     *
-     * @var float|int
-     */
-    private $marginRight = self::DEFAULT_MARGIN;
-
-    /**
-     * Bottom margin spacing.
-     *
-     * @var float|int
-     */
-    private $marginBottom = self::DEFAULT_MARGIN;
 
     /**
      * Page gutter spacing.
@@ -340,102 +311,6 @@ class Section extends Border
     public function setPageSizeH($value = null)
     {
         $this->pageSizeH = $this->setNumericVal($value, self::DEFAULT_HEIGHT);
-
-        return $this;
-    }
-
-    /**
-     * Get Margin Top.
-     *
-     * @return float|int
-     */
-    public function getMarginTop()
-    {
-        return $this->marginTop;
-    }
-
-    /**
-     * Set Margin Top.
-     *
-     * @param float|int $value
-     *
-     * @return self
-     */
-    public function setMarginTop($value = null)
-    {
-        $this->marginTop = $this->setNumericVal($value, self::DEFAULT_MARGIN);
-
-        return $this;
-    }
-
-    /**
-     * Get Margin Left.
-     *
-     * @return float|int
-     */
-    public function getMarginLeft()
-    {
-        return $this->marginLeft;
-    }
-
-    /**
-     * Set Margin Left.
-     *
-     * @param float|int $value
-     *
-     * @return self
-     */
-    public function setMarginLeft($value = null)
-    {
-        $this->marginLeft = $this->setNumericVal($value, self::DEFAULT_MARGIN);
-
-        return $this;
-    }
-
-    /**
-     * Get Margin Right.
-     *
-     * @return float|int
-     */
-    public function getMarginRight()
-    {
-        return $this->marginRight;
-    }
-
-    /**
-     * Set Margin Right.
-     *
-     * @param float|int $value
-     *
-     * @return self
-     */
-    public function setMarginRight($value = null)
-    {
-        $this->marginRight = $this->setNumericVal($value, self::DEFAULT_MARGIN);
-
-        return $this;
-    }
-
-    /**
-     * Get Margin Bottom.
-     *
-     * @return float|int
-     */
-    public function getMarginBottom()
-    {
-        return $this->marginBottom;
-    }
-
-    /**
-     * Set Margin Bottom.
-     *
-     * @param float|int $value
-     *
-     * @return self
-     */
-    public function setMarginBottom($value = null)
-    {
-        $this->marginBottom = $this->setNumericVal($value, self::DEFAULT_MARGIN);
 
         return $this;
     }

--- a/tests/PhpWordTests/Reader/Word2007/StyleTest.php
+++ b/tests/PhpWordTests/Reader/Word2007/StyleTest.php
@@ -17,6 +17,7 @@
 
 namespace PhpOffice\PhpWordTests\Reader\Word2007;
 
+use PhpOffice\PhpWord\SimpleType\Border;
 use PhpOffice\PhpWord\SimpleType\TblWidth;
 use PhpOffice\PhpWord\SimpleType\VerticalJc;
 use PhpOffice\PhpWord\Style;
@@ -49,28 +50,6 @@ class StyleTest extends AbstractTestReader
     }
 
     /**
-     * Test reading of cell spacing.
-     */
-    public function testReadCellSpacing(): void
-    {
-        $documentXml = '<w:tbl>
-            <w:tblPr>
-                <w:tblCellSpacing w:w="10.5" w:type="dxa"/>
-            </w:tblPr>
-        </w:tbl>';
-
-        $phpWord = $this->getDocumentFromString(['document' => $documentXml]);
-
-        $elements = $phpWord->getSection(0)->getElements();
-        self::assertInstanceOf('PhpOffice\PhpWord\Element\Table', $elements[0]);
-        self::assertInstanceOf('PhpOffice\PhpWord\Style\Table', $elements[0]->getStyle());
-        /** @var \PhpOffice\PhpWord\Style\Table $tableStyle */
-        $tableStyle = $elements[0]->getStyle();
-        self::assertEquals(TblWidth::AUTO, $tableStyle->getUnit());
-        self::assertEquals(10.5, $tableStyle->getCellSpacing());
-    }
-
-    /**
      * Test reading of table position.
      */
     public function testReadTablePosition(): void
@@ -100,6 +79,90 @@ class StyleTest extends AbstractTestReader
         self::assertEquals(50, $tableStyle->getTblpX());
         self::assertEquals(TablePosition::YALIGN_TOP, $tableStyle->getTblpYSpec());
         self::assertEquals(60, $tableStyle->getTblpY());
+    }
+
+    public function testReadTableCellNoWrap(): void
+    {
+        $documentXml = '<w:tbl>
+          <w:tr>
+            <w:tc>
+              <w:tcPr>
+                <w:noWrap />
+              </w:tcPr>
+            </w:tc>
+          </w:tr>
+        </w:tbl>';
+
+        $phpWord = $this->getDocumentFromString(['document' => $documentXml]);
+
+        $elements = $phpWord->getSection(0)->getElements();
+        self::assertInstanceOf('PhpOffice\PhpWord\Element\Table', $elements[0]);
+        $rows = $elements[0]->getRows();
+        $cells = $rows[0]->getCells();
+        self::assertTrue($cells[0]->getStyle()->getNoWrap());
+    }
+
+    /**
+     * Test reading of cell spacing.
+     */
+    public function testReadTableCellSpacing(): void
+    {
+        $documentXml = '<w:tbl>
+            <w:tblPr>
+                <w:tblCellSpacing w:w="10.5" w:type="dxa"/>
+            </w:tblPr>
+        </w:tbl>';
+
+        $phpWord = $this->getDocumentFromString(['document' => $documentXml]);
+
+        $elements = $phpWord->getSection(0)->getElements();
+        self::assertInstanceOf('PhpOffice\PhpWord\Element\Table', $elements[0]);
+        self::assertInstanceOf('PhpOffice\PhpWord\Style\Table', $elements[0]->getStyle());
+        /** @var \PhpOffice\PhpWord\Style\Table $tableStyle */
+        $tableStyle = $elements[0]->getStyle();
+        self::assertEquals(TblWidth::AUTO, $tableStyle->getUnit());
+        self::assertEquals(10.5, $tableStyle->getCellSpacing());
+    }
+
+    public function testReadTableCellStyle(): void
+    {
+        $documentXml = '<w:tbl>
+          <w:tr>
+            <w:tc>
+              <w:tcPr>
+                <w:tcBorders>
+                  <w:top w:val="single" w:sz="4" w:space="0" w:color="auto"/>
+                  <w:bottom w:val="double" w:sz="4" w:space="0" w:color="auto"/>
+                </w:tcBorders>
+                <w:tcMar>
+                  <w:top w:w="720" w:type="dxa"/>
+                  <w:start w:w="720" w:type="dxa"/>
+                  <w:bottom w:w="0" w:type="dxa"/>
+                  <w:end w:w="720" w:type="dxa"/>
+                </w:tcMar>
+              </w:tcPr>
+            </w:tc>
+          </w:tr>
+        </w:tbl>';
+
+        $phpWord = $this->getDocumentFromString(['document' => $documentXml]);
+
+        $elements = $phpWord->getSection(0)->getElements();
+        self::assertInstanceOf('PhpOffice\PhpWord\Element\Table', $elements[0]);
+        $rows = $elements[0]->getRows();
+        self::assertInstanceOf('PhpOffice\PhpWord\Element\Row', $rows[0]);
+        $cells = $rows[0]->getCells();
+        self::assertInstanceOf('PhpOffice\PhpWord\Element\Cell', $cells[0]);
+        $styleCell = $cells[0]->getStyle();
+        self::assertInstanceOf('PhpOffice\PhpWord\Style\Cell', $styleCell);
+
+        self::assertEquals(4, $styleCell->getBorderTopSize());
+        self::assertEquals(Border::SINGLE, $styleCell->getBorderTopStyle());
+        self::assertEquals('auto', $styleCell->getBorderTopColor());
+
+        self::assertEquals(4, $styleCell->getBorderBottomSize());
+        self::assertEquals(Border::DOUBLE, $styleCell->getBorderBottomStyle());
+        self::assertEquals('auto', $styleCell->getBorderBottomColor());
     }
 
     /**
@@ -188,27 +251,6 @@ class StyleTest extends AbstractTestReader
         /** @var \PhpOffice\PhpWord\Style\Font $fontStyle */
         $fontStyle = $textRun->getElement(0)->getFontStyle();
         self::assertTrue($fontStyle->isHidden());
-    }
-
-    public function testReadTableCellNoWrap(): void
-    {
-        $documentXml = '<w:tbl>
-          <w:tr>
-            <w:tc>
-              <w:tcPr>
-                <w:noWrap />
-              </w:tcPr>
-            </w:tc>
-          </w:tr>
-        </w:tbl>';
-
-        $phpWord = $this->getDocumentFromString(['document' => $documentXml]);
-
-        $elements = $phpWord->getSection(0)->getElements();
-        self::assertInstanceOf('PhpOffice\PhpWord\Element\Table', $elements[0]);
-        $rows = $elements[0]->getRows();
-        $cells = $rows[0]->getCells();
-        self::assertTrue($cells[0]->getStyle()->getNoWrap());
     }
 
     public function testReadHeading(): void


### PR DESCRIPTION
### Description

Add reading borders and margins for table cell in Word2007 reader.

About borders: http://www.datypic.com/sc/ooxml/e-w_tcBorders-1.html
About margins: http://www.datypic.com/sc/ooxml/e-w_tcMar-1.html

Based on PR #2351 by @kernusr 

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
