### PR TITLE
Fix "Attempt to read property "length" on array" error (issue 1974 )

### DIFF
--- a/src/PhpWord/Reader/Word2007/Document.php
+++ b/src/PhpWord/Reader/Word2007/Document.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.

--- a/src/PhpWord/Reader/Word2007/Document.php
+++ b/src/PhpWord/Reader/Word2007/Document.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.
@@ -45,7 +46,7 @@ class Document extends AbstractPart
     {
         $this->phpWord = $phpWord;
         $xmlReader = new XMLReader();
-        $xmlReader->getDomFromZip($this->docFile, $this->xmlFile);
+        $xmlReader->getDomFromZip($this->docFile, ltrim($this->xmlFile, '/'));
         $readMethods = ['w:p' => 'readWPNode', 'w:tbl' => 'readTable', 'w:sectPr' => 'readWSectPrNode'];
 
         $nodes = $xmlReader->getElements('w:body/*');


### PR DESCRIPTION
### Description

This avoids the `Attempt to read property "length" on array` error message when loading DOCX generated online.

Fixes #1974

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes (not needed, no change in behavior)
