### PR TITLE
PDF Writer : Add config for defining the default font

### DIFF
--- a/docs/changes/1.x/1.2.0.md
+++ b/docs/changes/1.x/1.2.0.md
@@ -10,6 +10,7 @@
 - Word2007 Reader : Added option to disable loading images by [@aelliott1485](https://github.com/aelliott1485) in GH-2450
 - HTML Writer : Added border-spacing to default styles for table by [@kernusr](https://github.com/kernusr) in GH-2451
 - Word2007 Reader : Support for table cell borders and margins by [@kernusr](https://github.com/kernusr) in GH-2454
+- PDF Writer : Add config for defining the default font by [@MikeMaldini](https://github.com/MikeMaldini) in [#2262](https://github.com/PHPOffice/PHPWord/pull/2262) & [#2468](https://github.com/PHPOffice/PHPWord/pull/2468)
 
 ### Bug fixes
 

--- a/docs/usage/writers.md
+++ b/docs/usage/writers.md
@@ -30,6 +30,24 @@ $writer = IOFactory::createWriter($oPhpWord, 'PDF');
 $writer->save(__DIR__ . '/sample.pdf');
 ```
 
+### Options
+
+You can define options like :
+* `font`: default font
+
+Options must be defined before creating the writer.
+
+``` php
+use PhpOffice\PhpWord\Settings;
+
+Settings::setPdfRendererOptions([
+    'font' => 'Arial'
+]);
+
+$writer = IOFactory::createWriter($oPhpWord, 'PDF');
+$writer->save(__DIR__ . '/sample.pdf');
+```
+
 ## RTF
 The name of the writer is `RTF`.
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2002,7 +2002,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method PhpOffice\\\\PhpWord\\\\Writer\\\\PDF\\:\\:getFont\\(\\)\\.$#"
-			count: 1
+			count: 2
 			path: tests/PhpWordTests/Writer/PDF/DomPDFTest.php
 
 		-
@@ -2047,7 +2047,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$libraryBaseDir of static method PhpOffice\\\\PhpWord\\\\Settings\\:\\:setPdfRenderer\\(\\) expects string, string\\|false given\\.$#"
-			count: 2
+			count: 3
 			path: tests/PhpWordTests/Writer/PDF/DomPDFTest.php
 
 		-
@@ -2057,6 +2057,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$libraryBaseDir of static method PhpOffice\\\\PhpWord\\\\Settings\\:\\:setPdfRenderer\\(\\) expects string, string\\|false given\\.$#"
+			count: 2
+			path: tests/PhpWordTests/Writer/PDF/MPDFTest.php
+
+		-
+			message: "#^Call to an undefined method PhpOffice\\\\PhpWord\\\\Writer\\\\PDF\\:\\:getFont\\(\\)\\.$#"
 			count: 1
 			path: tests/PhpWordTests/Writer/PDF/MPDFTest.php
 
@@ -2067,6 +2072,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$libraryBaseDir of static method PhpOffice\\\\PhpWord\\\\Settings\\:\\:setPdfRenderer\\(\\) expects string, string\\|false given\\.$#"
+			count: 2
+			path: tests/PhpWordTests/Writer/PDF/TCPDFTest.php
+
+		-
+			message: "#^Call to an undefined method PhpOffice\\\\PhpWord\\\\Writer\\\\PDF\\:\\:getFont\\(\\)\\.$#"
 			count: 1
 			path: tests/PhpWordTests/Writer/PDF/TCPDFTest.php
 

--- a/src/PhpWord/Settings.php
+++ b/src/PhpWord/Settings.php
@@ -90,6 +90,13 @@ class Settings
     private static $pdfRendererName;
 
     /**
+     * Options used for rendering PDF files.
+     *
+     * @var array
+     */
+    private static $pdfRendererOptions = [];
+
+    /**
      * Directory Path to the external Library used for rendering PDF files.
      *
      * @var null|string
@@ -224,6 +231,22 @@ class Settings
     public static function getPdfRendererPath(): ?string
     {
         return self::$pdfRendererPath;
+    }
+
+    /**
+     * Set options of the external library for rendering PDF files.
+     */
+    public static function setPdfRendererOptions(array $options): void
+    {
+        self::$pdfRendererOptions = $options;
+    }
+
+    /**
+     * Return the PDF Rendering Options.
+     */
+    public static function getPdfRendererOptions(): array
+    {
+        return self::$pdfRendererOptions;
     }
 
     /**

--- a/src/PhpWord/Writer/PDF/AbstractRenderer.php
+++ b/src/PhpWord/Writer/PDF/AbstractRenderer.php
@@ -81,6 +81,7 @@ abstract class AbstractRenderer extends HTML
     public function __construct(PhpWord $phpWord)
     {
         parent::__construct($phpWord);
+
         if ($this->includeFile != null) {
             $includeFile = Settings::getPdfRendererPath() . '/' . $this->includeFile;
             if (file_exists($includeFile)) {
@@ -92,6 +93,12 @@ abstract class AbstractRenderer extends HTML
                 throw new Exception('Unable to load PDF Rendering library');
                 // @codeCoverageIgnoreEnd
             }
+        }
+
+        // Configuration
+        $options = Settings::getPdfRendererOptions();
+        if (!empty($options['font'])) {
+            $this->setFont($options['font']);
         }
     }
 

--- a/src/PhpWord/Writer/PDF/DomPDF.php
+++ b/src/PhpWord/Writer/PDF/DomPDF.php
@@ -18,6 +18,7 @@
 namespace PhpOffice\PhpWord\Writer\PDF;
 
 use Dompdf\Dompdf as DompdfLib;
+use Dompdf\Options;
 use PhpOffice\PhpWord\Writer\WriterInterface;
 
 /**
@@ -42,7 +43,12 @@ class DomPDF extends AbstractRenderer implements WriterInterface
      */
     protected function createExternalWriterInstance()
     {
-        return new DompdfLib();
+        $options = new Options();
+        if ($this->getFont()) {
+            $options->set('defaultFont', $this->getFont());
+        }
+
+        return new DompdfLib($options);
     }
 
     /**

--- a/src/PhpWord/Writer/PDF/MPDF.php
+++ b/src/PhpWord/Writer/PDF/MPDF.php
@@ -52,7 +52,12 @@ class MPDF extends AbstractRenderer implements WriterInterface
     {
         $mPdfClass = $this->getMPdfClassName();
 
-        return new $mPdfClass();
+        $options = [];
+        if ($this->getFont()) {
+            $options['default_font'] = $this->getFont();
+        }
+
+        return new $mPdfClass($options);
     }
 
     /**

--- a/src/PhpWord/Writer/PDF/TCPDF.php
+++ b/src/PhpWord/Writer/PDF/TCPDF.php
@@ -46,7 +46,13 @@ class TCPDF extends AbstractRenderer implements WriterInterface
      */
     protected function createExternalWriterInstance($orientation, $unit, $paperSize)
     {
-        return new \TCPDF($orientation, $unit, $paperSize);
+        $instance = new \TCPDF($orientation, $unit, $paperSize);
+
+        if ($this->getFont()) {
+            $instance->setFont($this->getFont(), $instance->getFontStyle(), $instance->getFontSizePt());
+        }
+
+        return $instance;
     }
 
     /**

--- a/tests/PhpWordTests/SettingsTest.php
+++ b/tests/PhpWordTests/SettingsTest.php
@@ -41,6 +41,11 @@ class SettingsTest extends TestCase
 
     private $pdfRendererName;
 
+    /**
+     * @var array
+     */
+    private $pdfRendererOptions;
+
     private $pdfRendererPath;
 
     private $tempDir;
@@ -56,6 +61,7 @@ class SettingsTest extends TestCase
         $this->measurementUnit = Settings::getMeasurementUnit();
         $this->outputEscapingEnabled = Settings::isOutputEscapingEnabled();
         $this->pdfRendererName = Settings::getPdfRendererName();
+        $this->pdfRendererOptions = Settings::getPdfRendererOptions();
         $this->pdfRendererPath = Settings::getPdfRendererPath();
         $this->tempDir = Settings::getTempDir();
         $this->zipClass = Settings::getZipClass();
@@ -70,6 +76,7 @@ class SettingsTest extends TestCase
         Settings::setMeasurementUnit($this->measurementUnit);
         Settings::setOutputEscapingEnabled($this->outputEscapingEnabled);
         Settings::setPdfRendererName($this->pdfRendererName);
+        Settings::setPdfRendererOptions($this->pdfRendererOptions);
         Settings::setPdfRendererPath($this->pdfRendererPath);
         Settings::setTempDir($this->tempDir);
         Settings::setZipClass($this->zipClass);
@@ -122,6 +129,23 @@ class SettingsTest extends TestCase
         self::assertEquals($domPdfPath, Settings::getPdfRendererPath());
         self::assertFalse(Settings::setPdfRendererPath('dummy/path'));
         self::assertEquals($domPdfPath, Settings::getPdfRendererPath());
+    }
+
+    /**
+     * Test set/get PDF renderer.
+     */
+    public function testSetGetPdfOptions(): void
+    {
+        $domPdfPath = realpath(PHPWORD_TESTS_BASE_DIR . '/../vendor/dompdf/dompdf');
+
+        self::assertEquals([], Settings::getPdfRendererOptions());
+
+        Settings::setPdfRendererOptions([
+            'font' => 'Arial',
+        ]);
+        self::assertEquals([
+            'font' => 'Arial',
+        ], Settings::getPdfRendererOptions());
     }
 
     /**

--- a/tests/PhpWordTests/Writer/PDF/DomPDFTest.php
+++ b/tests/PhpWordTests/Writer/PDF/DomPDFTest.php
@@ -75,4 +75,21 @@ class DomPDFTest extends \PHPUnit\Framework\TestCase
         $writer->setTempDir(Settings::getTempDir());
         self::assertEquals(Settings::getTempDir(), $writer->getTempDir());
     }
+
+    /**
+     * Test set/get abstract renderer options.
+     */
+    public function testSetGetAbstractRendererOptions(): void
+    {
+        define('DOMPDF_ENABLE_AUTOLOAD', false);
+
+        $rendererName = Settings::PDF_RENDERER_DOMPDF;
+        $rendererLibraryPath = realpath(PHPWORD_TESTS_BASE_DIR . '/../vendor/dompdf/dompdf');
+        Settings::setPdfRenderer($rendererName, $rendererLibraryPath);
+        Settings::setPdfRendererOptions([
+            'font' => 'Arial',
+        ]);
+        $writer = new PDF(new PhpWord());
+        self::assertEquals('Arial', $writer->getFont());
+    }
 }

--- a/tests/PhpWordTests/Writer/PDF/MPDFTest.php
+++ b/tests/PhpWordTests/Writer/PDF/MPDFTest.php
@@ -50,4 +50,19 @@ class MPDFTest extends \PHPUnit\Framework\TestCase
 
         unlink($file);
     }
+
+    /**
+     * Test set/get abstract renderer options.
+     */
+    public function testSetGetAbstractRendererOptions(): void
+    {
+        $rendererName = Settings::PDF_RENDERER_MPDF;
+        $rendererLibraryPath = realpath(PHPWORD_TESTS_BASE_DIR . '/../vendor/mpdf/mpdf');
+        Settings::setPdfRenderer($rendererName, $rendererLibraryPath);
+        Settings::setPdfRendererOptions([
+            'font' => 'Arial',
+        ]);
+        $writer = new PDF(new PhpWord());
+        self::assertEquals('Arial', $writer->getFont());
+    }
 }

--- a/tests/PhpWordTests/Writer/PDF/TCPDFTest.php
+++ b/tests/PhpWordTests/Writer/PDF/TCPDFTest.php
@@ -49,4 +49,19 @@ class TCPDFTest extends \PHPUnit\Framework\TestCase
 
         unlink($file);
     }
+
+    /**
+     * Test set/get abstract renderer options.
+     */
+    public function testSetGetAbstractRendererOptions(): void
+    {
+        $rendererName = Settings::PDF_RENDERER_TCPDF;
+        $rendererLibraryPath = realpath(PHPWORD_TESTS_BASE_DIR . '/../vendor/tecnickcom/tcpdf');
+        Settings::setPdfRenderer($rendererName, $rendererLibraryPath);
+        Settings::setPdfRendererOptions([
+            'font' => 'Arial',
+        ]);
+        $writer = new PDF(new PhpWord());
+        self::assertEquals('Arial', $writer->getFont());
+    }
 }


### PR DESCRIPTION
### Description

PDF Writer : Add config for defining the default font

Based on PR #2262 by @MikeMaldini

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
