### PR TITLE
Remove deprecated utf8_encode in PHP 8.2

### DIFF
--- a/docs/changes/1.x/1.2.0.md
+++ b/docs/changes/1.x/1.2.0.md
@@ -35,3 +35,4 @@
 - Bump phpstan/phpstan-phpunit from 1.3.13 to 1.3.14 by [@dependabot](https://github.com/dependabot) in [#2457](https://github.com/PHPOffice/PHPWord/pull/2457)
 - Bump symfony/process from 5.4.26 to 5.4.28 by [@dependabot](https://github.com/dependabot) in [#2456](https://github.com/PHPOffice/PHPWord/pull/2456)
 - Bump phpunit/phpunit from 9.6.10 to 9.6.11 by [@dependabot](https://github.com/dependabot) in [#2455](https://github.com/PHPOffice/PHPWord/pull/2455)
+- Remove deprecated utf8_encode in PHP 8.2 by [@mhcwebdesign](https://github.com/mhcwebdesign) in [#2447](https://github.com/PHPOffice/PHPWord/pull/2447) & [#2472](https://github.com/PHPOffice/PHPWord/pull/2472)

--- a/src/PhpWord/Shared/Text.php
+++ b/src/PhpWord/Shared/Text.php
@@ -145,7 +145,11 @@ class Text
     public static function toUTF8($value = '')
     {
         if (null !== $value && !self::isUTF8($value)) {
-            $value = utf8_encode($value);
+            if (PHP_VERSION_ID < 80200) {
+                $value = utf8_encode($value);
+            } else {
+                $value = mb_convert_encoding($value, 'UTF-8', mb_list_encodings());
+            }
         }
 
         return $value;

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -257,7 +257,11 @@ class TemplateProcessor
     protected static function ensureUtf8Encoded($subject)
     {
         if (!Text::isUTF8($subject) && null !== $subject) {
-            $subject = utf8_encode($subject);
+            if (PHP_VERSION_ID < 80200) {
+                $subject = utf8_encode($subject);
+            } else {
+                $subject = mb_convert_encoding($subject, 'UTF-8', mb_list_encodings());
+            }
         }
 
         return (null !== $subject) ? $subject : '';


### PR DESCRIPTION
### Description

Remove deprecated utf8_encode in PHP 8.2

Superseeds #2447 by @mhcwebdesign

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
