### PR TITLE
check for null on $fontDefaultStyle

### DIFF
--- a/src/PhpWord/Reader/Word2007/Styles.php
+++ b/src/PhpWord/Reader/Word2007/Styles.php
@@ -39,14 +39,16 @@ class Styles extends AbstractPart
         $fontDefaults = $xmlReader->getElement('w:docDefaults/w:rPrDefault');
         if ($fontDefaults !== null) {
             $fontDefaultStyle = $this->readFontStyle($xmlReader, $fontDefaults);
-            if (array_key_exists('name', $fontDefaultStyle)) {
-                $phpWord->setDefaultFontName($fontDefaultStyle['name']);
-            }
-            if (array_key_exists('size', $fontDefaultStyle)) {
-                $phpWord->setDefaultFontSize($fontDefaultStyle['size']);
-            }
-            if (array_key_exists('lang', $fontDefaultStyle)) {
-                $phpWord->getSettings()->setThemeFontLang(new Language($fontDefaultStyle['lang']));
+            if ($fontDefaultStyle !== null) {   
+                if (array_key_exists('name', $fontDefaultStyle)) {
+                    $phpWord->setDefaultFontName($fontDefaultStyle['name']);
+                }
+                if (array_key_exists('size', $fontDefaultStyle)) {
+                    $phpWord->setDefaultFontSize($fontDefaultStyle['size']);
+                }
+                if (array_key_exists('lang', $fontDefaultStyle)) {
+                    $phpWord->getSettings()->setThemeFontLang(new Language($fontDefaultStyle['lang']));
+                }
             }
         }
 


### PR DESCRIPTION
after trying everything i could to try to absolve the offending file, i implemented this small check that get's around a null error that i encountered when converting a docx file (downloaded from google drive) to txt