### PR TITLE
Word2007 Reader : Fixed reading of Office365 DocX file

### DIFF
--- a/docs/changes/1.x/1.2.0.md
+++ b/docs/changes/1.x/1.2.0.md
@@ -38,6 +38,7 @@
 - Fixed PHP 8.2 deprecated about Allow access to an undefined property by [@DAdq26](https://github.com/DAdq26) in GH-2440
 - Template Processor : Fixed choose dimention for Float Value by [@gdevilbat](https://github.com/gdevilbat) in GH-2449
 - HTML Parser : Fix image parsing from url without extension by [@JokubasR](https://github.com/JokubasR) in GH-2459
+- Word2007 Reader : Fixed reading of Office365 DocX file by [@filippotoso](https://github.com/filippotoso) & [@lfglopes](https://github.com/lfglopes) in [#2506](https://github.com/PHPOffice/PHPWord/pull/2506)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Shared/XMLReader.php
+++ b/src/PhpWord/Shared/XMLReader.php
@@ -62,7 +62,7 @@ class XMLReader
 
         $zip = new ZipArchive();
         $zip->open($zipFile);
-        $content = $zip->getFromName($xmlFile);
+        $content = $zip->getFromName(ltrim($xmlFile, '/'));
         $zip->close();
 
         if ($content === false) {

--- a/tests/PhpWordTests/Shared/XMLReaderTest.php
+++ b/tests/PhpWordTests/Shared/XMLReaderTest.php
@@ -59,6 +59,21 @@ class XMLReaderTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Office 365 add some slash before the path of XML file.
+     */
+    public function testDomFromZipOffice365(): void
+    {
+        $archiveFile = __DIR__ . '/../_files/xml/reader.zip';
+
+        $reader = new XMLReader();
+        $reader->getDomFromZip($archiveFile, '/test.xml');
+
+        self::assertTrue($reader->elementExists('/element/child'));
+
+        self::assertFalse($reader->getDomFromZip($archiveFile, 'non_existing_xml_file.xml'));
+    }
+
+    /**
      * Test that read from non existing archive throws exception.
      */
     public function testThrowsExceptionOnNonExistingArchive(): void


### PR DESCRIPTION
### Description

Fixes #1974

Superseeds #2463

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
