### PR TITLE
Word2007 Reader : Check for null on $fontDefaultStyle

### DIFF
--- a/docs/changes/1.x/1.2.0.md
+++ b/docs/changes/1.x/1.2.0.md
@@ -41,6 +41,7 @@
 - Template Processor : Fixed choose dimention for Float Value by [@gdevilbat](https://github.com/gdevilbat) in GH-2449
 - HTML Parser : Fix image parsing from url without extension by [@JokubasR](https://github.com/JokubasR) in GH-2459
 - Word2007 Reader : Fixed reading of Office365 DocX file by [@filippotoso](https://github.com/filippotoso) & [@lfglopes](https://github.com/lfglopes) in [#2506](https://github.com/PHPOffice/PHPWord/pull/2506)
+- Word2007 Reader : Check for null on $fontDefaultStyle by [@spatialfree](https://github.com/spatialfree) in [#2513](https://github.com/PHPOffice/PHPWord/pull/2513)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Reader/Word2007/Styles.php
+++ b/src/PhpWord/Reader/Word2007/Styles.php
@@ -39,14 +39,16 @@ class Styles extends AbstractPart
         $fontDefaults = $xmlReader->getElement('w:docDefaults/w:rPrDefault');
         if ($fontDefaults !== null) {
             $fontDefaultStyle = $this->readFontStyle($xmlReader, $fontDefaults);
-            if (array_key_exists('name', $fontDefaultStyle)) {
-                $phpWord->setDefaultFontName($fontDefaultStyle['name']);
-            }
-            if (array_key_exists('size', $fontDefaultStyle)) {
-                $phpWord->setDefaultFontSize($fontDefaultStyle['size']);
-            }
-            if (array_key_exists('lang', $fontDefaultStyle)) {
-                $phpWord->getSettings()->setThemeFontLang(new Language($fontDefaultStyle['lang']));
+            if ($fontDefaultStyle) {
+                if (array_key_exists('name', $fontDefaultStyle)) {
+                    $phpWord->setDefaultFontName($fontDefaultStyle['name']);
+                }
+                if (array_key_exists('size', $fontDefaultStyle)) {
+                    $phpWord->setDefaultFontSize($fontDefaultStyle['size']);
+                }
+                if (array_key_exists('lang', $fontDefaultStyle)) {
+                    $phpWord->getSettings()->setThemeFontLang(new Language($fontDefaultStyle['lang']));
+                }
             }
         }
 


### PR DESCRIPTION
### Description

Word2007 Reader : Check for null on $fontDefaultStyle

Superseeds #2491 by @spatialfree

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [x] I have updated the documentation to describe the changes
