### PR TITLE
Invalid Annotation in Test Member

### DIFF
--- a/tests/PhpWordTests/Element/FormulaTest.php
+++ b/tests/PhpWordTests/Element/FormulaTest.php
@@ -30,7 +30,7 @@ use PhpOffice\PhpWordTests\AbstractWebServerEmbeddedTest;
 class FormulaTest extends AbstractWebServerEmbeddedTest
 {
     /**
-     * @covers \Formula::__construct
+     * @covers \PhpOffice\PhpWord\Element\Formula::__construct
      */
     public function testConstruct(): void
     {
@@ -40,8 +40,8 @@ class FormulaTest extends AbstractWebServerEmbeddedTest
     }
 
     /**
-     * @covers \Formula::getMath
-     * @covers \Formula::setMath
+     * @covers \PhpOffice\PhpWord\Element\Formula::getMath
+     * @covers \PhpOffice\PhpWord\Element\Formula::setMath
      */
     public function testMath(): void
     {

--- a/tests/PhpWordTests/PhpWordTest.php
+++ b/tests/PhpWordTests/PhpWordTest.php
@@ -18,6 +18,7 @@
 namespace PhpOffice\PhpWordTests;
 
 use BadMethodCallException;
+use DateTimeImmutable;
 use PhpOffice\PhpWord\Metadata\DocInfo;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Settings;
@@ -35,8 +36,14 @@ class PhpWordTest extends \PHPUnit\Framework\TestCase
      */
     public function testConstruct(): void
     {
-        $phpWord = new PhpWord();
-        self::assertEquals(new DocInfo(), $phpWord->getDocInfo());
+        do {
+            $dtStart = new DateTimeImmutable();
+            $startSecond = $dtStart->format('s');
+            $phpWord = new PhpWord();
+            $docInfo = new DocInfo();
+            $endSecond = (new DateTimeImmutable('now'))->format('s');
+        } while ($startSecond !== $endSecond);
+        self::assertEquals($docInfo, $phpWord->getDocInfo());
         self::assertEquals(Settings::DEFAULT_FONT_NAME, $phpWord->getDefaultFontName());
         self::assertEquals(Settings::DEFAULT_FONT_SIZE, $phpWord->getDefaultFontSize());
     }


### PR DESCRIPTION
PhpUnit cannot parse the `@covers` lines in FormulaTest; they result in warnings in Coverage and Deploy tests. This PR fixes them; no change log entry should be needed.

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
