### PR TITLE
Fix 32-bit Problem in PasswordEncoder

### DIFF
--- a/docs/changes/2.x/2.0.0.md
+++ b/docs/changes/2.x/2.0.0.md
@@ -10,6 +10,8 @@
 
 - bug: TemplateProcessor fix multiline values [@gimler](https://github.com/gimler) fixing [#268](https://github.com/PHPOffice/PHPWord/issues/268), [#2323](https://github.com/PHPOffice/PHPWord/issues/2323) and [#2486](https://github.com/PHPOffice/PHPWord/issues/2486) in [#2522](https://github.com/PHPOffice/PHPWord/pull/2522)
 
+- 32-bit Problem in PasswordEncoder [@oleibman](https://github.com/oleibman) fixing [#2550](https://github.com/PHPOffice/PHPWord/issues/2550) in [#2551](https://github.com/PHPOffice/PHPWord/pull/2551)
+
 ### Miscellaneous
 
 - Bump dompdf/dompdf from 2.0.3 to 2.0.4 by [@dependabot](https://github.com/dependabot) in [#2530](https://github.com/PHPOffice/PHPWord/pull/2530)

--- a/src/PhpWord/Shared/Microsoft/PasswordEncoder.php
+++ b/src/PhpWord/Shared/Microsoft/PasswordEncoder.php
@@ -34,6 +34,9 @@ class PasswordEncoder
     const ALGORITHM_MAC = 'MAC';
     const ALGORITHM_HMAC = 'HMAC';
 
+    private const ALL_ONE_BITS = (PHP_INT_SIZE > 4) ? 0xFFFFFFFF : -1;
+    private const HIGH_ORDER_BIT = (PHP_INT_SIZE > 4) ? 0x80000000 : PHP_INT_MIN;
+
     /**
      * Mapping between algorithm name and algorithm ID.
      *
@@ -128,7 +131,7 @@ class PasswordEncoder
         // build low-order word and hig-order word and combine them
         $combinedKey = self::buildCombinedKey($byteChars);
         // build reversed hexadecimal string
-        $hex = str_pad(strtoupper(dechex($combinedKey & 0xFFFFFFFF)), 8, '0', \STR_PAD_LEFT);
+        $hex = str_pad(strtoupper(dechex($combinedKey & self::ALL_ONE_BITS)), 8, '0', \STR_PAD_LEFT);
         $reversedHex = $hex[6] . $hex[7] . $hex[4] . $hex[5] . $hex[2] . $hex[3] . $hex[0] . $hex[1];
 
         $generatedKey = mb_convert_encoding($reversedHex, 'UCS-2LE', 'UTF-8');
@@ -232,10 +235,10 @@ class PasswordEncoder
      */
     private static function int32($value)
     {
-        $value = ($value & 0xFFFFFFFF);
+        $value = $value & self::ALL_ONE_BITS;
 
-        if ($value & 0x80000000) {
-            $value = -((~$value & 0xFFFFFFFF) + 1);
+        if ($value & self::HIGH_ORDER_BIT) {
+            $value = -((~$value & self::ALL_ONE_BITS) + 1);
         }
 
         return $value;


### PR DESCRIPTION
### Description

Password encoder is not 32-bit safe.

Fixes #2550

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
