### PR TITLE
Php7 Problem with TemplateProcessor Destructor

### DIFF
--- a/docs/changes/2.x/2.0.0.md
+++ b/docs/changes/2.x/2.0.0.md
@@ -10,6 +10,7 @@
 
 - MsDoc Reader : Correct Font Size Calculation by [@oleibman](https://github.com/oleibman) fixing [#2526](https://github.com/PHPOffice/PHPWord/issues/2526) in [#2531](https://github.com/PHPOffice/PHPWord/pull/2531)
 - TemplateProcessor Persist File After Destruct [@oleibman](https://github.com/oleibman) fixing [#2539](https://github.com/PHPOffice/PHPWord/issues/2539) in [#2545](https://github.com/PHPOffice/PHPWord/pull/2545)
+- TemplateProcessor Destructor Problem with Php7 [@oleibman](https://github.com/oleibman) fixing [#2548](https://github.com/PHPOffice/PHPWord/issues/2548) in [#2554](https://github.com/PHPOffice/PHPWord/pull/2554)
 - bug: TemplateProcessor fix multiline values [@gimler](https://github.com/gimler) fixing [#268](https://github.com/PHPOffice/PHPWord/issues/268), [#2323](https://github.com/PHPOffice/PHPWord/issues/2323) and [#2486](https://github.com/PHPOffice/PHPWord/issues/2486) in [#2522](https://github.com/PHPOffice/PHPWord/pull/2522)
 
 ### Miscellaneous

--- a/src/PhpWord/Shared/ZipArchive.php
+++ b/src/PhpWord/Shared/ZipArchive.php
@@ -20,6 +20,7 @@ namespace PhpOffice\PhpWord\Shared;
 use PclZip;
 use PhpOffice\PhpWord\Exception\Exception;
 use PhpOffice\PhpWord\Settings;
+use Throwable;
 
 /**
  * ZipArchive wrapper.
@@ -162,13 +163,16 @@ class ZipArchive
      * Close the active archive.
      *
      * @return bool
-     *
-     * @codeCoverageIgnore Can't find any test case. Uncomment when found.
      */
     public function close()
     {
         if (!$this->usePclzip) {
-            if ($this->zip->close() === false) {
+            try {
+                $result = @$this->zip->close();
+            } catch (Throwable $e) {
+                $result = false;
+            }
+            if ($result === false) {
                 throw new Exception("Could not close zip file {$this->filename}: ");
             }
         }

--- a/tests/PhpWordTests/TemplateProcessorTest.php
+++ b/tests/PhpWordTests/TemplateProcessorTest.php
@@ -25,6 +25,7 @@ use PhpOffice\PhpWord\IOFactory;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\TemplateProcessor;
+use Throwable;
 use TypeError;
 use ZipArchive;
 
@@ -63,12 +64,21 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
      *
      * @covers ::__construct
      * @covers ::__destruct
+     * @covers \PhpOffice\PhpWord\Shared\ZipArchive::close
      */
     public function testTheConstruct(): void
     {
         $object = $this->getTemplateProcessor(__DIR__ . '/_files/templates/blank.docx');
         self::assertInstanceOf('PhpOffice\\PhpWord\\TemplateProcessor', $object);
         self::assertEquals([], $object->getVariables());
+        $object->save();
+
+        try {
+            $object->zip()->close();
+            self::fail('Expected exception for double close');
+        } catch (Throwable $e) {
+            // nothing to do here
+        }
     }
 
     /**


### PR DESCRIPTION

### Description

A particularly perplexing problem accidentally introduced by PR #2475. Problem does not arise for Php8, and does not arise for Php7 unit tests. But, running *not* under Phpunit auspices with Php7 can cause a warning message at destructor time if the `save` function has been used. A very artificial test is introduced to test this situation.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # 2548

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
