### PR TITLE
Background and border color transparency support for textboxes when color is undefined

### DIFF
--- a/src/PhpWord/Writer/Word2007/Element/TextBox.php
+++ b/src/PhpWord/Writer/Word2007/Element/TextBox.php
@@ -50,6 +50,13 @@ class TextBox extends Image
 
         if ($style->getBgColor()) {
             $xmlWriter->writeAttribute('fillcolor', $style->getBgColor());
+        } else {
+            $xmlWriter->writeAttribute('filled', 'f');
+        }
+
+        if (!$style->getBorderColor()) {
+            $xmlWriter->writeAttribute('stroked', 'f');
+            $xmlWriter->writeAttribute('strokecolor', 'white');
         }
 
         $styleWriter->write();


### PR DESCRIPTION
### Description

In project we use text boxes for imprints and side notes on a word document. It's currently not possible to use non-white background with border. As a simple fix I implement simple check if border or background color is set - if not then text box should be rendered with a transparent colors, else current behavior will be used.

Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
