### PR TITLE
TemplateProcessor SetComplexBlock/Value and Sections

### DIFF
--- a/docs/changes/2.x/2.0.0.md
+++ b/docs/changes/2.x/2.0.0.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 - MsDoc Reader : Correct Font Size Calculation by [@oleibman](https://github.com/oleibman) fixing [#2526](https://github.com/PHPOffice/PHPWord/issues/2526) in [#2531](https://github.com/PHPOffice/PHPWord/pull/2531)
+- TemplateProcessor setComplexBlock/Value and Section by [@oleibman](https://github.com/oleibman) fixing [#2561](https://github.com/PHPOffice/PHPWord/issues/2561) in [#2562](https://github.com/PHPOffice/PHPWord/pull/2562)
 - TemplateProcessor Persist File After Destruct [@oleibman](https://github.com/oleibman) fixing [#2539](https://github.com/PHPOffice/PHPWord/issues/2539) in [#2545](https://github.com/PHPOffice/PHPWord/pull/2545)
 - bug: TemplateProcessor fix multiline values [@gimler](https://github.com/gimler) fixing [#268](https://github.com/PHPOffice/PHPWord/issues/268), [#2323](https://github.com/PHPOffice/PHPWord/issues/2323) and [#2486](https://github.com/PHPOffice/PHPWord/issues/2486) in [#2522](https://github.com/PHPOffice/PHPWord/pull/2522)
 

--- a/docs/changes/2.x/2.0.0.md
+++ b/docs/changes/2.x/2.0.0.md
@@ -9,7 +9,6 @@
 ### Bug fixes
 
 - MsDoc Reader : Correct Font Size Calculation by [@oleibman](https://github.com/oleibman) fixing [#2526](https://github.com/PHPOffice/PHPWord/issues/2526) in [#2531](https://github.com/PHPOffice/PHPWord/pull/2531)
-- TemplateProcessor setComplexBlock/Value and Section by [@oleibman](https://github.com/oleibman) fixing [#2561](https://github.com/PHPOffice/PHPWord/issues/2561) in [#2562](https://github.com/PHPOffice/PHPWord/pull/2562)
 - TemplateProcessor Persist File After Destruct [@oleibman](https://github.com/oleibman) fixing [#2539](https://github.com/PHPOffice/PHPWord/issues/2539) in [#2545](https://github.com/PHPOffice/PHPWord/pull/2545)
 - bug: TemplateProcessor fix multiline values [@gimler](https://github.com/gimler) fixing [#268](https://github.com/PHPOffice/PHPWord/issues/268), [#2323](https://github.com/PHPOffice/PHPWord/issues/2323) and [#2486](https://github.com/PHPOffice/PHPWord/issues/2486) in [#2522](https://github.com/PHPOffice/PHPWord/pull/2522)
 

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -275,8 +275,10 @@ class TemplateProcessor
     /**
      * @param string $search
      */
-    public function setComplexValue($search, Element\AbstractElement $complexType): void
+    public function setComplexValue($search, Element\AbstractElement $complexType, bool $multiple = false): void
     {
+        $originalSearch = $search;
+
         $elementName = substr(get_class($complexType), strrpos(get_class($complexType), '\\') + 1);
         if ($elementName === 'Section') {
             $elementName = 'Container';
@@ -300,6 +302,9 @@ class TemplateProcessor
 
         $search = static::ensureMacroCompleted($search);
         $this->replaceXmlBlock($search, $xmlWriter->getData(), 'w:r');
+        if ($multiple === true) {
+            $this->setComplexValue($originalSearch, $complexType, true);
+        }
     }
 
     /**

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -278,6 +278,9 @@ class TemplateProcessor
     public function setComplexValue($search, Element\AbstractElement $complexType): void
     {
         $elementName = substr(get_class($complexType), strrpos(get_class($complexType), '\\') + 1);
+        if ($elementName === 'Section') {
+            $elementName = 'Container';
+        }
         $objectClass = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Element\\' . $elementName;
 
         $xmlWriter = new XMLWriter();
@@ -305,6 +308,9 @@ class TemplateProcessor
     public function setComplexBlock($search, Element\AbstractElement $complexType): void
     {
         $elementName = substr(get_class($complexType), strrpos(get_class($complexType), '\\') + 1);
+        if ($elementName === 'Section') {
+            $elementName = 'Container';
+        }
         $objectClass = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Element\\' . $elementName;
 
         $xmlWriter = new XMLWriter();

--- a/tests/PhpWordTests/TemplateProcessorSectionTest.php
+++ b/tests/PhpWordTests/TemplateProcessorSectionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PHPWord - A pure PHP library for reading and writing
  * word processing documents.

--- a/tests/PhpWordTests/TemplateProcessorSectionTest.php
+++ b/tests/PhpWordTests/TemplateProcessorSectionTest.php
@@ -54,7 +54,7 @@ final class TemplateProcessorSectionTest extends \PHPUnit\Framework\TestCase
 
     public function testSetComplexSection(): void
     {
-        $templateProcessor = $this->getTemplateProcessor('C:/git/sectiontemplate/tests/PhpWordTests/_files/templates/document22-xml.docx');
+        $templateProcessor = $this->getTemplateProcessor(__DIR__ . '/_files/templates/document22-xml.docx');
         $html = '
             <p>&nbsp;Bug Report:</p>
             <p><span style="background-color: #ff0000;">BugTracker X</span> is ${facing1} an issue.</p>

--- a/tests/PhpWordTests/TemplateProcessorSectionTest.php
+++ b/tests/PhpWordTests/TemplateProcessorSectionTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWordTests;
+
+use PhpOffice\PhpWord\Element\Section;
+use PhpOffice\PhpWord\Element\TextRun;
+use PhpOffice\PhpWord\Shared\Html;
+use PhpOffice\PhpWord\TemplateProcessor;
+
+/**
+ * @covers \PhpOffice\PhpWord\TemplateProcessor
+ *
+ * @coversDefaultClass \PhpOffice\PhpWord\TemplateProcessor
+ *
+ * @runTestsInSeparateProcesses
+ */
+final class TemplateProcessorSectionTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var ?TemplateProcessor */
+    private $templateProcessor;
+
+    private function getTemplateProcessor(string $filename): TemplateProcessor
+    {
+        $this->templateProcessor = new TemplateProcessor($filename);
+
+        return $this->templateProcessor;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->templateProcessor !== null) {
+            $filename = $this->templateProcessor->getTempDocumentFilename();
+            $this->templateProcessor = null;
+            if (file_exists($filename)) {
+                @unlink($filename);
+            }
+        }
+    }
+
+    public function testSetComplexSection(): void
+    {
+        $templateProcessor = $this->getTemplateProcessor('C:/git/sectiontemplate/tests/PhpWordTests/_files/templates/document22-xml.docx');
+        $html = '
+            <p>&nbsp;Bug Report:</p>
+            <p><span style="background-color: #ff0000;">BugTracker X</span> is ${facing1} an issue.</p>
+            <p><span style="background-color: #00ff00;">BugTracker X</span> is ${facing2} an issue.</p>
+            ';
+        $section = new Section(0);
+        Html::addHtml($section, $html, false, false);
+        $templateProcessor->setComplexBlock('test', $section);
+        $facing1 = new TextRun();
+        $facing1->addText('facing', ['bold' => true]);
+        $facing2 = new TextRun();
+        $facing2->addText('facing', ['italic' => true]);
+
+        $templateProcessor->setComplexBlock('test', $section);
+        $templateProcessor->setComplexValue('facing1', $facing1);
+        $templateProcessor->setComplexValue('facing2', $facing2);
+
+        $docName = $templateProcessor->save();
+        $docFound = file_exists($docName);
+        self::assertTrue($docFound);
+        $contents = file_get_contents("zip://$docName#word/document2.xml");
+        unlink($docName);
+        self::assertNotFalse($contents);
+        $contents = preg_replace('/>\s+</', '><', $contents) ?? '';
+        self::assertStringContainsString('<w:t>Test</w:t>', $contents);
+        self::assertStringContainsString('<w:r><w:rPr><w:b w:val="1"/><w:bCs w:val="1"/></w:rPr><w:t xml:space="preserve">facing</w:t></w:r>', $contents, 'bold string found');
+        self::assertStringContainsString('<w:r><w:rPr><w:i w:val="1"/><w:iCs w:val="1"/></w:rPr><w:t xml:space="preserve">facing</w:t></w:r>', $contents, 'italic string found');
+        self::assertStringNotContainsString('$', $contents, 'no leftover macros');
+        self::assertStringNotContainsString('facing1', $contents, 'no leftover replaced string1');
+        self::assertStringNotContainsString('facing2', $contents, 'no leftover replaced string2');
+    }
+}

--- a/tests/PhpWordTests/TemplateProcessorSectionTest.php
+++ b/tests/PhpWordTests/TemplateProcessorSectionTest.php
@@ -59,6 +59,7 @@ final class TemplateProcessorSectionTest extends \PHPUnit\Framework\TestCase
             <p>&nbsp;Bug Report:</p>
             <p><span style="background-color: #ff0000;">BugTracker X</span> is ${facing1} an issue.</p>
             <p><span style="background-color: #00ff00;">BugTracker X</span> is ${facing2} an issue.</p>
+            <p><span style="background-color: #0000ff;">BugTracker X</span> is ${facing1} an issue.</p>
             ';
         $section = new Section(0);
         Html::addHtml($section, $html, false, false);
@@ -69,7 +70,7 @@ final class TemplateProcessorSectionTest extends \PHPUnit\Framework\TestCase
         $facing2->addText('facing', ['italic' => true]);
 
         $templateProcessor->setComplexBlock('test', $section);
-        $templateProcessor->setComplexValue('facing1', $facing1);
+        $templateProcessor->setComplexValue('facing1', $facing1, true);
         $templateProcessor->setComplexValue('facing2', $facing2);
 
         $docName = $templateProcessor->save();
@@ -80,8 +81,10 @@ final class TemplateProcessorSectionTest extends \PHPUnit\Framework\TestCase
         self::assertNotFalse($contents);
         $contents = preg_replace('/>\s+</', '><', $contents) ?? '';
         self::assertStringContainsString('<w:t>Test</w:t>', $contents);
-        self::assertStringContainsString('<w:r><w:rPr><w:b w:val="1"/><w:bCs w:val="1"/></w:rPr><w:t xml:space="preserve">facing</w:t></w:r>', $contents, 'bold string found');
-        self::assertStringContainsString('<w:r><w:rPr><w:i w:val="1"/><w:iCs w:val="1"/></w:rPr><w:t xml:space="preserve">facing</w:t></w:r>', $contents, 'italic string found');
+        $count = substr_count($contents, '<w:r><w:rPr><w:b w:val="1"/><w:bCs w:val="1"/></w:rPr><w:t xml:space="preserve">facing</w:t></w:r>');
+        self::assertSame(2, $count, 'should be 2 bold strings');
+        $count = substr_count($contents, '<w:r><w:rPr><w:i w:val="1"/><w:iCs w:val="1"/></w:rPr><w:t xml:space="preserve">facing</w:t></w:r>');
+        self::assertSame(1, $count, 'should be 1 italic string');
         self::assertStringNotContainsString('$', $contents, 'no leftover macros');
         self::assertStringNotContainsString('facing1', $contents, 'no leftover replaced string1');
         self::assertStringNotContainsString('facing2', $contents, 'no leftover replaced string2');


### PR DESCRIPTION
### Description

Allow the TemplateProcessor methods `setComplexBlock` and `setComplexValue` to work with Sections.

Fixes #2561

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
