### PR TITLE
Alterd the function ensureUtf8Encoded to return only an empty string on null and false

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -269,7 +269,7 @@ class TemplateProcessor
      */
     protected static function ensureUtf8Encoded($subject)
     {
-        return $subject ? Text::toUTF8($subject) : '';
+        return !is_null($subject) ? Text::toUTF8($subject) : '';
     }
 
     /**

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -269,7 +269,7 @@ class TemplateProcessor
      */
     protected static function ensureUtf8Encoded($subject)
     {
-        return !is_null($subject) ? Text::toUTF8($subject) : '';
+        return $subject !== null ? Text::toUTF8($subject) : '';
     }
 
     /**

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -269,7 +269,7 @@ class TemplateProcessor
      */
     protected static function ensureUtf8Encoded($subject)
     {
-        return $subject !== null ? Text::toUTF8($subject) : '';
+        return ($subject !== null) ? Text::toUTF8($subject) : '';
     }
 
     /**

--- a/tests/PhpWordTests/TemplateProcessorTest.php
+++ b/tests/PhpWordTests/TemplateProcessorTest.php
@@ -1630,4 +1630,101 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
         $templateProcessor->setUpdateFields(false);
         self::assertStringContainsString('<w:updateFields w:val="false"/>', $templateProcessor->getSettingsPart());
     }
+
+    public function testEnsureUtf8Encoded(): void
+    {
+        $mainPart = '<w:tbl>
+            <w:tr>
+                <w:tc>
+                    <w:tcPr>
+                        <w:vMerge w:val="restart"/>
+                    </w:tcPr>
+                    <w:p>
+                        <w:r>
+                            <w:t t=1>${stringZero}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:p>
+                        <w:r>
+                            <w:t t=2>${intZero}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:p>
+                        <w:r>
+                            <w:t t=3>${stringTest}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:p>
+                        <w:r>
+                            <w:t t=4>${null}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:p>
+                        <w:r>
+                            <w:t t=5>${floatZero}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:p>
+                        <w:r>
+                            <w:t t=6>${intTen}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:p>
+                        <w:r>
+                            <w:t t=7>${boolFalse}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:p>
+                        <w:r>
+                            <w:t t=8>${boolTrue}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+            </w:tr>
+        </w:tbl>';
+        $templateProcessor = new TestableTemplateProcesor($mainPart);
+
+        self::assertEquals(
+            ['stringZero', 'intZero', 'stringTest', 'null', 'floatZero', 'intTen', 'boolFalse', 'boolTrue'],
+            $templateProcessor->getVariables()
+        );
+
+        $templateProcessor->setValue('stringZero', '0');
+        self::assertStringContainsString('<w:t t=1>0</w:t>', $templateProcessor->getMainPart());
+
+        $templateProcessor->setValue('intZero', 0);
+        self::assertStringContainsString('<w:t t=2>0</w:t>', $templateProcessor->getMainPart());
+
+        $templateProcessor->setValue('stringTest', 'test');
+        self::assertStringContainsString('<w:t t=3>test</w:t>', $templateProcessor->getMainPart());
+
+        $templateProcessor->setValue('null', null);
+        self::assertStringContainsString('<w:t t=4></w:t>', $templateProcessor->getMainPart());
+
+        $templateProcessor->setValue('floatZero', 0.00);
+        self::assertStringContainsString('<w:t t=5>0</w:t>', $templateProcessor->getMainPart());
+
+        $templateProcessor->setValue('intTen', 10);
+        self::assertStringContainsString('<w:t t=6>10</w:t>', $templateProcessor->getMainPart());
+
+        $templateProcessor->setValue('boolFalse', false);
+        self::assertStringContainsString('<w:t t=7></w:t>', $templateProcessor->getMainPart());
+
+        $templateProcessor->setValue('boolTrue', true);
+        self::assertStringContainsString('<w:t t=8>1</w:t>', $templateProcessor->getMainPart());
+    }
 }


### PR DESCRIPTION
### Description

I ran into a problem that nothing was printed when 0 was given as the value for function TemplateProcessor->setValue(). I tracked this issue down to the function ensureUtf8Encoded that checked if $subject was true, instead of is not null.

I changed the line to check if $subject is null  and only then return a empty string else the value is send to Text::toUTF8().

The test I wrote might be a bit overkill, but I hope it sufficient to test te fix

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
