### PR TITLE
<w:lastRenderedPageBreak/> page break support

### DIFF
--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -199,7 +199,7 @@ abstract class AbstractPart
             $fontStyle = $this->readFontStyle($xmlReader, $domNode);
             $nodes = $xmlReader->getElements('w:r', $domNode);
             foreach ($nodes as $node) {
-                if ($xmlReader->elementExists('w:lastRenderedPageBreak',$node)) {
+                if ($xmlReader->elementExists('w:lastRenderedPageBreak', $node)) {
                     $parent->addPageBreak();
                 }
                 $instrText = $xmlReader->getValue('w:instrText', $node);

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -199,6 +199,9 @@ abstract class AbstractPart
             $fontStyle = $this->readFontStyle($xmlReader, $domNode);
             $nodes = $xmlReader->getElements('w:r', $domNode);
             foreach ($nodes as $node) {
+                if ($xmlReader->elementExists('w:lastRenderedPageBreak',$node)) {
+                    $parent->addPageBreak();
+                }
                 $instrText = $xmlReader->getValue('w:instrText', $node);
                 if ($xmlReader->elementExists('w:fldChar', $node)) {
                     $fldCharType = $xmlReader->getAttribute('w:fldCharType', $node, 'w:fldChar');


### PR DESCRIPTION
### Description

Some Word2007 document are using <w:lastRenderedPageBreak/>for page break. When converting this document to PDF, it does not add page break in final PDF.

