### PR TITLE
[BUGFIX] Handle direct and nested title text paths

### DIFF
--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -255,7 +255,8 @@ abstract class AbstractPart
         $headingDepth = $xmlReader->elementExists('w:pPr', $domNode) ? $this->getHeadingDepth($paragraphStyle) : null;
         if ($headingDepth !== null) {
             $textContent = null;
-            $nodes = $xmlReader->getElements('w:r|w:hyperlink', $domNode);
+            // @todo Evaluate if a generic relative './/w:r' would be better fitting here.
+            $nodes = $xmlReader->getElements('w:r|w:sdt/w:sdtContent/w:r|w:hyperlink|w:sdt/w:sdtContent/w:hyperlink', $domNode);
             if ($nodes->length === 1) {
                 $textContent = htmlspecialchars($xmlReader->getValue('w:t', $nodes->item(0)), ENT_QUOTES, 'UTF-8');
             } else {


### PR DESCRIPTION
It seems that in newer formats it's possible that the
`w:r` for an pStyle can be deeper nested as a sibling
of the parent note.

Older versions:

```
<w:p
    w:rsidR="00000000" w:rsidDel="00000000"
    w:rsidP="00000000" w:rsidRDefault="00000000"
    w:rsidRPr="00000000" w14:paraId="00000001">
    <w:pPr>
        <w:pStyle w:val="Heading1"/>
        <w:rPr/>
    </w:pPr>
    <w:r w:rsidDel="00000000" w:rsidR="00000000"
         w:rsidRPr="00000000">
        <w:rPr>
            <w:rtl w:val="0"/>
        </w:rPr>
        <w:t xml:space="preserve">Überschrift 1</w:t>
    </w:r>
</w:p>
```

versu newer versions:

```
<w:p w14:paraId="64815DFA" w14:textId="77777777"
     w:rsidR="002A1C92" w:rsidRDefault="00000000">
    <w:pPr>
        <w:pStyle w:val="berschrift1"/>
    </w:pPr>
    <w:sdt>
        <w:sdtPr>
            <w:id w:val="-1128864550"/>
            <w:placeholder>
                <w:docPart w:val="6F00E81731533248A49CB16AC5C3C3DE"/>
            </w:placeholder>
            <w:temporary/>
            <w:showingPlcHdr/>
            <w15:appearance w15:val="hidden"/>
        </w:sdtPr>
        <w:sdtContent>
            <w:r w:rsidR="00D04D7B">
                <w:t>Überschrift 1</w:t>
            </w:r>
        </w:sdtContent>
    </w:sdt>
</w:p>
```

Therefore, this change now uses a double check for the direct and the
nested variant to detect the content (text) of a title text section:

```php
// old
    'w:r',
    $domNode
);

// new
    'w:r|w:sdt/w:sdtContent/w:r',
    $domNode
);
```

in `\PhpOffice\PhpWord\Reader\Word2007\AbstractPart::readParagraph()`.
