### PR TITLE
[BUGFIX] Remove invalid tool call from composer `check` script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,20 +36,19 @@
     ],
     "scripts": {
         "test": [
-            "phpunit --color=always"
+            "@php vendor/bin/phpunit --color=always"
         ],
         "test-no-coverage": [
-            "phpunit --color=always --no-coverage"
+            "@php vendor/bin/phpunit --color=always --no-coverage"
         ],
         "check": [
-            "php-cs-fixer fix --ansi --dry-run --diff",
-            "phpcs --report-width=200 --report-summary --report-full samples/ src/ tests/ --ignore=src/PhpWord/Shared/PCLZip --standard=PSR2 -n",
-            "phpmd src/,tests/ text ./phpmd.xml.dist --exclude pclzip.lib.php",
+            "@php vendor/bin/php-cs-fixer fix --ansi --dry-run --diff",
+            "@php vendor/bin/phpmd src/,tests/ text ./phpmd.xml.dist --exclude pclzip.lib.php",
             "@test-no-coverage",
-            "phpstan analyse --ansi"
+            "@php vendor/bin/phpstan analyse --ansi"
         ],
         "fix": [
-            "php-cs-fixer fix --ansi"
+            "@php vendor/bin/php-cs-fixer fix --ansi"
         ]
     },
     "scripts-descriptions": {


### PR DESCRIPTION
With commit [1] development dependencies have been removed
from the `composer.json`, but not from the `composer.lock`.

This indicates a inproper use of `composer` and should be
taken care in review of pull-requests. A good practice here
is to etablish a rule that composer commands needs to be
added to the commit message and the pull-request.

Other removed dependency and downgraded dependencies have
been fixed or readded meanwhile, still missing the `phpcs`
tool for the `check composer script`.

The `CONTRIBUTION.md` states to execute `composer check`
before creating a pull-request, which is literally broken
due to the missing dependency.

This change removes the php sniffer call from the check
script. Additionally, the composer scripts are enhanced
to use the same php binary used to invoke composer itself
to mitigate issues using the wrong php version on systems
with multiple php version binaries.

Further consideration should be to use the check command in
the Github Action workflow to have a border if development
toolchain is gonna be broken with a change.
