### PR TITLE
[BUGFIX] Respect wrapped  paragraph in table cells

### DIFF
--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -493,6 +493,13 @@ abstract class AbstractPart
                                 $this->readParagraph($xmlReader, $cellNode, $cell, $docPart);
                             } elseif ($cellNode->nodeName == 'w:tbl') { // Table
                                 $this->readTable($xmlReader, $cellNode, $cell, $docPart);
+                            } elseif ('w:sdt' == $cellNode->nodeName) {
+                                if ($xmlReader->elementExists('w:sdtContent/w:p', $cellNode)) {
+                                    $cellParagraphNode = $xmlReader->getElement('w:sdtContent/w:p', $cellNode);
+                                    if ($cellParagraphNode instanceof DOMElement) {
+                                        $this->readParagraph($xmlReader, $cellParagraphNode, $cell, $docPart);
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This change ensures that `w:sdt->w:sdtContent` wrapped
table cell content is properly read and respected.
