### PR TITLE
FIX: StrikeThrough property in word2007

### DIFF
--- a/src/PhpWord/Writer/Word2007/Style/Font.php
+++ b/src/PhpWord/Writer/Word2007/Style/Font.php
@@ -117,8 +117,8 @@ class Font extends AbstractStyle
         $xmlWriter->writeElementIf($style->isItalic() !== null, 'w:iCs', 'w:val', $this->writeOnOf($style->isItalic()));
 
         // Strikethrough, double strikethrough
-        $xmlWriter->writeElementIf($style->isStrikethrough() !== null, 'w:strike', 'w:val', $this->writeOnOf($style->isStrikethrough()));
-        $xmlWriter->writeElementIf($style->isDoubleStrikethrough() !== null, 'w:dstrike', 'w:val', $this->writeOnOf($style->isDoubleStrikethrough()));
+        $xmlWriter->writeElementIf($style->isStrikethrough(), 'w:strike', 'w:val', $this->writeOnOf($style->isStrikethrough()));
+        $xmlWriter->writeElementIf($style->isDoubleStrikethrough(), 'w:dstrike', 'w:val', $this->writeOnOf($style->isDoubleStrikethrough()));
 
         // Small caps, all caps
         $xmlWriter->writeElementIf($style->isSmallCaps() !== null, 'w:smallCaps', 'w:val', $this->writeOnOf($style->isSmallCaps()));


### PR DESCRIPTION
I had a problem with strike through in Word2007.
If a strikethrough style was added to a text element it never appeared in the resulting document.
Indeed, the XML generated was as follows
```
<w:r>
    <w:rPr>
        <w:strike w:val="1"/>
        <w:dstrike w:val="0"/>
     </w:rPr>
     <w:t xml:space="preserve">some text</w:t>
</w:r>
```
The statement `<w:dstrike w:val="0"/>` should not be present here
I figure out that the test  `$style->isDoubleStrikethrough() !== null` is true if `$style->isDoubleStrikethrough() === false`
So as a text cannot be strike and doublestrike at the same time, word2007 ignores it.
