### PR TITLE
Prevented fatal errors when opening corrupt files or "doc" files

### DIFF
--- a/docs/changes/2.x/2.0.0.md
+++ b/docs/changes/2.x/2.0.0.md
@@ -17,6 +17,7 @@
 - bug: TemplateProcessor fix multiline values [@gimler](https://github.com/gimler) fixing [#268](https://github.com/PHPOffice/PHPWord/issues/268), [#2323](https://github.com/PHPOffice/PHPWord/issues/2323) and [#2486](https://github.com/PHPOffice/PHPWord/issues/2486) in [#2522](https://github.com/PHPOffice/PHPWord/pull/2522)
 - 32-bit Problem in PasswordEncoder [@oleibman](https://github.com/oleibman) fixing [#2550](https://github.com/PHPOffice/PHPWord/issues/2550) in [#2551](https://github.com/PHPOffice/PHPWord/pull/2551)
 - Typo : Fix hardcoded macro chars in TemplateProcessor method [@glafarge](https://github.com/glafarge) in [#2618](https://github.com/PHPOffice/PHPWord/pull/2618)
+- XML Reader : Prevent fatal errors when opening corrupt files or "doc" files [@mmcev106](https://github.com/mmcev106) in [#2626](https://github.com/PHPOffice/PHPWord/pull/2626)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Shared/XMLReader.php
+++ b/src/PhpWord/Shared/XMLReader.php
@@ -62,7 +62,7 @@ class XMLReader
 
         $zip = new ZipArchive();
         $openStatus = $zip->open($zipFile);
-        if($openStatus !== true){
+        if ($openStatus !== true) {
             /**
              * Throw an exception since making further calls on the ZipArchive would cause a fatal error.
              * This prevents fatal errors on corrupt archives and attempts to open old "doc" files.

--- a/src/PhpWord/Shared/XMLReader.php
+++ b/src/PhpWord/Shared/XMLReader.php
@@ -61,7 +61,15 @@ class XMLReader
         }
 
         $zip = new ZipArchive();
-        $zip->open($zipFile);
+        $openStatus = $zip->open($zipFile);
+        if($openStatus !== true){
+            /**
+             * Throw an exception since making further calls on the ZipArchive would cause a fatal error.
+             * This prevents fatal errors on corrupt archives and attempts to open old "doc" files.
+             */
+            throw new Exception("The archive failed to load with the following error code: $openStatus");
+        }
+
         $content = $zip->getFromName(ltrim($xmlFile, '/'));
         $zip->close();
 

--- a/tests/PhpWordTests/Shared/XMLReaderTest.php
+++ b/tests/PhpWordTests/Shared/XMLReaderTest.php
@@ -90,6 +90,9 @@ class XMLReaderTest extends \PHPUnit\Framework\TestCase
      */
     public function testThrowsExceptionOnZipArchiveOpenErrors(): void
     {
+        /**
+         * @var string
+         */
         $tempPath = tempnam(sys_get_temp_dir(), 'PhpWord');
 
         // Simulate a corrupt archive

--- a/tests/PhpWordTests/Shared/XMLReaderTest.php
+++ b/tests/PhpWordTests/Shared/XMLReaderTest.php
@@ -93,18 +93,18 @@ class XMLReaderTest extends \PHPUnit\Framework\TestCase
         $tempPath = tempnam(sys_get_temp_dir(), 'PhpWord');
 
         // Simulate a corrupt archive
-        file_put_contents($tempPath, rand());
+        file_put_contents($tempPath, mt_rand());
 
         $exceptionMessage = null;
-        try{
+
+        try {
             $reader = new XMLReader();
             $reader->getDomFromZip($tempPath, 'test.xml');
-        }
-        catch(\Exception $e){
+        } catch (Exception $e) {
             $exceptionMessage = $e->getMessage();
         }
 
-        $this->assertNotNull($exceptionMessage);
+        self::assertNotNull($exceptionMessage);
 
         unlink($tempPath);
     }

--- a/tests/PhpWordTests/Shared/XMLReaderTest.php
+++ b/tests/PhpWordTests/Shared/XMLReaderTest.php
@@ -86,6 +86,30 @@ class XMLReaderTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test that read from invalid archive throws exception.
+     */
+    public function testThrowsExceptionOnZipArchiveOpenErrors(): void
+    {
+        $tempPath = tempnam(sys_get_temp_dir(), 'PhpWord');
+
+        // Simulate a corrupt archive
+        file_put_contents($tempPath, rand());
+
+        $exceptionMessage = null;
+        try{
+            $reader = new XMLReader();
+            $reader->getDomFromZip($tempPath, 'test.xml');
+        }
+        catch(\Exception $e){
+            $exceptionMessage = $e->getMessage();
+        }
+
+        $this->assertNotNull($exceptionMessage);
+
+        unlink($tempPath);
+    }
+
+    /**
      * Test elements count.
      */
     public function testCountElements(): void


### PR DESCRIPTION
### Description

This prevents fatal exceptions when trying to load corrupt files or old "doc" files, allowing applications to catch the exception and fail gracefully.

Fixes # (issue) - None. I just fixed it without reporting an issue.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/2.x/2.0.0.md)
