### PR TITLE
Adding the possibility to use iterate search and replace with setValues

### DIFF
--- a/docs/changes/2.x/2.0.0.md
+++ b/docs/changes/2.x/2.0.0.md
@@ -24,5 +24,6 @@
 - Bump symfony/process from 5.4.28 to 5.4.34 by [@dependabot](https://github.com/dependabot) in [#2536](https://github.com/PHPOffice/PHPWord/pull/2536)
 - Allow rgb() when converting Html by [@oleibman](https://github.com/oleibman) fixing [#2508](https://github.com/PHPOffice/PHPWord/issues/2508) in [#2512](https://github.com/PHPOffice/PHPWord/pull/2512)
 - Improved Issue Template by [@Progi1984](https://github.com/Progi1984) in [#2609](https://github.com/PHPOffice/PHPWord/pull/2609)
+- Adding the possibility to use iterate search and replace with setValues by [@moghwan](https://github.com/moghwan) in [#2632](https://github.com/PHPOffice/PHPWord/pull/2632)
 
 ### BC Breaks

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -362,7 +362,7 @@ class TemplateProcessor
     /**
      * Set values from a one-dimensional array of "variable => value"-pairs.
      */
-    public function setValues(array $values, $limit = self::MAXIMUM_REPLACEMENTS_DEFAULT): void
+    public function setValues(array $values, int $limit = self::MAXIMUM_REPLACEMENTS_DEFAULT): void
     {
         foreach ($values as $macro => $replace) {
             $this->setValue($macro, $replace, $limit);

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -362,10 +362,10 @@ class TemplateProcessor
     /**
      * Set values from a one-dimensional array of "variable => value"-pairs.
      */
-    public function setValues(array $values): void
+    public function setValues(array $values, $limit = self::MAXIMUM_REPLACEMENTS_DEFAULT): void
     {
         foreach ($values as $macro => $replace) {
-            $this->setValue($macro, $replace);
+            $this->setValue($macro, $replace, $limit);
         }
     }
 


### PR DESCRIPTION
edit: closed in favor of https://github.com/PHPOffice/PHPWord/pull/2640
reason: making a pull request with a branch different from master

### Description

This PR adds a limit parameter to the setValues function, which itself is uses within with setValue. This will help to avoid to minimize written if the limit is needed for a bulk search&replace operation.

example:

```php
$templateProcessor = new TemplateProcessor('sample.docx');

$firstname = 'John';
$middlename = 'Mc';
$lastname = 'Doe';

// current
$templateProcessor->setValues([
    "firstname" => $firstname,
    "middlename" => $middlename,
    "lastname" => $lastname,
]);

// assuming we want to change the only the "first" name variables:
// workaround
$templateProcessor->setValue("firstname", $firstname, 1);
$templateProcessor->setValue("middlename", $middlename, 1);
$templateProcessor->setValue("lastname", $lastname, 1);

// improvement
$templateProcessor->setValues([
    "firstname" => $firstname,
    "middlename" => $middlename,
    "lastname" => $lastname,
], 1);
```

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/2.x/2.0.0.md)
