### PR TITLE
Extend the Options section of the PDF Writer documentation

### DIFF
--- a/docs/changes/2.x/2.0.0.md
+++ b/docs/changes/2.x/2.0.0.md
@@ -5,6 +5,7 @@
 ## Enhancements
 
 - IOFactory : Added extractVariables method to extract variables from a document [@sibalonat](https://github.com/sibalonat) in [#2515](https://github.com/PHPOffice/PHPWord/pull/2515)
+- PDF Writer : Documented how to specify a PDF renderer, when working with the PDF writer, as well as the three available choices 
 
 ### Bug fixes
 

--- a/docs/changes/2.x/2.0.0.md
+++ b/docs/changes/2.x/2.0.0.md
@@ -5,7 +5,7 @@
 ## Enhancements
 
 - IOFactory : Added extractVariables method to extract variables from a document [@sibalonat](https://github.com/sibalonat) in [#2515](https://github.com/PHPOffice/PHPWord/pull/2515)
-- PDF Writer : Documented how to specify a PDF renderer, when working with the PDF writer, as well as the three available choices 
+- PDF Writer : Documented how to specify a PDF renderer, when working with the PDF writer, as well as the three available choices by [@settermjd](https://github.com/settermjd) in [#2642](https://github.com/PHPOffice/PHPWord/pull/2642)
 
 ### Bug fixes
 

--- a/docs/usage/writers.md
+++ b/docs/usage/writers.md
@@ -87,6 +87,29 @@ $writer = IOFactory::createWriter($oPhpWord, 'PDF');
 $writer->save(__DIR__ . '/sample.pdf');
 ```
 
+#### Specify the PDF Renderer
+
+Before PHPWord can write a PDF, you **must** specify the renderer to use and the path to it.
+Currently, three renderers are supported: 
+
+- [DomPDF](https://github.com/dompdf/dompdf)
+- [MPDF](https://mpdf.github.io/)
+- [TCPDF](https://tcpdf.org/)
+
+To specify the renderer you use two static `Settings` functions:
+
+- `setPdfRendererName`: This sets the name of the renderer library to use.
+  Provide one of [`Settings`' three `PDF_` constants](https://github.com/PHPOffice/PHPWord/blob/master/src/PhpWord/Settings.php#L39-L41) to the function call.
+- `setPdfRendererPath`: This sets the path to the renderer library. 
+  This directory is the renderer's package directory within Composer's _vendor_ directory.
+
+In the code below, you can see an example of setting MPDF as the desired PDF renderer.
+
+```php
+Settings::setPdfRendererName(Settings::PDF_RENDERER_MPDF);
+Settings::setPdfRendererPath(__DIR__ . '/../vendor/mpdf/mpdf');
+```
+
 ## RTF
 The name of the writer is `RTF`.
 


### PR DESCRIPTION
### Description

When I used PHPWord to write a PDF document, recently, I followed [the relevant docs](https://github.com/PHPOffice/PHPWord/blob/master/docs/usage/writers.md#pdf) only to find that I also had to specify a PDF renderer — otherwise the operation failed.

After a bit of research to figure out what to do to specify one, I thought it only right to document what I learned in the official documentation.

### Checklist:

- [x] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [X] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/2.x/2.0.0.md)
