### PR TITLE
Word2007 Reader : Support for FormFields

### DIFF
--- a/docs/changes/2.x/2.0.0.md
+++ b/docs/changes/2.x/2.0.0.md
@@ -8,6 +8,7 @@
 - PDF Writer : Documented how to specify a PDF renderer, when working with the PDF writer, as well as the three available choices by [@settermjd](https://github.com/settermjd) in [#2642](https://github.com/PHPOffice/PHPWord/pull/2642)
 - Word2007 Reader: Support for Paragraph Border Style by [@damienfa](https://github.com/damienfa) in [#2651](https://github.com/PHPOffice/PHPWord/pull/2651)
 - Word2007 Writer: Support for field REF by [@crystoline](https://github.com/crystoline) in [#2652](https://github.com/PHPOffice/PHPWord/pull/2652)
+- Word2007 Reader : Support for FormFields by [@vincentKool](https://github.com/vincentKool) in [#2653](https://github.com/PHPOffice/PHPWord/pull/2653)
 
 ### Bug fixes
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -236,11 +236,6 @@ parameters:
 			path: src/PhpWord/Reader/Word2007/AbstractPart.php
 
 		-
-			message: "#^Parameter \\#1 \\$count of method PhpOffice\\\\PhpWord\\\\Element\\\\AbstractContainer\\:\\:addTextBreak\\(\\) expects int, null given\\.$#"
-			count: 1
-			path: src/PhpWord/Reader/Word2007/AbstractPart.php
-
-		-
 			message: "#^Parameter \\#1 \\$depth of method PhpOffice\\\\PhpWord\\\\Element\\\\AbstractContainer\\:\\:addListItemRun\\(\\) expects int, string\\|null given\\.$#"
 			count: 1
 			path: src/PhpWord/Reader/Word2007/AbstractPart.php

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -196,13 +196,10 @@ abstract class AbstractPart
         if ($xmlReader->elementExists('w:r/w:fldChar/w:ffData', $domNode)) {
             // FormField
             $partOfFormField = false;
-            $formNodes = array();
+            $formNodes = [];
             $formType = null;
-//            $field = new FormField("type", "forntsyle", "paragraphstyle"):
             $textRunContainers = $xmlReader->countElements('w:r|w:ins|w:del|w:hyperlink|w:smartTag', $domNode);
-            if (0 === $textRunContainers) {
-                $parent->addTextBreak(null, $paragraphStyle);
-            } else {
+            if ($textRunContainers > 0) {
                 $nodes = $xmlReader->getElements('*', $domNode);
                 $paragraph = $parent->addTextRun($paragraphStyle);
                 foreach ($nodes as $node) {
@@ -312,7 +309,7 @@ abstract class AbstractPart
         // Text and TextRun
         $textRunContainers = $xmlReader->countElements('w:r|w:ins|w:del|w:hyperlink|w:smartTag|w:commentReference|w:commentRangeStart|w:commentRangeEnd', $domNode);
         if (0 === $textRunContainers) {
-            $parent->addTextBreak(null, $paragraphStyle);
+            $parent->addTextBreak(1, $paragraphStyle);
         } else {
             $nodes = $xmlReader->getElements('*', $domNode);
             $paragraph = $parent->addTextRun($paragraphStyle);
@@ -323,15 +320,14 @@ abstract class AbstractPart
     }
 
     /**
-     * @param XMLReader $xmlReader
-     * @param \DOMElement[] $domNodes
+     * @param DOMElement[] $domNodes
      * @param AbstractContainer $parent
      * @param mixed $paragraphStyle
      * @param string $formType
      */
-    private function readFormField(XMLReader $xmlReader, array $domNodes, $parent, $paragraphStyle, $formType)
+    private function readFormField(XMLReader $xmlReader, array $domNodes, $parent, $paragraphStyle, $formType): void
     {
-        if (!in_array($formType, array('textinput', 'checkbox', 'dropdown'))) {
+        if (!in_array($formType, ['textinput', 'checkbox', 'dropdown'])) {
             return;
         }
 
@@ -339,57 +335,67 @@ abstract class AbstractPart
         $ffData = $xmlReader->getElement('w:fldChar/w:ffData', $domNodes[0]);
 
         foreach ($xmlReader->getElements('*', $ffData) as $node) {
-            /** @var \DOMElement $node */
+            /** @var DOMElement $node */
             switch ($node->localName) {
                 case 'name':
                     $formField->setName($node->getAttribute('w:val'));
+
                     break;
                 case 'ddList':
-                    $listEntries = array();
+                    $listEntries = [];
                     foreach ($xmlReader->getElements('*', $node) as $ddListNode) {
                         switch ($ddListNode->localName) {
                             case 'result':
                                 $formField->setValue($xmlReader->getAttribute('w:val', $ddListNode));
+
                                 break;
                             case 'default':
                                 $formField->setDefault($xmlReader->getAttribute('w:val', $ddListNode));
+
                                 break;
                             case 'listEntry':
                                 $listEntries[] = $xmlReader->getAttribute('w:val', $ddListNode);
+
                                 break;
                         }
                     }
                     $formField->setEntries($listEntries);
-                    if (!is_null($formField->getValue())) {
+                    if (null !== $formField->getValue()) {
                         $formField->setText($listEntries[$formField->getValue()]);
                     }
+
                     break;
                 case 'textInput':
                     foreach ($xmlReader->getElements('*', $node) as $ddListNode) {
                         switch ($ddListNode->localName) {
                             case 'default':
                                 $formField->setDefault($xmlReader->getAttribute('w:val', $ddListNode));
+
                                 break;
                             case 'format':
                             case 'maxLength':
                                 break;
                         }
                     }
+
                     break;
                 case 'checkBox':
                     foreach ($xmlReader->getElements('*', $node) as $ddListNode) {
                         switch ($ddListNode->localName) {
                             case 'default':
                                 $formField->setDefault($xmlReader->getAttribute('w:val', $ddListNode));
+
                                 break;
                             case 'checked':
                                 $formField->setValue($xmlReader->getAttribute('w:val', $ddListNode));
+
                                 break;
                             case 'size':
                             case 'sizeAuto':
                                 break;
                         }
                     }
+
                     break;
             }
         }
@@ -417,7 +423,7 @@ abstract class AbstractPart
     }
 
     /**
-     * Returns the depth of the Heading, returns 0 for a Title
+     * Returns the depth of the Heading, returns 0 for a Title.
      *
      * @return null|number
      */

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -206,26 +206,25 @@ abstract class AbstractPart
                 $nodes = $xmlReader->getElements('*', $domNode);
                 $paragraph = $parent->addTextRun($paragraphStyle);
                 foreach ($nodes as $node) {
-                    if($xmlReader->elementExists('w:fldChar/w:ffData', $node)) {
+                    if ($xmlReader->elementExists('w:fldChar/w:ffData', $node)) {
                         $partOfFormField = true;
                         $formNodes[] = $node;
-                        if($xmlReader->elementExists('w:fldChar/w:ffData/w:ddList', $node)) {
-                            $formType = "dropdown";
+                        if ($xmlReader->elementExists('w:fldChar/w:ffData/w:ddList', $node)) {
+                            $formType = 'dropdown';
                         } elseif ($xmlReader->elementExists('w:fldChar/w:ffData/w:textInput', $node)) {
-                            $formType = "textinput";
+                            $formType = 'textinput';
                         } elseif ($xmlReader->elementExists('w:fldChar/w:ffData/w:checkBox', $node)) {
-                            $formType = "checkbox";
+                            $formType = 'checkbox';
                         }
-                    } elseif (
-                        $partOfFormField &&
+                    } elseif ($partOfFormField &&
                         $xmlReader->elementExists('w:fldChar', $node) &&
-                        "end" == $xmlReader->getAttribute('w:fldCharType', $node, 'w:fldChar')
+                        'end' == $xmlReader->getAttribute('w:fldCharType', $node, 'w:fldChar')
                     ) {
                         $formNodes[] = $node;
                         $partOfFormField = false;
                         // Process the form fields
                         $this->readFormField($xmlReader, $formNodes, $paragraph, $docPart, $paragraphStyle, $formType);
-                    } elseif ($partOfFormField){
+                    } elseif ($partOfFormField) {
                         $formNodes[] = $node;
                     } else {
                         // normal runs
@@ -330,33 +329,34 @@ abstract class AbstractPart
      * @param string $docPart
      * @param null $paragraphStyle
      * @param string $formType
-     * @return void
      */
-    private function readFormField(XMLReader $xmlReader, array $domNodes, $parent, $docPart = 'document', $paragraphStyle = null, $formType)
+    private function readFormField(XMLReader $xmlReader, array $domNodes, $parent, $docPart, $paragraphStyle, $formType)
     {
-        if(!in_array($formType, array("textinput", "checkbox", "dropdown"))) return;
+        if (!in_array($formType, array('textinput', 'checkbox', 'dropdown'))) {
+            return;
+        }
 
         $formField = $parent->addFormField($formType, null, $paragraphStyle);
-        $ffData = $xmlReader->getElement("w:fldChar/w:ffData", $domNodes[0]);
+        $ffData = $xmlReader->getElement('w:fldChar/w:ffData', $domNodes[0]);
 
-        foreach ($xmlReader->getElements("*", $ffData) as $node) {
+        foreach ($xmlReader->getElements('*', $ffData) as $node) {
             /** @var \DOMElement $node */
             switch ($node->localName) {
-                case "name":
-                    $formField->setName($node->getAttribute("w:val"));
+                case 'name':
+                    $formField->setName($node->getAttribute('w:val'));
                     break;
-                case "ddList":
+                case 'ddList':
                     $listEntries = array();
-                    foreach ($xmlReader->getElements("*", $node) as $ddListNode) {
+                    foreach ($xmlReader->getElements('*', $node) as $ddListNode) {
                         switch ($ddListNode->localName) {
-                            case "result":
-                                $formField->setValue($xmlReader->getAttribute("w:val", $ddListNode));
+                            case 'result':
+                                $formField->setValue($xmlReader->getAttribute('w:val', $ddListNode));
                                 break;
-                            case "default":
-                                $formField->setDefault($xmlReader->getAttribute("w:val", $ddListNode));
+                            case 'default':
+                                $formField->setDefault($xmlReader->getAttribute('w:val', $ddListNode));
                                 break;
-                            case "listEntry":
-                                $listEntries[] = $xmlReader->getAttribute("w:val", $ddListNode);
+                            case 'listEntry':
+                                $listEntries[] = $xmlReader->getAttribute('w:val', $ddListNode);
                                 break;
                         }
                     }
@@ -365,30 +365,29 @@ abstract class AbstractPart
                         $formField->setText($listEntries[$formField->getValue()]);
                     }
                     break;
-                case "textInput":
-                    foreach ($xmlReader->getElements("*", $node) as $ddListNode) {
+                case 'textInput':
+                    foreach ($xmlReader->getElements('*', $node) as $ddListNode) {
                         switch ($ddListNode->localName) {
-                            case "default":
-                                $formField->setDefault($xmlReader->getAttribute("w:val", $ddListNode));
+                            case 'default':
+                                $formField->setDefault($xmlReader->getAttribute('w:val', $ddListNode));
                                 break;
-                            case "format":
-                            case "maxLength":
+                            case 'format':
+                            case 'maxLength':
                                 break;
                         }
                     }
                     break;
-                case "checkBox":
-                    foreach ($xmlReader->getElements("*", $node) as $ddListNode) {
-
+                case 'checkBox':
+                    foreach ($xmlReader->getElements('*', $node) as $ddListNode) {
                         switch ($ddListNode->localName) {
-                            case "default":
-                                $formField->setDefault($xmlReader->getAttribute("w:val", $ddListNode));
+                            case 'default':
+                                $formField->setDefault($xmlReader->getAttribute('w:val', $ddListNode));
                                 break;
-                            case "checked":
-                                $formField->setValue($xmlReader->getAttribute("w:val", $ddListNode));
+                            case 'checked':
+                                $formField->setValue($xmlReader->getAttribute('w:val', $ddListNode));
                                 break;
-                            case "size":
-                            case "sizeAuto":
+                            case 'size':
+                            case 'sizeAuto':
                                 break;
                         }
                     }
@@ -396,9 +395,9 @@ abstract class AbstractPart
             }
         }
 
-        if ("textinput" == $formType) {
+        if ('textinput' == $formType) {
             $ignoreText = true;
-            $textContent = "";
+            $textContent = '';
             foreach ($domNodes as $node) {
                 if ($xmlReader->elementExists('w:fldChar', $node)) {
                     $fldCharType = $xmlReader->getAttribute('w:fldCharType', $node, 'w:fldChar');
@@ -417,7 +416,6 @@ abstract class AbstractPart
             $formField->setText(htmlspecialchars($textContent, ENT_QUOTES, 'UTF-8'));
         }
     }
-
 
     /**
      * Returns the depth of the Heading, returns 0 for a Title

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -223,7 +223,7 @@ abstract class AbstractPart
                         $formNodes[] = $node;
                         $partOfFormField = false;
                         // Process the form fields
-                        $this->readFormField($xmlReader, $formNodes, $paragraph, $docPart, $paragraphStyle, $formType);
+                        $this->readFormField($xmlReader, $formNodes, $paragraph, $paragraphStyle, $formType);
                     } elseif ($partOfFormField) {
                         $formNodes[] = $node;
                     } else {
@@ -326,11 +326,10 @@ abstract class AbstractPart
      * @param XMLReader $xmlReader
      * @param \DOMElement[] $domNodes
      * @param AbstractContainer $parent
-     * @param string $docPart
-     * @param null $paragraphStyle
+     * @param mixed $paragraphStyle
      * @param string $formType
      */
-    private function readFormField(XMLReader $xmlReader, array $domNodes, $parent, $docPart, $paragraphStyle, $formType)
+    private function readFormField(XMLReader $xmlReader, array $domNodes, $parent, $paragraphStyle, $formType)
     {
         if (!in_array($formType, array('textinput', 'checkbox', 'dropdown'))) {
             return;

--- a/tests/PhpWordTests/Reader/Word2007/ElementTest.php
+++ b/tests/PhpWordTests/Reader/Word2007/ElementTest.php
@@ -355,4 +355,143 @@ class ElementTest extends AbstractTestReader
         $elements = $phpWord->getSection(0)->getElements();
         self::assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
     }
+
+
+    /**
+     * Test reading FormField - DROPDOWN
+     */
+    public function testReadFormFieldDropdown()
+    {
+        $documentXml = '<w:p>
+            <w:r>
+                <w:t>Reference</w:t>
+            </w:r>
+            <w:r>
+                <w:fldChar w:fldCharType="begin">
+                    <w:ffData>
+                        <w:name w:val="DropDownList1"/>
+                        <w:enabled/>
+                        <w:calcOnExit w:val="0"/>
+                        <w:ddList>
+                            <w:result w:val="2"/>
+                            <w:listEntry w:val="TBD"/>
+                            <w:listEntry w:val="Option One"/>
+                            <w:listEntry w:val="Option Two"/>
+                            <w:listEntry w:val="Option Three"/>
+                            <w:listEntry w:val="Other"/>
+                        </w:ddList>
+                    </w:ffData>
+                </w:fldChar>
+            </w:r>
+            <w:r>
+                <w:instrText xml:space="preserve"> FORMDROPDOWN </w:instrText>
+            </w:r>
+            <w:r>
+                <w:rPr>
+                    <w:lang w:val="en-GB"/>
+                </w:rPr>
+            </w:r>
+            <w:r>
+                <w:rPr>
+                    <w:lang w:val="en-GB"/>
+                </w:rPr>
+                <w:fldChar w:fldCharType="separate"/>
+            </w:r>
+            <w:r>
+                <w:rPr>
+                    <w:lang w:val="en-GB"/>
+                </w:rPr>
+                <w:fldChar w:fldCharType="end"/>
+            </w:r>
+        </w:p>';
+
+        $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
+
+        $elements = $phpWord->getSection(0)->getElements();
+        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
+
+        $subElements = $elements[0]->getElements();
+
+        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $subElements[0]);
+        $this->assertEquals("Reference", $subElements[0]->getText());
+
+        $this->assertInstanceOf('PhpOffice\PhpWord\Element\FormField', $subElements[1]);
+        $this->assertEquals("dropdown", $subElements[1]->getType());
+        $this->assertEquals("DropDownList1", $subElements[1]->getName());
+        $this->assertEquals("2", $subElements[1]->getValue());
+        $this->assertEquals("Option Two", $subElements[1]->getText());
+        $this->assertEquals(array("TBD", "Option One", "Option Two", "Option Three", "Other"), $subElements[1]->getEntries());
+
+    }
+
+
+
+    /**
+     * Test reading FormField - textinput
+     */
+    public function testReadFormFieldTextinput()
+    {
+        $documentXml = '<w:p>
+            <w:r>
+                <w:t>Fieldname</w:t>
+            </w:r>
+            <w:r>
+                <w:fldChar w:fldCharType="begin">
+                    <w:ffData>
+                        <w:name w:val="TextInput2"/>
+                        <w:enabled/>
+                        <w:calcOnExit w:val="0"/>
+                        <w:textInput>
+                            <w:default w:val="TBD"/>
+                            <w:maxLength w:val="200"/>
+                        </w:textInput>
+                    </w:ffData>
+                </w:fldChar>
+            </w:r>
+            <w:r>
+                <w:instrText xml:space="preserve"> FORMTEXT </w:instrText>
+            </w:r>
+            <w:r>
+                <w:rPr>
+                    <w:lang w:val="en-GB"/>
+                </w:rPr>
+            </w:r>
+            <w:r>
+                <w:rPr>
+                    <w:lang w:val="en-GB"/>
+                </w:rPr>
+                <w:fldChar w:fldCharType="separate"/>
+            </w:r>
+            <w:r w:rsidR="00807709">
+                <w:rPr>
+                    <w:noProof/>
+                    <w:lang w:val="en-GB"/>
+                </w:rPr>
+                <w:t>This is some sample text</w:t>
+            </w:r>
+            <w:r>
+                <w:rPr>
+                    <w:lang w:val="en-GB"/>
+                </w:rPr>
+                <w:fldChar w:fldCharType="end"/>
+            </w:r>
+        </w:p>';
+
+        $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
+
+        $elements = $phpWord->getSection(0)->getElements();
+        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
+
+        $subElements = $elements[0]->getElements();
+
+        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $subElements[0]);
+        $this->assertEquals("Fieldname", $subElements[0]->getText());
+
+        $this->assertInstanceOf('PhpOffice\PhpWord\Element\FormField', $subElements[1]);
+        $this->assertEquals("textinput", $subElements[1]->getType());
+        $this->assertEquals("TextInput2", $subElements[1]->getName());
+        $this->assertEquals("This is some sample text", $subElements[1]->getValue());
+        $this->assertEquals("This is some sample text", $subElements[1]->getText());
+    }
+
 }

--- a/tests/PhpWordTests/Reader/Word2007/ElementTest.php
+++ b/tests/PhpWordTests/Reader/Word2007/ElementTest.php
@@ -356,7 +356,6 @@ class ElementTest extends AbstractTestReader
         self::assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
     }
 
-
     /**
      * Test reading FormField - DROPDOWN
      */
@@ -413,18 +412,15 @@ class ElementTest extends AbstractTestReader
         $subElements = $elements[0]->getElements();
 
         $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $subElements[0]);
-        $this->assertEquals("Reference", $subElements[0]->getText());
+        $this->assertEquals('Reference', $subElements[0]->getText());
 
         $this->assertInstanceOf('PhpOffice\PhpWord\Element\FormField', $subElements[1]);
-        $this->assertEquals("dropdown", $subElements[1]->getType());
-        $this->assertEquals("DropDownList1", $subElements[1]->getName());
-        $this->assertEquals("2", $subElements[1]->getValue());
-        $this->assertEquals("Option Two", $subElements[1]->getText());
-        $this->assertEquals(array("TBD", "Option One", "Option Two", "Option Three", "Other"), $subElements[1]->getEntries());
-
+        $this->assertEquals('dropdown', $subElements[1]->getType());
+        $this->assertEquals('DropDownList1', $subElements[1]->getName());
+        $this->assertEquals('2', $subElements[1]->getValue());
+        $this->assertEquals('Option Two', $subElements[1]->getText());
+        $this->assertEquals(array('TBD', 'Option One', 'Option Two', 'Option Three', 'Other'), $subElements[1]->getEntries());
     }
-
-
 
     /**
      * Test reading FormField - textinput
@@ -485,13 +481,66 @@ class ElementTest extends AbstractTestReader
         $subElements = $elements[0]->getElements();
 
         $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $subElements[0]);
-        $this->assertEquals("Fieldname", $subElements[0]->getText());
+        $this->assertEquals('Fieldname', $subElements[0]->getText());
 
         $this->assertInstanceOf('PhpOffice\PhpWord\Element\FormField', $subElements[1]);
-        $this->assertEquals("textinput", $subElements[1]->getType());
-        $this->assertEquals("TextInput2", $subElements[1]->getName());
-        $this->assertEquals("This is some sample text", $subElements[1]->getValue());
-        $this->assertEquals("This is some sample text", $subElements[1]->getText());
+        $this->assertEquals('textinput', $subElements[1]->getType());
+        $this->assertEquals('TextInput2', $subElements[1]->getName());
+        $this->assertEquals('This is some sample text', $subElements[1]->getValue());
+        $this->assertEquals('This is some sample text', $subElements[1]->getText());
     }
 
+    /**
+     * Test reading FormField - checkbox
+     */
+    public function testReadFormFieldCheckbox()
+    {
+        $documentXml = '<w:p>
+			<w:pPr/>
+			<w:r>
+				<w:fldChar w:fldCharType="begin">
+					<w:ffData>
+						<w:enabled w:val="1"/>
+						<w:name w:val="SomeCheckbox"/>
+						<w:calcOnExit w:val="0"/>
+						<w:checkBox>
+							<w:sizeAuto w:val=""/>
+							<w:default w:val="0"/>
+							<w:checked w:val="0"/>
+						</w:checkBox>
+					</w:ffData>
+				</w:fldChar>
+			</w:r>
+			<w:r>
+				<w:rPr/>
+				<w:instrText xml:space="preserve">FORMCHECKBOX</w:instrText>
+			</w:r>
+			<w:r>
+				<w:rPr/>
+				<w:fldChar w:fldCharType="separate"/>
+			</w:r>
+			<w:r>
+				<w:rPr/>
+				<w:t xml:space="preserve">                              </w:t>
+			</w:r>
+			<w:r>
+				<w:rPr/>
+				<w:fldChar w:fldCharType="end"/>
+			</w:r>
+		</w:p>';
+
+        $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
+
+        $elements = $phpWord->getSection(0)->getElements();
+        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
+
+        $subElements = $elements[0]->getElements();
+
+//        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $subElements[0]);
+//        $this->assertEquals('Fieldname', $subElements[0]->getText());
+
+        $this->assertInstanceOf('PhpOffice\PhpWord\Element\FormField', $subElements[0]);
+        $this->assertEquals('checkbox', $subElements[0]->getType());
+        $this->assertEquals('SomeCheckbox', $subElements[0]->getName());
+    }
 }

--- a/tests/PhpWordTests/Reader/Word2007/ElementTest.php
+++ b/tests/PhpWordTests/Reader/Word2007/ElementTest.php
@@ -357,9 +357,9 @@ class ElementTest extends AbstractTestReader
     }
 
     /**
-     * Test reading FormField - DROPDOWN
+     * Test reading FormField - DROPDOWN.
      */
-    public function testReadFormFieldDropdown()
+    public function testReadFormFieldDropdown(): void
     {
         $documentXml = '<w:p>
             <w:r>
@@ -404,28 +404,28 @@ class ElementTest extends AbstractTestReader
             </w:r>
         </w:p>';
 
-        $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
+        $phpWord = $this->getDocumentFromString(['document' => $documentXml]);
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
+        self::assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
 
         $subElements = $elements[0]->getElements();
 
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $subElements[0]);
-        $this->assertEquals('Reference', $subElements[0]->getText());
+        self::assertInstanceOf('PhpOffice\PhpWord\Element\Text', $subElements[0]);
+        self::assertEquals('Reference', $subElements[0]->getText());
 
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\FormField', $subElements[1]);
-        $this->assertEquals('dropdown', $subElements[1]->getType());
-        $this->assertEquals('DropDownList1', $subElements[1]->getName());
-        $this->assertEquals('2', $subElements[1]->getValue());
-        $this->assertEquals('Option Two', $subElements[1]->getText());
-        $this->assertEquals(array('TBD', 'Option One', 'Option Two', 'Option Three', 'Other'), $subElements[1]->getEntries());
+        self::assertInstanceOf('PhpOffice\PhpWord\Element\FormField', $subElements[1]);
+        self::assertEquals('dropdown', $subElements[1]->getType());
+        self::assertEquals('DropDownList1', $subElements[1]->getName());
+        self::assertEquals('2', $subElements[1]->getValue());
+        self::assertEquals('Option Two', $subElements[1]->getText());
+        self::assertEquals(['TBD', 'Option One', 'Option Two', 'Option Three', 'Other'], $subElements[1]->getEntries());
     }
 
     /**
-     * Test reading FormField - textinput
+     * Test reading FormField - textinput.
      */
-    public function testReadFormFieldTextinput()
+    public function testReadFormFieldTextinput(): void
     {
         $documentXml = '<w:p>
             <w:r>
@@ -473,27 +473,27 @@ class ElementTest extends AbstractTestReader
             </w:r>
         </w:p>';
 
-        $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
+        $phpWord = $this->getDocumentFromString(['document' => $documentXml]);
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
+        self::assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
 
         $subElements = $elements[0]->getElements();
 
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $subElements[0]);
-        $this->assertEquals('Fieldname', $subElements[0]->getText());
+        self::assertInstanceOf('PhpOffice\PhpWord\Element\Text', $subElements[0]);
+        self::assertEquals('Fieldname', $subElements[0]->getText());
 
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\FormField', $subElements[1]);
-        $this->assertEquals('textinput', $subElements[1]->getType());
-        $this->assertEquals('TextInput2', $subElements[1]->getName());
-        $this->assertEquals('This is some sample text', $subElements[1]->getValue());
-        $this->assertEquals('This is some sample text', $subElements[1]->getText());
+        self::assertInstanceOf('PhpOffice\PhpWord\Element\FormField', $subElements[1]);
+        self::assertEquals('textinput', $subElements[1]->getType());
+        self::assertEquals('TextInput2', $subElements[1]->getName());
+        self::assertEquals('This is some sample text', $subElements[1]->getValue());
+        self::assertEquals('This is some sample text', $subElements[1]->getText());
     }
 
     /**
-     * Test reading FormField - checkbox
+     * Test reading FormField - checkbox.
      */
-    public function testReadFormFieldCheckbox()
+    public function testReadFormFieldCheckbox(): void
     {
         $documentXml = '<w:p>
 			<w:pPr/>
@@ -529,18 +529,18 @@ class ElementTest extends AbstractTestReader
 			</w:r>
 		</w:p>';
 
-        $phpWord = $this->getDocumentFromString(array('document' => $documentXml));
+        $phpWord = $this->getDocumentFromString(['document' => $documentXml]);
 
         $elements = $phpWord->getSection(0)->getElements();
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
+        self::assertInstanceOf('PhpOffice\PhpWord\Element\TextRun', $elements[0]);
 
         $subElements = $elements[0]->getElements();
 
 //        $this->assertInstanceOf('PhpOffice\PhpWord\Element\Text', $subElements[0]);
 //        $this->assertEquals('Fieldname', $subElements[0]->getText());
 
-        $this->assertInstanceOf('PhpOffice\PhpWord\Element\FormField', $subElements[0]);
-        $this->assertEquals('checkbox', $subElements[0]->getType());
-        $this->assertEquals('SomeCheckbox', $subElements[0]->getName());
+        self::assertInstanceOf('PhpOffice\PhpWord\Element\FormField', $subElements[0]);
+        self::assertEquals('checkbox', $subElements[0]->getType());
+        self::assertEquals('SomeCheckbox', $subElements[0]->getName());
     }
 }


### PR DESCRIPTION
### Description

PHPWord had the option to create and write FormFields (checkbox, textinput and dropdown). This pull requests add the functionality to read those fields into the PHPWord model

Fixes #2281

Superseeds #2282 by @vincentKool

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/2.x/2.0.0.md)
