### PR TITLE
HTML Reader : Read width & height attributes in points

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5067,7 +5067,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "phpstan/phpstan-phpunit": 0
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/docs/changes/2.x/2.0.0.md
+++ b/docs/changes/2.x/2.0.0.md
@@ -22,6 +22,7 @@
 - Typo : Fix hardcoded macro chars in TemplateProcessor method [@glafarge](https://github.com/glafarge) in [#2618](https://github.com/PHPOffice/PHPWord/pull/2618)
 - XML Reader : Prevent fatal errors when opening corrupt files or "doc" files [@mmcev106](https://github.com/mmcev106) in [#2626](https://github.com/PHPOffice/PHPWord/pull/2626)
 - Documentation : Updated Comment element by [@laminga](https://github.com/laminga) in [#2650](https://github.com/PHPOffice/PHPWord/pull/2650)
+- HTML Reader : Read width & height attributes in points fixing [#2589](https://github.com/PHPOffice/PHPWord/issues/2589) by [@Progi1984](https://github.com/Progi1984) in [#2654](https://github.com/PHPOffice/PHPWord/pull/2654)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -902,12 +902,34 @@ class Html
                     break;
                 case 'width':
                     $width = $attribute->value;
+
+                    // pt
+                    if (false !== strpos($width, 'pt')) {
+                        $width = Converter::pointToPixel((float) str_replace('pt', '', $width));
+                    }
+
+                    // px
+                    if (false !== strpos($width, 'px')) {
+                        $width = str_replace('px', '', $width);
+                    }
+
                     $style['width'] = $width;
                     $style['unit'] = \PhpOffice\PhpWord\Style\Image::UNIT_PX;
 
                     break;
                 case 'height':
                     $height = $attribute->value;
+
+                    // pt
+                    if (false !== strpos($height, 'pt')) {
+                        $height = Converter::pointToPixel((float) str_replace('pt', '', $height));
+                    }
+
+                    // px
+                    if (false !== strpos($height, 'px')) {
+                        $height = str_replace('px', '', $height);
+                    }
+
                     $style['height'] = $height;
                     $style['unit'] = \PhpOffice\PhpWord\Style\Image::UNIT_PX;
 

--- a/tests/PhpWordTests/Shared/HtmlTest.php
+++ b/tests/PhpWordTests/Shared/HtmlTest.php
@@ -807,6 +807,66 @@ HTML;
     }
 
     /**
+     * Test parsing of img.
+     */
+    public function testParseImageSizeInPixels(): void
+    {
+        $src = __DIR__ . '/../_files/images/firefox.png';
+
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<p><img src="' . $src . '" width="150px" height="200px" /></p>';
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $baseXpath = '/w:document/w:body/w:p/w:r';
+        self::assertTrue($doc->elementExists($baseXpath . '/w:pict/v:shape'));
+        self::assertStringMatchesFormat('%Swidth:150px%S', $doc->getElementAttribute($baseXpath . '[1]/w:pict/v:shape', 'style'));
+        self::assertStringMatchesFormat('%Sheight:200px%S', $doc->getElementAttribute($baseXpath . '[1]/w:pict/v:shape', 'style'));
+    }
+
+    /**
+     * Test parsing of img.
+     */
+    public function testParseImageSizeInPoints(): void
+    {
+        $src = __DIR__ . '/../_files/images/firefox.png';
+
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<p><img src="' . $src . '" width="150pt" height="200pt" /></p>';
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $baseXpath = '/w:document/w:body/w:p/w:r';
+        self::assertTrue($doc->elementExists($baseXpath . '/w:pict/v:shape'));
+        self::assertStringMatchesFormat('%Swidth:200px%S', $doc->getElementAttribute($baseXpath . '[1]/w:pict/v:shape', 'style'));
+        self::assertStringMatchesFormat('%Sheight:266.66666666667%S', $doc->getElementAttribute($baseXpath . '[1]/w:pict/v:shape', 'style'));
+    }
+
+    /**
+     * Test parsing of img.
+     */
+    public function testParseImageSizeWithoutUnits(): void
+    {
+        $src = __DIR__ . '/../_files/images/firefox.png';
+
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<p><img src="' . $src . '" width="150" height="200" /></p>';
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $baseXpath = '/w:document/w:body/w:p/w:r';
+        self::assertTrue($doc->elementExists($baseXpath . '/w:pict/v:shape'));
+        self::assertStringMatchesFormat('%Swidth:150px%S', $doc->getElementAttribute($baseXpath . '[1]/w:pict/v:shape', 'style'));
+        self::assertStringMatchesFormat('%Sheight:200px%S', $doc->getElementAttribute($baseXpath . '[1]/w:pict/v:shape', 'style'));
+    }
+
+    /**
      * Test parsing of remote img.
      */
     public function testParseRemoteImage(): void


### PR DESCRIPTION
### Description

HTML Reader : Read width & height attributes in points

Fixes #2589

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/2.x/2.0.0.md)
