### PR TITLE
RTF Writer : Support for Table Border Style

### DIFF
--- a/docs/changes/2.x/2.0.0.md
+++ b/docs/changes/2.x/2.0.0.md
@@ -9,6 +9,7 @@
 - Word2007 Reader: Support for Paragraph Border Style by [@damienfa](https://github.com/damienfa) in [#2651](https://github.com/PHPOffice/PHPWord/pull/2651)
 - Word2007 Writer: Support for field REF by [@crystoline](https://github.com/crystoline) in [#2652](https://github.com/PHPOffice/PHPWord/pull/2652)
 - Word2007 Reader : Support for FormFields by [@vincentKool](https://github.com/vincentKool) in [#2653](https://github.com/PHPOffice/PHPWord/pull/2653)
+- RTF Writer : Support for Table Border Style fixing [#345](https://github.com/PHPOffice/PHPWord/issues/345) by [@Progi1984](https://github.com/Progi1984) in [#2656](https://github.com/PHPOffice/PHPWord/pull/2656)
 
 ### Bug fixes
 

--- a/src/PhpWord/Style/Border.php
+++ b/src/PhpWord/Style/Border.php
@@ -34,7 +34,7 @@ class Border extends AbstractStyle
     /**
      * Border Top Color.
      *
-     * @var string
+     * @var null|string
      */
     protected $borderTopColor;
 
@@ -55,7 +55,7 @@ class Border extends AbstractStyle
     /**
      * Border Left Color.
      *
-     * @var string
+     * @var null|string
      */
     protected $borderLeftColor;
 
@@ -76,7 +76,7 @@ class Border extends AbstractStyle
     /**
      * Border Right Color.
      *
-     * @var string
+     * @var null|string
      */
     protected $borderRightColor;
 
@@ -97,7 +97,7 @@ class Border extends AbstractStyle
     /**
      * Border Bottom Color.
      *
-     * @var string
+     * @var null|string
      */
     protected $borderBottomColor;
 
@@ -171,7 +171,7 @@ class Border extends AbstractStyle
     /**
      * Get border color.
      *
-     * @return string[]
+     * @return array<null|string>
      */
     public function getBorderColor()
     {
@@ -186,7 +186,7 @@ class Border extends AbstractStyle
     /**
      * Set border color.
      *
-     * @param string $value
+     * @param null|string $value
      *
      * @return self
      */
@@ -259,7 +259,7 @@ class Border extends AbstractStyle
     /**
      * Get border top color.
      *
-     * @return string
+     * @return null|string
      */
     public function getBorderTopColor()
     {
@@ -269,7 +269,7 @@ class Border extends AbstractStyle
     /**
      * Set border top color.
      *
-     * @param string $value
+     * @param null|string $value
      *
      * @return self
      */
@@ -331,7 +331,7 @@ class Border extends AbstractStyle
     /**
      * Get border left color.
      *
-     * @return string
+     * @return null|string
      */
     public function getBorderLeftColor()
     {
@@ -341,7 +341,7 @@ class Border extends AbstractStyle
     /**
      * Set border left color.
      *
-     * @param string $value
+     * @param null|string $value
      *
      * @return self
      */
@@ -403,7 +403,7 @@ class Border extends AbstractStyle
     /**
      * Get border right color.
      *
-     * @return string
+     * @return null|string
      */
     public function getBorderRightColor()
     {
@@ -413,7 +413,7 @@ class Border extends AbstractStyle
     /**
      * Set border right color.
      *
-     * @param string $value
+     * @param null|string $value
      *
      * @return self
      */
@@ -475,7 +475,7 @@ class Border extends AbstractStyle
     /**
      * Get border bottom color.
      *
-     * @return string
+     * @return null|string
      */
     public function getBorderBottomColor()
     {
@@ -485,7 +485,7 @@ class Border extends AbstractStyle
     /**
      * Set border bottom color.
      *
-     * @param string $value
+     * @param null|string $value
      *
      * @return self
      */

--- a/src/PhpWord/Writer/HTML/Element/Table.php
+++ b/src/PhpWord/Writer/HTML/Element/Table.php
@@ -120,9 +120,7 @@ class Table extends AbstractElement
             return '';
         }
         if (is_string($tableStyle)) {
-            $style = ' class="' . $tableStyle;
-
-            return $style . '"';
+            return ' class="' . $tableStyle . '"';
         }
 
         $styleWriter = new TableStyleWriter($tableStyle);

--- a/src/PhpWord/Writer/RTF/Element/AbstractElement.php
+++ b/src/PhpWord/Writer/RTF/Element/AbstractElement.php
@@ -24,7 +24,7 @@ use PhpOffice\PhpWord\Shared\Text as SharedText;
 use PhpOffice\PhpWord\Style;
 use PhpOffice\PhpWord\Style\Font as FontStyle;
 use PhpOffice\PhpWord\Style\Paragraph as ParagraphStyle;
-use PhpOffice\PhpWord\Writer\AbstractWriter;
+use PhpOffice\PhpWord\Writer\RTF as WriterRTF;
 use PhpOffice\PhpWord\Writer\RTF\Style\Font as FontStyleWriter;
 use PhpOffice\PhpWord\Writer\RTF\Style\Paragraph as ParagraphStyleWriter;
 
@@ -38,7 +38,7 @@ abstract class AbstractElement
     /**
      * Parent writer.
      *
-     * @var \PhpOffice\PhpWord\Writer\AbstractWriter
+     * @var WriterRTF
      */
     protected $parentWriter;
 
@@ -82,7 +82,7 @@ abstract class AbstractElement
      */
     protected $escaper;
 
-    public function __construct(AbstractWriter $parentWriter, Element $element, bool $withoutP = false)
+    public function __construct(WriterRTF $parentWriter, Element $element, bool $withoutP = false)
     {
         $this->parentWriter = $parentWriter;
         $this->element = $element;

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -21,6 +21,7 @@ use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\Shared\Converter;
 use PhpOffice\PhpWord\Style;
 use PhpOffice\PhpWord\Style\Font;
+use PhpOffice\PhpWord\Style\Table;
 
 /**
  * RTF header part writer.
@@ -236,6 +237,14 @@ class Header extends AbstractPart
             $this->registerTableItem($this->fontTable, $style->getName(), $defaultFont);
             $this->registerTableItem($this->colorTable, $style->getColor(), $defaultColor);
             $this->registerTableItem($this->colorTable, $style->getFgColor(), $defaultColor);
+
+            return;
+        }
+        if ($style instanceof Table) {
+            $this->registerTableItem($this->colorTable, $style->getBorderTopColor(), $defaultColor);
+            $this->registerTableItem($this->colorTable, $style->getBorderRightColor(), $defaultColor);
+            $this->registerTableItem($this->colorTable, $style->getBorderLeftColor(), $defaultColor);
+            $this->registerTableItem($this->colorTable, $style->getBorderBottomColor(), $defaultColor);
         }
     }
 

--- a/src/PhpWord/Writer/Word2007/Style/MarginBorder.php
+++ b/src/PhpWord/Writer/Word2007/Style/MarginBorder.php
@@ -120,7 +120,7 @@ class MarginBorder extends AbstractStyle
     /**
      * Set colors.
      *
-     * @param string[] $value
+     * @param array<null|string> $value
      */
     public function setColors($value): void
     {

--- a/tests/PhpWordTests/Writer/RTF/Element/TableTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Element/TableTest.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWordTests\Writer\RTF\Element;
+
+use PhpOffice\PhpWord\Element\Table;
+use PhpOffice\PhpWord\Settings;
+use PhpOffice\PhpWord\SimpleType\Border;
+use PhpOffice\PhpWord\Style;
+use PhpOffice\PhpWord\Writer\RTF;
+use PhpOffice\PhpWord\Writer\RTF\Element\Table as WriterTable;
+
+class TableTest extends \PHPUnit\Framework\TestCase
+{
+    protected function tearDown(): void
+    {
+        Settings::setDefaultRtl(null);
+    }
+
+    public function removeCr(WriterTable $field): string
+    {
+        return str_replace("\r\n", "\n", $field->write());
+    }
+
+    public function testTable(): void
+    {
+        Settings::setDefaultRtl(false);
+        $parentWriter = new RTF();
+        $element = new \PhpOffice\PhpWord\Element\Table();
+        $width = 100;
+        $width2 = 2 * $width;
+        $element->addRow();
+        $tce = $element->addCell($width);
+        $tce->addText('1');
+        $tce = $element->addCell($width);
+        $tce->addText('2');
+        $element->addRow();
+        $tce = $element->addCell($width);
+        $tce->addText('3');
+        $tce = $element->addCell($width);
+        $tce->addText('4');
+        $table = new WriterTable($parentWriter, $element);
+        $expect = implode("\n", [
+            '\\pard',
+            "\\trowd \\cellx$width \\cellx$width2 ",
+            '\\intbl',
+            '\\ql{\\cf0\\f0 1}\\par',
+            '\\cell',
+            '\\intbl',
+            '{\\cf0\\f0 2}\\par',
+            '\\cell',
+            '\\row',
+            "\\trowd \\cellx$width \\cellx$width2 ",
+            '\\intbl',
+            '\\ql{\\cf0\\f0 3}\\par',
+            '\\cell',
+            '\\intbl',
+            '{\\cf0\\f0 4}\par',
+            '\\cell',
+            '\\row',
+            '\\pard',
+            '',
+        ]);
+
+        self::assertEquals($expect, $this->removeCr($table));
+    }
+
+    public function testTableStyle(): void
+    {
+        $width = 100;
+
+        Settings::setDefaultRtl(false);
+        $parentWriter = new RTF();
+
+        Style::addTableStyle('TableStyle', ['borderSize' => 6, 'borderColor' => '006699']);
+
+        $element = new Table('TableStyle');
+        $element->addRow();
+        $elementCell = $element->addCell($width);
+        $elementCell->addText('1');
+
+        $expect = implode("\n", [
+            '\\pard',
+            '\\trowd \\clbrdrt\\brdrs\\brdrw2\\brdrcf0',
+            '\\clbrdrl\\brdrs\\brdrw2\\brdrcf0',
+            '\\clbrdrb\\brdrs\\brdrw2\\brdrcf0',
+            '\\clbrdrr\\brdrs\\brdrw2\\brdrcf0',
+            "\\cellx$width ",
+            '\\intbl',
+            '\\ql{\\cf0\\f0 1}\\par',
+            '\\cell',
+            '\\row',
+            '\\pard',
+            '',
+        ]);
+
+        self::assertEquals($expect, $this->removeCr(new WriterTable($parentWriter, $element)));
+    }
+
+    public function testTableStyleNotExisting(): void
+    {
+        $width = 100;
+
+        Settings::setDefaultRtl(false);
+        $parentWriter = new RTF();
+
+        $element = new Table('TableStyleNotExisting');
+        $element->addRow();
+        $elementCell = $element->addCell($width);
+        $elementCell->addText('1');
+
+        $expect = implode("\n", [
+            '\\pard',
+            "\\trowd \\cellx$width ",
+            '\\intbl',
+            '\\ql{\\cf0\\f0 1}\\par',
+            '\\cell',
+            '\\row',
+            '\\pard',
+            '',
+        ]);
+
+        self::assertEquals($expect, $this->removeCr(new WriterTable($parentWriter, $element)));
+    }
+
+    public function testTableCellStyle(): void
+    {
+        $width = 100;
+
+        Settings::setDefaultRtl(false);
+        $parentWriter = new RTF();
+
+        $element = new Table();
+        $element->addRow();
+        $elementCell = $element->addCell($width, ['borderSize' => 6, 'borderColor' => '006699', 'borderStyle' => Border::DOTTED]);
+        $elementCell->addText('1');
+
+        $expect = implode("\n", [
+            '\\pard',
+            '\\trowd \\clbrdrt\\brdrdot\\brdrw2\\brdrcf0',
+            '\\clbrdrl\\brdrdot\\brdrw2\\brdrcf0',
+            '\\clbrdrb\\brdrdot\\brdrw2\\brdrcf0',
+            '\\clbrdrr\\brdrdot\\brdrw2\\brdrcf0',
+            "\\cellx$width ",
+            '\\intbl',
+            '\\ql{\\cf0\\f0 1}\\par',
+            '\\cell',
+            '\\row',
+            '\\pard',
+            '',
+        ]);
+
+        self::assertEquals($expect, $this->removeCr(new WriterTable($parentWriter, $element)));
+    }
+}

--- a/tests/PhpWordTests/Writer/RTF/Element2Test.php
+++ b/tests/PhpWordTests/Writer/RTF/Element2Test.php
@@ -19,7 +19,6 @@ namespace PhpOffice\PhpWordTests\Writer\RTF;
 
 use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\Writer\RTF;
-use PhpOffice\PhpWord\Writer\RTF\Element\Table as WriterTable;
 use PhpOffice\PhpWord\Writer\RTF\Element\TextRun as WriterTextRun;
 use PhpOffice\PhpWord\Writer\RTF\Element\Title as WriterTitle;
 
@@ -33,53 +32,10 @@ class Element2Test extends \PHPUnit\Framework\TestCase
         Settings::setDefaultRtl(null);
     }
 
-    /** @param WriterTable|WriterTextRun|WriterTitle $field */
+    /** @param WriterTextRun|WriterTitle $field */
     public function removeCr($field): string
     {
         return str_replace("\r\n", "\n", $field->write());
-    }
-
-    public function testTable(): void
-    {
-        Settings::setDefaultRtl(false);
-        $parentWriter = new RTF();
-        $element = new \PhpOffice\PhpWord\Element\Table();
-        $width = 100;
-        $width2 = 2 * $width;
-        $element->addRow();
-        $tce = $element->addCell($width);
-        $tce->addText('1');
-        $tce = $element->addCell($width);
-        $tce->addText('2');
-        $element->addRow();
-        $tce = $element->addCell($width);
-        $tce->addText('3');
-        $tce = $element->addCell($width);
-        $tce->addText('4');
-        $table = new WriterTable($parentWriter, $element);
-        $expect = implode("\n", [
-            '\\pard',
-            "\\trowd \\cellx$width \\cellx$width2 ",
-            '\\intbl',
-            '\\ql{\\cf0\\f0 1}\\par',
-            '\\cell',
-            '\\intbl',
-            '{\\cf0\\f0 2}\\par',
-            '\\cell',
-            '\\row',
-            "\\trowd \\cellx$width \\cellx$width2 ",
-            '\\intbl',
-            '\\ql{\\cf0\\f0 3}\\par',
-            '\\cell',
-            '\\intbl',
-            '{\\cf0\\f0 4}\par',
-            '\\cell',
-            '\\row',
-            '\\pard',
-            '',
-        ]);
-
-        self::assertEquals($expect, $this->removeCr($table));
     }
 
     public function testTextRun(): void


### PR DESCRIPTION
### Description

RTF Writer : Support for Table Border Style

Fixes #245
Fixes #345

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/2.x/2.0.0.md)
