### PR TITLE
Word2007 Writer : Fixed StrikeThrough property

### DIFF
--- a/docs/changes/1.x/1.3.0.md
+++ b/docs/changes/1.x/1.3.0.md
@@ -28,6 +28,7 @@
 - Word2007 Writer : Fix first footnote appearing as separator [#2634](https://github.com/PHPOffice/PHPWord/issues/2634) by [@jacksleight](https://github.com/jacksleight) in [#2635](https://github.com/PHPOffice/PHPWord/pull/2635)
 - Template Processor : Fixed images with transparent backgrounds displaying a white background by [@ElwynVdb](https://github.com/ElwynVdb) in [#2638](https://github.com/PHPOffice/PHPWord/pull/2638)
 - HTML Writer : Fixed rowspan for tables by [@andomiell](https://github.com/andomiell) in [#2659](https://github.com/PHPOffice/PHPWord/pull/2659)
+- Word2007 Writer : Fixed StrikeThrough property by [@noec764](https://github.com/noec764) fixing [#1722](https://github.com/PHPOffice/PHPWord/issues/1722) & [#1693](https://github.com/PHPOffice/PHPWord/issues/1693) in [#2661](https://github.com/PHPOffice/PHPWord/pull/2661)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Style/Font.php
+++ b/src/PhpWord/Style/Font.php
@@ -565,10 +565,8 @@ class Font extends AbstractStyle
 
     /**
      * Get strikethrough.
-     *
-     * @return bool
      */
-    public function isStrikethrough()
+    public function isStrikethrough(): ?bool
     {
         return $this->strikethrough;
     }
@@ -577,20 +575,16 @@ class Font extends AbstractStyle
      * Set strikethrough.
      *
      * @param bool $value
-     *
-     * @return self
      */
-    public function setStrikethrough($value = true)
+    public function setStrikethrough($value = true): self
     {
         return $this->setPairedVal($this->strikethrough, $this->doubleStrikethrough, $value);
     }
 
     /**
      * Get double strikethrough.
-     *
-     * @return bool
      */
-    public function isDoubleStrikethrough()
+    public function isDoubleStrikethrough(): ?bool
     {
         return $this->doubleStrikethrough;
     }
@@ -599,10 +593,8 @@ class Font extends AbstractStyle
      * Set double strikethrough.
      *
      * @param bool $value
-     *
-     * @return self
      */
-    public function setDoubleStrikethrough($value = true)
+    public function setDoubleStrikethrough($value = true): self
     {
         return $this->setPairedVal($this->doubleStrikethrough, $this->strikethrough, $value);
     }

--- a/src/PhpWord/Writer/Word2007/Style/Font.php
+++ b/src/PhpWord/Writer/Word2007/Style/Font.php
@@ -117,8 +117,8 @@ class Font extends AbstractStyle
         $xmlWriter->writeElementIf($style->isItalic() !== null, 'w:iCs', 'w:val', $this->writeOnOf($style->isItalic()));
 
         // Strikethrough, double strikethrough
-        $xmlWriter->writeElementIf($style->isStrikethrough() !== null, 'w:strike', 'w:val', $this->writeOnOf($style->isStrikethrough()));
-        $xmlWriter->writeElementIf($style->isDoubleStrikethrough() !== null, 'w:dstrike', 'w:val', $this->writeOnOf($style->isDoubleStrikethrough()));
+        $xmlWriter->writeElementIf($style->isStrikethrough(), 'w:strike', 'w:val', $this->writeOnOf($style->isStrikethrough()));
+        $xmlWriter->writeElementIf($style->isDoubleStrikethrough(), 'w:dstrike', 'w:val', $this->writeOnOf($style->isDoubleStrikethrough()));
 
         // Small caps, all caps
         $xmlWriter->writeElementIf($style->isSmallCaps() !== null, 'w:smallCaps', 'w:val', $this->writeOnOf($style->isSmallCaps()));

--- a/tests/PhpWordTests/Writer/Word2007/Part/DocumentTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/Part/DocumentTest.php
@@ -533,10 +533,45 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         self::assertTrue($doc->elementExists("{$parent}/w:i"));
         self::assertEquals($styles['underline'], $doc->getElementAttribute("{$parent}/w:u", 'w:val'));
         self::assertTrue($doc->elementExists("{$parent}/w:strike"));
+        self::assertFalse($doc->elementExists("{$parent}/w:dstrike"));
         self::assertEquals('superscript', $doc->getElementAttribute("{$parent}/w:vertAlign", 'w:val'));
         self::assertEquals($styles['color'], $doc->getElementAttribute("{$parent}/w:color", 'w:val'));
         self::assertEquals($styles['fgColor'], $doc->getElementAttribute("{$parent}/w:highlight", 'w:val'));
         self::assertTrue($doc->elementExists("{$parent}/w:smallCaps"));
+    }
+
+    /**
+     * covers ::_writeTextStyle.
+     *
+     * @dataProvider providerFontStyleStrikethrough
+     */
+    public function testWriteFontStyleStrikethrough(
+        bool $isStrikethrough,
+        bool $isDoubleStrikethrough,
+        bool $expectedStrikethrough,
+        bool $expectedDoubleStrikethrough
+    ): void {
+        $phpWord = new PhpWord();
+        $styles['strikethrough'] = $isStrikethrough;
+        $styles['doublestrikethrough'] = $isDoubleStrikethrough;
+
+        $section = $phpWord->addSection();
+        $section->addText('Test', $styles);
+        $doc = TestHelperDOCX::getDocument($phpWord);
+
+        $parent = '/w:document/w:body/w:p/w:r/w:rPr';
+        self::assertSame($expectedStrikethrough, $doc->elementExists("{$parent}/w:strike"));
+        self::assertSame($expectedDoubleStrikethrough, $doc->elementExists("{$parent}/w:dstrike"));
+    }
+
+    public static function providerFontStyleStrikethrough(): iterable
+    {
+        return [
+            [true, true, false, true],
+            [true, false, true, false],
+            [false, true, false, true],
+            [false, false, false, false],
+        ];
     }
 
     /**


### PR DESCRIPTION
### Description

Word2007 Writer : Fixed StrikeThrough property

Superseeds #2604 by @noec764

Fixes #1693
Fixes #1722

> If a strikethrough style was added to a text element it never appeared in the resulting document.
> Indeed, the XML generated was as follows
> ```
><w:r>
>    <w:rPr>
>        <w:strike w:val="1"/>
>        <w:dstrike w:val="0"/>
>     </w:rPr>
>     <w:t xml:space="preserve">some text</w:t>
></w:r>
>```
> The statement `<w:dstrike w:val="0"/>` should not be present here
> I figure out that the test  `$style->isDoubleStrikethrough() !== null` is true if `$style->isDoubleStrikethrough() === false`
> So as a text cannot be strike and doublestrike at the same time, word2007 ignores it.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/2.x/2.0.0.md)
