### PR TITLE
Word2007 Reader: Support the page break (`<w:lastRenderedPageBreak/>`)

### DIFF
--- a/docs/changes/1.x/1.3.0.md
+++ b/docs/changes/1.x/1.3.0.md
@@ -10,6 +10,7 @@
 - Word2007 Writer: Support for field REF by [@crystoline](https://github.com/crystoline) in [#2652](https://github.com/PHPOffice/PHPWord/pull/2652)
 - Word2007 Reader : Support for FormFields by [@vincentKool](https://github.com/vincentKool) in [#2653](https://github.com/PHPOffice/PHPWord/pull/2653)
 - RTF Writer : Support for Table Border Style fixing [#345](https://github.com/PHPOffice/PHPWord/issues/345) by [@Progi1984](https://github.com/Progi1984) in [#2656](https://github.com/PHPOffice/PHPWord/pull/2656)
+- Word2007 Reader: Support the page break (<w:lastRenderedPageBreak/>) by [@stanolacko](https://github.com/stanolacko) in [#2662](https://github.com/PHPOffice/PHPWord/pull/2662)
 
 ### Bug fixes
 

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -236,18 +236,21 @@ abstract class AbstractPart
             $fontStyle = $this->readFontStyle($xmlReader, $domNode);
             $nodes = $xmlReader->getElements('w:r', $domNode);
             foreach ($nodes as $node) {
-                $instrText = $xmlReader->getValue('w:instrText', $node);
-                if ($xmlReader->elementExists('w:fldChar', $node)) {
-                    $fldCharType = $xmlReader->getAttribute('w:fldCharType', $node, 'w:fldChar');
-                    if ('begin' == $fldCharType) {
-                        $ignoreText = true;
-                    } elseif ('end' == $fldCharType) {
-                        $ignoreText = false;
-                    }
+                if ($xmlReader->elementExists('w:lastRenderedPageBreak', $node)) {
+                    $parent->addPageBreak();
                 }
+                $instrText = $xmlReader->getValue('w:instrText', $node);
                 if (null !== $instrText) {
                     $textContent .= '{' . $instrText . '}';
                 } else {
+                    if ($xmlReader->elementExists('w:fldChar', $node)) {
+                        $fldCharType = $xmlReader->getAttribute('w:fldCharType', $node, 'w:fldChar');
+                        if ('begin' == $fldCharType) {
+                            $ignoreText = true;
+                        } elseif ('end' == $fldCharType) {
+                            $ignoreText = false;
+                        }
+                    }
                     if (false === $ignoreText) {
                         $textContent .= $xmlReader->getValue('w:t', $node);
                     }

--- a/src/PhpWord/Reader/Word2007/Document.php
+++ b/src/PhpWord/Reader/Word2007/Document.php
@@ -138,8 +138,6 @@ class Document extends AbstractPart
 
     /**
      * Read w:p node.
-     *
-     * @todo <w:lastRenderedPageBreak>
      */
     private function readWPNode(XMLReader $xmlReader, DOMElement $node, Section &$section): void
     {


### PR DESCRIPTION
### Description

Word2007 Reader: Support the page break (<w:lastRenderedPageBreak/>)

Some Word2007 document are using <w:lastRenderedPageBreak/>for page break. When converting this document to PDF, it does not add page break in final PDF.

Superseeds #2573 by @stanolacko

Fixes # (issue)

### Checklist:

- [x] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/2.x/2.0.0.md)
