### PR TITLE
Feature: Add support for the firstLineChars style in Word2007.

### DIFF
--- a/src/PhpWord/Style/Indentation.php
+++ b/src/PhpWord/Style/Indentation.php
@@ -47,6 +47,13 @@ class Indentation extends AbstractStyle
     private $firstLine = 0;
 
     /**
+     * Additional first line chars indentation (twip).
+     *
+     * @var float|int
+     */
+    private $firstLineChars = 0;
+
+    /**
      * Indentation removed from first line (twip).
      *
      * @var float|int
@@ -132,6 +139,29 @@ class Indentation extends AbstractStyle
     {
         $this->firstLine = $this->setNumericVal($value, $this->firstLine);
 
+        return $this;
+    }
+
+    /**
+     * Get first line chars.
+     *
+     * @return float|int
+     */
+    public function getFirstLineChars()
+    {
+        return $this->firstLineChars;
+    }
+
+    /**
+     * Set first line chars.
+     *
+     * @param float|int $value
+     *
+     * @return $this
+     */
+    public function setFirstLineChars($value)
+    {
+        $this->firstLineChars = $this->setNumericVal($value, $this->firstLineChars);
         return $this;
     }
 

--- a/src/PhpWord/Writer/Word2007/Style/Indentation.php
+++ b/src/PhpWord/Writer/Word2007/Style/Indentation.php
@@ -43,6 +43,9 @@ class Indentation extends AbstractStyle
         $firstLine = $style->getFirstLine();
         $xmlWriter->writeAttributeIf(null !== $firstLine, 'w:firstLine', $this->convertTwip($firstLine));
 
+        $firstLineChars = $style->getFirstLineChars();
+        $xmlWriter->writeAttributeIf(null !== $firstLineChars, 'w:firstLineChars', $this->convertTwip($firstLineChars));
+
         $hanging = $style->getHanging();
         $xmlWriter->writeAttributeIf(null !== $hanging, 'w:hanging', $this->convertTwip($hanging));
 


### PR DESCRIPTION
### Description

Add support for the firstLineChars style in Word2007.

![微信截图_20240902103751](https://github.com/user-attachments/assets/a9576b53-2bf4-4a16-8860-27e090e9efd9)


Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist:

- [x] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [ ] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/2.x/2.0.0.md)
