### PR TITLE
feat: Add support for vAlign styles in the HTML Writer (Table)

### DIFF
--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -5,6 +5,7 @@
 ## Enhancements
 
 - Writer ODText: Support for ListItemRun by [@Progi1984](https://github.com/Progi1984) fixing [#2159](https://github.com/PHPOffice/PHPWord/issues/2159), [#2620](https://github.com/PHPOffice/PHPWord/issues/2620) in [#2669](https://github.com/PHPOffice/PHPWord/pull/2669)
+- Writer HTML: Support for vAlign in Tables by [@SpraxDev](https://github.com/SpraxDev) in [#2675](https://github.com/PHPOffice/PHPWord/pull/2675)
 
 ### Bug fixes
 

--- a/src/PhpWord/Writer/HTML/Style/Table.php
+++ b/src/PhpWord/Writer/HTML/Style/Table.php
@@ -46,6 +46,9 @@ class Table extends AbstractStyle
                 $css['direction'] = 'rtl';
             }
         }
+        if (is_object($style) && method_exists($style, 'getVAlign')) {
+            $css['vertical-align'] = $style->getVAlign();
+        }
 
         foreach (['Top', 'Left', 'Bottom', 'Right'] as $direction) {
             $method = 'getBorder' . $direction . 'Style';

--- a/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
@@ -19,7 +19,7 @@ namespace PhpOffice\PhpWordTests\Writer\HTML\Element;
 
 use DOMXPath;
 use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Writer\HTML\Element\Table;
+use PhpOffice\PhpWord\SimpleType\VerticalJc;
 use PhpOffice\PhpWordTests\Writer\HTML\Helper;
 use PHPUnit\Framework\TestCase;
 
@@ -161,5 +161,30 @@ class TableTest extends TestCase
         $style = Helper::getTextContent($xpath, '/html/head/style');
         self::assertNotFalse(preg_match('/^[.]tstyle[^\\r\\n]*/m', $style, $matches));
         self::assertEquals(".tstyle {table-layout: auto; $cssnone}", $matches[0]);
+    }
+
+    public function testWriteTableCellVAlign(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+
+        $table = $section->addTable();
+        $row = $table->addRow();
+
+        $cell = $row->addCell();
+        $cell->addText('top text');
+        $cell->getStyle()->setVAlign(VerticalJc::TOP);
+
+        $cell = $row->addCell();
+        $cell->addText('bottom text');
+        $cell->getStyle()->setVAlign(VerticalJc::BOTTOM);
+
+        $dom = Helper::getAsHTML($phpWord);
+        $xpath = new DOMXPath($dom);
+
+        $cell1Style = Helper::getTextContent($xpath, '//table/tr/td[1]', 'style');
+        $cell2Style = Helper::getTextContent($xpath, '//table/tr/td[2]', 'style');
+        self::assertSame('vertical-align: top;', $cell1Style);
+        self::assertSame('vertical-align: bottom;', $cell2Style);
     }
 }


### PR DESCRIPTION
### Description

vAlign is parsed by PHPWord but the HTMLWriter does not support it yet.

~~Fixes # (issue)~~ (no related open issue found)

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] ~~I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes~~ (does not apply)
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)
