### PR TITLE
fix: Allow vAlign and vMerge on Style\Cell to be set to null

### DIFF
--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -10,6 +10,7 @@
 ### Bug fixes
 
 - Writer ODText: Support for images inside a textRun by [@Progi1984](https://github.com/Progi1984) fixing [#2240](https://github.com/PHPOffice/PHPWord/issues/2240) in [#2668](https://github.com/PHPOffice/PHPWord/pull/2668)
+- Allow vAlign and vMerge on Style\Cell to be set to null by [@SpraxDev](https://github.com/SpraxDev) fixing [#2673](https://github.com/PHPOffice/PHPWord/issues/2673) in [#2676](https://github.com/PHPOffice/PHPWord/pull/2676)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Style/Cell.php
+++ b/src/PhpWord/Style/Cell.php
@@ -69,7 +69,7 @@ class Cell extends Border
     /**
      * Vertical align (top, center, both, bottom).
      *
-     * @var string
+     * @var null|string
      */
     private $vAlign;
 
@@ -93,7 +93,7 @@ class Cell extends Border
      * - restart: Start/restart merged region
      * - continue: Continue merged region
      *
-     * @var string
+     * @var null|string
      */
     private $vMerge;
 
@@ -128,7 +128,7 @@ class Cell extends Border
     /**
      * Get vertical align.
      *
-     * @return string
+     * @return null|string
      */
     public function getVAlign()
     {
@@ -138,12 +138,18 @@ class Cell extends Border
     /**
      * Set vertical align.
      *
-     * @param string $value
+     * @param null|string $value
      *
      * @return self
      */
     public function setVAlign($value = null)
     {
+        if ($value === null) {
+            $this->vAlign = null;
+
+            return $this;
+        }
+
         VerticalJc::validate($value);
         $this->vAlign = $this->setEnumVal($value, VerticalJc::values(), $this->vAlign);
 
@@ -235,7 +241,7 @@ class Cell extends Border
     /**
      * Get vertical merge (rowspan).
      *
-     * @return string
+     * @return null|string
      */
     public function getVMerge()
     {
@@ -245,12 +251,18 @@ class Cell extends Border
     /**
      * Set vertical merge (rowspan).
      *
-     * @param string $value
+     * @param null|string $value
      *
      * @return self
      */
     public function setVMerge($value = null)
     {
+        if ($value === null) {
+            $this->vMerge = null;
+
+            return $this;
+        }
+
         $enum = [self::VMERGE_RESTART, self::VMERGE_CONTINUE];
         $this->vMerge = $this->setEnumVal($value, $enum, $this->vMerge);
 

--- a/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
@@ -179,6 +179,11 @@ class TableTest extends TestCase
         $cell->addText('bottom text');
         $cell->getStyle()->setVAlign(VerticalJc::BOTTOM);
 
+        $cell = $row->addCell();
+        $cell->addText('no vAlign');
+        $cell->getStyle()->setVAlign(VerticalJc::BOTTOM);
+        $cell->getStyle()->setVAlign();
+
         $dom = Helper::getAsHTML($phpWord);
         $xpath = new DOMXPath($dom);
 
@@ -186,5 +191,12 @@ class TableTest extends TestCase
         $cell2Style = Helper::getTextContent($xpath, '//table/tr/td[2]', 'style');
         self::assertSame('vertical-align: top;', $cell1Style);
         self::assertSame('vertical-align: bottom;', $cell2Style);
+
+        $cell3Query = $xpath->query('//table/tr/td[3]');
+        self::assertNotFalse($cell3Query);
+        self::assertCount(1, $cell3Query);
+
+        $cell3Style = $cell3Query->item(0)->attributes->getNamedItem('style');
+        self::assertNull($cell3Style);
     }
 }


### PR DESCRIPTION
### Description

vAlign and vMerge are initialized as `null` until it is explicitly set. Right now, it is not possible to unset them, after it has been set once.

I've added a null-check to skip the validation, based on the default parameter value of `null`, which indicates to me that it once was intended to work like this.

I've also fixed the type-hints, which were wrong from the start.

Fixes #2673

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] ~~I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes~~ (does not apply)
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)
