### PR TITLE
test: Add test case for vMerge's default value of continue

### DIFF
--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -15,5 +15,6 @@
 ### Miscellaneous
 
 - Bump dompdf/dompdf from 2.0.4 to 3.0.0 by [@dependabot](https://github.com/dependabot) fixing [#2621](https://github.com/PHPOffice/PHPWord/issues/2621) in [#2666](https://github.com/PHPOffice/PHPWord/pull/2666)
+- Add test case to make sure vMerge defaults to 'continue' by [@SpraxDev](https://github.com/SpraxDev) in [#2677](https://github.com/PHPOffice/PHPWord/pull/2677)
 
 ### BC Breaks

--- a/tests/PhpWordTests/Reader/Word2007/StyleTest.php
+++ b/tests/PhpWordTests/Reader/Word2007/StyleTest.php
@@ -165,6 +165,44 @@ class StyleTest extends AbstractTestReader
         self::assertEquals('auto', $styleCell->getBorderBottomColor());
     }
 
+    public function testReadTableCellsWithVerticalMerge(): void
+    {
+        $documentXml = '<w:tbl>
+          <w:tr>
+            <w:tc>
+              <w:tcPr>
+                <w:vMerge w:val="restart" />
+              </w:tcPr>
+            </w:tc>
+          </w:tr>
+          <w:tr>
+            <w:tc>
+              <w:tcPr>
+                <w:vMerge />
+              </w:tcPr>
+            </w:tc>
+          </w:tr>
+          <w:tr>
+            <w:tc />
+          </w:tr>
+        </w:tbl>';
+
+        $phpWord = $this->getDocumentFromString(['document' => $documentXml]);
+
+        $table = $phpWord->getSection(0)->getElements()[0];
+        self::assertInstanceOf('PhpOffice\PhpWord\Element\Table', $table);
+
+        $rows = $table->getRows();
+        self::assertCount(3, $rows);
+        foreach ($rows as $row) {
+            self::assertCount(1, $row->getCells());
+        }
+
+        self::assertSame('restart', $rows[0]->getCells()[0]->getStyle()->getVMerge());
+        self::assertSame('continue', $rows[1]->getCells()[0]->getStyle()->getVMerge());
+        self::assertNull($rows[2]->getCells()[0]->getStyle()->getVMerge());
+    }
+
     /**
      * Test reading of position.
      */


### PR DESCRIPTION
### Description

This new test case essentially covers the changes in b457ff5f7fadf28f4d62d1fcd5b9ee3424392835.
It ensures the new behavior works as intended and doesn't break/change by accident in the future.

~~Fixes # (issue)~~ (does not apply)

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] ~~I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes~~ (does not apply)
- [x] ~~I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)~~ (does not apply)
