### PR TITLE
Fix that style objects cannot be passed to element constructors

### DIFF
--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -11,6 +11,7 @@
 
 - Writer ODText: Support for images inside a textRun by [@Progi1984](https://github.com/Progi1984) fixing [#2240](https://github.com/PHPOffice/PHPWord/issues/2240) in [#2668](https://github.com/PHPOffice/PHPWord/pull/2668)
 - Allow vAlign and vMerge on Style\Cell to be set to null by [@SpraxDev](https://github.com/SpraxDev) fixing [#2673](https://github.com/PHPOffice/PHPWord/issues/2673) in [#2676](https://github.com/PHPOffice/PHPWord/pull/2676)
+- Fixed that passed style objects to the constructor of elements were ignored like `\PhpOffice\PhpWord\Style\Cell` for `\PhpOffice\PhpWord\Element\Cell` by [@hazington](https://github.com/hazington)
 
 ### Miscellaneous
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,16 +11,6 @@ parameters:
 			path: src/PhpWord/Element/AbstractContainer.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function md5 expects string, int\\<0, max\\> given\\.$#"
-			count: 1
-			path: src/PhpWord/Element/AbstractElement.php
-
-		-
-			message: "#^Parameter \\#2 \\$styleValue of method PhpOffice\\\\PhpWord\\\\Element\\\\AbstractElement\\:\\:setNewStyle\\(\\) expects array\\|PhpOffice\\\\PhpWord\\\\Style\\|string\\|null, array\\|PhpOffice\\\\PhpWord\\\\Style\\\\Cell\\|null given\\.$#"
-			count: 1
-			path: src/PhpWord/Element/Cell.php
-
-		-
 			message: "#^Method PhpOffice\\\\PhpWord\\\\Element\\\\Field\\:\\:setOptions\\(\\) should return PhpOffice\\\\PhpWord\\\\Element\\\\Field but returns array\\.$#"
 			count: 1
 			path: src/PhpWord/Element/Field.php
@@ -39,11 +29,6 @@ parameters:
 			message: "#^Result of \\|\\| is always true\\.$#"
 			count: 1
 			path: src/PhpWord/Element/Field.php
-
-		-
-			message: "#^Parameter \\#2 \\$styleValue of method PhpOffice\\\\PhpWord\\\\Element\\\\AbstractElement\\:\\:setNewStyle\\(\\) expects array\\|PhpOffice\\\\PhpWord\\\\Style\\|string\\|null, array\\|PhpOffice\\\\PhpWord\\\\Style\\\\Paragraph\\|string\\|null given\\.$#"
-			count: 1
-			path: src/PhpWord/Element/Footnote.php
 
 		-
 			message: "#^Method PhpOffice\\\\PhpWord\\\\Element\\\\Image\\:\\:getArchiveImageSize\\(\\) should return array\\|null but returns array<int\\|string, int\\|string>\\|false\\|null\\.$#"
@@ -82,11 +67,6 @@ parameters:
 
 		-
 			message: "#^Method PhpOffice\\\\PhpWord\\\\Element\\\\Section\\:\\:addHeaderFooter\\(\\) should return PhpOffice\\\\PhpWord\\\\Element\\\\Footer but returns PhpOffice\\\\PhpWord\\\\Element\\\\AbstractContainer\\.$#"
-			count: 1
-			path: src/PhpWord/Element/Section.php
-
-		-
-			message: "#^Parameter \\#2 \\$styleValue of method PhpOffice\\\\PhpWord\\\\Element\\\\AbstractElement\\:\\:setNewStyle\\(\\) expects array\\|PhpOffice\\\\PhpWord\\\\Style\\|string\\|null, array\\|PhpOffice\\\\PhpWord\\\\Style\\|PhpOffice\\\\PhpWord\\\\Style\\\\Section\\|string given\\.$#"
 			count: 1
 			path: src/PhpWord/Element/Section.php
 

--- a/src/PhpWord/Element/AbstractElement.php
+++ b/src/PhpWord/Element/AbstractElement.php
@@ -19,12 +19,10 @@ namespace PhpOffice\PhpWord\Element;
 
 use DateTime;
 use InvalidArgumentException;
-use function is_array;
 use PhpOffice\PhpWord\Collection\Comments;
 use PhpOffice\PhpWord\Media;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Style;
-
 use PhpOffice\PhpWord\Style\AbstractStyle;
 
 /**
@@ -484,13 +482,13 @@ abstract class AbstractElement
     /**
      * Set new style value.
      *
-     * @param AbstractStyle $styleObject Style object
+     * @param mixed $styleObject Style object
      * @param null|AbstractStyle|array|string|Style $styleValue Style value
      * @param bool $returnObject Always return object
      *
      * @return mixed
      */
-    protected function setNewStyle($styleObject, $styleValue = null, $returnObject = false)
+    protected function setNewStyle($styleObject, $styleValue = null, bool $returnObject = false)
     {
         if ($styleValue instanceof AbstractStyle && get_class($styleValue) === get_class($styleObject)) {
             return $styleValue;

--- a/src/PhpWord/Element/AbstractElement.php
+++ b/src/PhpWord/Element/AbstractElement.php
@@ -485,7 +485,7 @@ abstract class AbstractElement
      * Set new style value.
      *
      * @param AbstractStyle $styleObject Style object
-     * @param null|AbstractStyle|array|string $styleValue Style value
+     * @param null|AbstractStyle|Style|array|string $styleValue Style value
      * @param bool $returnObject Always return object
      *
      * @return mixed

--- a/src/PhpWord/Element/AbstractElement.php
+++ b/src/PhpWord/Element/AbstractElement.php
@@ -485,7 +485,7 @@ abstract class AbstractElement
      * Set new style value.
      *
      * @param AbstractStyle $styleObject Style object
-     * @param null|AbstractStyle|Style|array|string $styleValue Style value
+     * @param null|AbstractStyle|array|string|Style $styleValue Style value
      * @param bool $returnObject Always return object
      *
      * @return mixed

--- a/src/PhpWord/Element/AbstractElement.php
+++ b/src/PhpWord/Element/AbstractElement.php
@@ -19,13 +19,13 @@ namespace PhpOffice\PhpWord\Element;
 
 use DateTime;
 use InvalidArgumentException;
+use function is_array;
 use PhpOffice\PhpWord\Collection\Comments;
 use PhpOffice\PhpWord\Media;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Style;
-use PhpOffice\PhpWord\Style\AbstractStyle;
 
-use function is_array;
+use PhpOffice\PhpWord\Style\AbstractStyle;
 
 /**
  * Element abstract class.
@@ -485,19 +485,20 @@ abstract class AbstractElement
      * Set new style value.
      *
      * @param AbstractStyle $styleObject Style object
-     * @param null|string|array|AbstractStyle $styleValue Style value
+     * @param null|AbstractStyle|array|string $styleValue Style value
      * @param bool $returnObject Always return object
      *
-     * @return null|string|array|AbstractStyle
+     * @return mixed
      */
     protected function setNewStyle($styleObject, $styleValue = null, $returnObject = false)
     {
         if ($styleValue instanceof AbstractStyle && get_class($styleValue) === get_class($styleObject)) {
-            return clone $styleValue;
+            return $styleValue;
         }
 
         if (is_array($styleValue)) {
             $styleObject->setStyleByArray($styleValue);
+
             return $styleObject;
         }
 

--- a/src/PhpWord/Element/AbstractElement.php
+++ b/src/PhpWord/Element/AbstractElement.php
@@ -23,6 +23,9 @@ use PhpOffice\PhpWord\Collection\Comments;
 use PhpOffice\PhpWord\Media;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Style;
+use PhpOffice\PhpWord\Style\AbstractStyle;
+
+use function is_array;
 
 /**
  * Element abstract class.
@@ -256,7 +259,7 @@ abstract class AbstractElement
      */
     public function setElementId(): void
     {
-        $this->elementId = substr(md5(mt_rand()), 0, 6);
+        $this->elementId = substr(md5((string) mt_rand()), 0, 6);
     }
 
     /**
@@ -481,22 +484,24 @@ abstract class AbstractElement
     /**
      * Set new style value.
      *
-     * @param mixed $styleObject Style object
-     * @param null|array|string|Style $styleValue Style value
+     * @param AbstractStyle $styleObject Style object
+     * @param null|string|array|AbstractStyle $styleValue Style value
      * @param bool $returnObject Always return object
      *
-     * @return mixed
+     * @return null|string|array|AbstractStyle
      */
     protected function setNewStyle($styleObject, $styleValue = null, $returnObject = false)
     {
-        if (null !== $styleValue && is_array($styleValue)) {
-            $styleObject->setStyleByArray($styleValue);
-            $style = $styleObject;
-        } else {
-            $style = $returnObject ? $styleObject : $styleValue;
+        if ($styleValue instanceof AbstractStyle && get_class($styleValue) === get_class($styleObject)) {
+            return clone $styleValue;
         }
 
-        return $style;
+        if (is_array($styleValue)) {
+            $styleObject->setStyleByArray($styleValue);
+            return $styleObject;
+        }
+
+        return $returnObject === true ? $styleObject : $styleValue;
     }
 
     /**

--- a/tests/PhpWordTests/Element/CellTest.php
+++ b/tests/PhpWordTests/Element/CellTest.php
@@ -51,6 +51,17 @@ class CellTest extends AbstractWebServerEmbeddedTest
     }
 
     /**
+     * Test if the style object passed to the constructor is actually used
+     */
+    public function testConstructWithStyleObject(): void
+    {
+        $style = new \PhpOffice\PhpWord\Style\Cell();
+        $oCell = new Cell(null, $style);
+
+        self::assertSame($style, $oCell->getStyle());
+    }
+
+    /**
      * Add text.
      */
     public function testAddText(): void

--- a/tests/PhpWordTests/Element/CellTest.php
+++ b/tests/PhpWordTests/Element/CellTest.php
@@ -51,7 +51,7 @@ class CellTest extends AbstractWebServerEmbeddedTest
     }
 
     /**
-     * Test if the style object passed to the constructor is actually used
+     * Test if the style object passed to the constructor is actually used.
      */
     public function testConstructWithStyleObject(): void
     {


### PR DESCRIPTION
### Description

I generally prefer to use style objects over style arrays in elements. But, if you pass a `\PhpOffice\PhpWord\Style\Cell` style element to the `\PhpOffice\PhpWord\Element\Cell` constructor then the `$returnObject: true` argument of the `setNewStyle()` method in the constructor completely ignores the passed style element, because the `setNewStyle()` method only checks if `$styleValue` is an array and returns `$styleObject` as empty style object otherwise. Imho, if `$styleValue` is a style object with the same type as `$styleObject` then the `$returnObject: true` should also be "ignored" and the passed style object should then be returned instead of the empty base style object.

Fixes # (issue)

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] ~I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes~ *(not applicable, bugfix did not change the behavior)*
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)