### PR TITLE
feat(font): add default asian font name

### DIFF
--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -4,6 +4,8 @@
 
 ## Enhancements
 
+- Default Font: Allow specify Asisn font and Latin font separately
+
 - Writer ODText: Support for ListItemRun by [@Progi1984](https://github.com/Progi1984) fixing [#2159](https://github.com/PHPOffice/PHPWord/issues/2159), [#2620](https://github.com/PHPOffice/PHPWord/issues/2620) in [#2669](https://github.com/PHPOffice/PHPWord/pull/2669)
 - Writer HTML: Support for vAlign in Tables by [@SpraxDev](https://github.com/SpraxDev) in [#2675](https://github.com/PHPOffice/PHPWord/pull/2675)
 

--- a/docs/usage/introduction.md
+++ b/docs/usage/introduction.md
@@ -138,6 +138,14 @@ $phpWord->setDefaultFontName('Times New Roman');
 $phpWord->setDefaultFontSize(12);
 ```
 
+Or you can specify Asian Font
+
+``` php
+<?php
+
+$phpWord->setDefaultAsianFontName('標楷體');
+```
+
 ## Document settings
 
 Settings for the generated document can be set using ``$phpWord->getSettings()``

--- a/src/PhpWord/PhpWord.php
+++ b/src/PhpWord/PhpWord.php
@@ -257,6 +257,26 @@ class PhpWord
     }
 
     /**
+     * Get default asian font name.
+     *
+     * @return string
+     */
+    public function getDefaultAsianFontName()
+    {
+        return Settings::getDefaultAsianFontName();
+    }
+
+    /**
+     * Set default font name.
+     *
+     * @param string $fontName
+     */
+    public function setDefaultAsianFontName($fontName): void
+    {
+        Settings::setDefaultAsianFontName($fontName);
+    }
+
+    /**
      * Get default font size.
      *
      * @return int

--- a/src/PhpWord/PhpWord.php
+++ b/src/PhpWord/PhpWord.php
@@ -258,8 +258,6 @@ class PhpWord
 
     /**
      * Get default asian font name.
-     *
-     * @return string
      */
     public function getDefaultAsianFontName(): string
     {

--- a/src/PhpWord/PhpWord.php
+++ b/src/PhpWord/PhpWord.php
@@ -261,7 +261,7 @@ class PhpWord
      *
      * @return string
      */
-    public function getDefaultAsianFontName()
+    public function getDefaultAsianFontName(): string
     {
         return Settings::getDefaultAsianFontName();
     }

--- a/src/PhpWord/Settings.php
+++ b/src/PhpWord/Settings.php
@@ -118,6 +118,13 @@ class Settings
     private static $defaultFontName = self::DEFAULT_FONT_NAME;
 
     /**
+     * Default font name.
+     *
+     * @var string
+     */
+    private static $defaultAsianFontName = self::DEFAULT_FONT_NAME;
+
+    /**
      * Default font size.
      *
      * @var float|int
@@ -355,12 +362,31 @@ class Settings
     }
 
     /**
+     * Get default font name.
+     */
+    public static function getDefaultAsianFontName(): string
+    {
+        return self::$defaultAsianFontName;
+    }
+
+    /**
      * Set default font name.
      */
     public static function setDefaultFontName(string $value): bool
     {
         if (trim($value) !== '') {
             self::$defaultFontName = $value;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public static function setDefaultAsianFontName(string $value): bool
+    {
+        if (trim($value) !== '') {
+            self::$defaultAsianFontName = $value;
 
             return true;
         }

--- a/src/PhpWord/Writer/Word2007/Part/Styles.php
+++ b/src/PhpWord/Writer/Word2007/Part/Styles.php
@@ -83,6 +83,7 @@ class Styles extends AbstractPart
     {
         $phpWord = $this->getParentWriter()->getPhpWord();
         $fontName = $phpWord->getDefaultFontName();
+        $asianFontName = $phpWord->getDefaultAsianFontName();
         $fontSize = $phpWord->getDefaultFontSize();
         $language = $phpWord->getSettings()->getThemeFontLang();
         $latinLanguage = ($language == null || $language->getLatin() === null) ? 'en-US' : $language->getLatin();
@@ -94,7 +95,7 @@ class Styles extends AbstractPart
         $xmlWriter->startElement('w:rFonts');
         $xmlWriter->writeAttribute('w:ascii', $fontName);
         $xmlWriter->writeAttribute('w:hAnsi', $fontName);
-        $xmlWriter->writeAttribute('w:eastAsia', $fontName);
+        $xmlWriter->writeAttribute('w:eastAsia', $asianFontName);
         $xmlWriter->writeAttribute('w:cs', $fontName);
         $xmlWriter->endElement(); // w:rFonts
         $xmlWriter->startElement('w:sz');

--- a/tests/PhpWordTests/PhpWordTest.php
+++ b/tests/PhpWordTests/PhpWordTest.php
@@ -83,6 +83,18 @@ class PhpWordTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test set/get default asian font name.
+     */
+    public function testSetGetDefaultAsianFontName(): void
+    {
+        $phpWord = new PhpWord();
+        $fontName = 'Times New Roman';
+        self::assertEquals(Settings::DEFAULT_FONT_NAME, $phpWord->getDefaultAsianFontName());
+        $phpWord->setDefaultAsianFontName($fontName);
+        self::assertEquals($fontName, $phpWord->getDefaultAsianFontName());
+    }
+
+    /**
      * Test set default paragraph style.
      */
     public function testSetDefaultParagraphStyle(): void

--- a/tests/PhpWordTests/SettingsTest.php
+++ b/tests/PhpWordTests/SettingsTest.php
@@ -217,6 +217,20 @@ class SettingsTest extends TestCase
     }
 
     /**
+     * Test set/get default font name.
+     */
+    public function testSetGetDefaultAsianFontName(): void
+    {
+        self::assertEquals(Settings::DEFAULT_FONT_NAME, Settings::getDefaultAsianFontName());
+        self::assertFalse(Settings::setDefaultAsianFontName(' '));
+        self::assertEquals(Settings::DEFAULT_FONT_NAME, Settings::getDefaultAsianFontName());
+        self::assertTrue(Settings::setDefaultAsianFontName('Times New Roman'));
+        self::assertEquals('Times New Roman', Settings::getDefaultAsianFontName());
+        self::assertFalse(Settings::setDefaultAsianFontName(' '));
+        self::assertEquals('Times New Roman', Settings::getDefaultAsianFontName());
+    }
+
+    /**
      * Test set/get default font size.
      */
     public function testSetGetDefaultFontSize(): void


### PR DESCRIPTION
### Description

Allow PHPWord to set Latin / Asian font separately

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)
