### PR TITLE
Feature: Ruby (phonetic guide) text - Word2007 Read/Write, HTML Read/Write, RTF write, ODT basic write

### DIFF
--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -11,7 +11,7 @@
 - Writer Word2007: Support for padding in Table Cell by [@Azamat8405](https://github.com/Azamat8405) in [#2697](https://github.com/PHPOffice/PHPWord/pull/2697)
 - Added support for PHP 8.4 by [@Progi1984](https://github.com/Progi1984) in [#2660](https://github.com/PHPOffice/PHPWord/pull/2660)
 - Autoload : Allow to use PHPWord without Composer fixing [#2543](https://github.com/PHPOffice/PHPWord/issues/2543), [#2552](https://github.com/PHPOffice/PHPWord/issues/2552), [#2716](https://github.com/PHPOffice/PHPWord/issues/2716), [#2717](https://github.com/PHPOffice/PHPWord/issues/2717) in [#2722](https://github.com/PHPOffice/PHPWord/pull/2722)
-- Add basic ruby text (phonetic guide) support for Word2007 Reader and Writer by [@Deadpikle](https://github.com/Deadpikle)
+- Add basic ruby text (phonetic guide) support for Word2007 Reader/Writer and HTML by [@Deadpikle](https://github.com/Deadpikle) in [#2727](https://github.com/PHPOffice/PHPWord/pull/2727)
 
 ### Bug fixes
 

--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -11,6 +11,7 @@
 - Writer Word2007: Support for padding in Table Cell by [@Azamat8405](https://github.com/Azamat8405) in [#2697](https://github.com/PHPOffice/PHPWord/pull/2697)
 - Added support for PHP 8.4 by [@Progi1984](https://github.com/Progi1984) in [#2660](https://github.com/PHPOffice/PHPWord/pull/2660)
 - Autoload : Allow to use PHPWord without Composer fixing [#2543](https://github.com/PHPOffice/PHPWord/issues/2543), [#2552](https://github.com/PHPOffice/PHPWord/issues/2552), [#2716](https://github.com/PHPOffice/PHPWord/issues/2716), [#2717](https://github.com/PHPOffice/PHPWord/issues/2717) in [#2722](https://github.com/PHPOffice/PHPWord/pull/2722)
+- Add basic ruby text (phonetic guide) support for Word2007 Reader and Writer by [@Deadpikle](https://github.com/Deadpikle)
 
 ### Bug fixes
 

--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -11,7 +11,7 @@
 - Writer Word2007: Support for padding in Table Cell by [@Azamat8405](https://github.com/Azamat8405) in [#2697](https://github.com/PHPOffice/PHPWord/pull/2697)
 - Added support for PHP 8.4 by [@Progi1984](https://github.com/Progi1984) in [#2660](https://github.com/PHPOffice/PHPWord/pull/2660)
 - Autoload : Allow to use PHPWord without Composer fixing [#2543](https://github.com/PHPOffice/PHPWord/issues/2543), [#2552](https://github.com/PHPOffice/PHPWord/issues/2552), [#2716](https://github.com/PHPOffice/PHPWord/issues/2716), [#2717](https://github.com/PHPOffice/PHPWord/issues/2717) in [#2722](https://github.com/PHPOffice/PHPWord/pull/2722)
-- Add basic ruby text (phonetic guide) support for Word2007 Reader/Writer and HTML by [@Deadpikle](https://github.com/Deadpikle) in [#2727](https://github.com/PHPOffice/PHPWord/pull/2727)
+- Add basic ruby text (phonetic guide) support for Word2007 Reader/Writer and HTML writing by [@Deadpikle](https://github.com/Deadpikle) in [#2727](https://github.com/PHPOffice/PHPWord/pull/2727)
 
 ### Bug fixes
 

--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -11,7 +11,7 @@
 - Writer Word2007: Support for padding in Table Cell by [@Azamat8405](https://github.com/Azamat8405) in [#2697](https://github.com/PHPOffice/PHPWord/pull/2697)
 - Added support for PHP 8.4 by [@Progi1984](https://github.com/Progi1984) in [#2660](https://github.com/PHPOffice/PHPWord/pull/2660)
 - Autoload : Allow to use PHPWord without Composer fixing [#2543](https://github.com/PHPOffice/PHPWord/issues/2543), [#2552](https://github.com/PHPOffice/PHPWord/issues/2552), [#2716](https://github.com/PHPOffice/PHPWord/issues/2716), [#2717](https://github.com/PHPOffice/PHPWord/issues/2717) in [#2722](https://github.com/PHPOffice/PHPWord/pull/2722)
-- Add basic ruby text (phonetic guide) support for Word2007 Reader/Writer and HTML writing by [@Deadpikle](https://github.com/Deadpikle) in [#2727](https://github.com/PHPOffice/PHPWord/pull/2727)
+- Add basic ruby text (phonetic guide) support for Word2007 and HTML Reader/Writer, RTF Writer by [@Deadpikle](https://github.com/Deadpikle) in [#2727](https://github.com/PHPOffice/PHPWord/pull/2727)
 
 ### Bug fixes
 

--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -11,7 +11,7 @@
 - Writer Word2007: Support for padding in Table Cell by [@Azamat8405](https://github.com/Azamat8405) in [#2697](https://github.com/PHPOffice/PHPWord/pull/2697)
 - Added support for PHP 8.4 by [@Progi1984](https://github.com/Progi1984) in [#2660](https://github.com/PHPOffice/PHPWord/pull/2660)
 - Autoload : Allow to use PHPWord without Composer fixing [#2543](https://github.com/PHPOffice/PHPWord/issues/2543), [#2552](https://github.com/PHPOffice/PHPWord/issues/2552), [#2716](https://github.com/PHPOffice/PHPWord/issues/2716), [#2717](https://github.com/PHPOffice/PHPWord/issues/2717) in [#2722](https://github.com/PHPOffice/PHPWord/pull/2722)
-- Add basic ruby text (phonetic guide) support for Word2007 and HTML Reader/Writer, RTF Writer by [@Deadpikle](https://github.com/Deadpikle) in [#2727](https://github.com/PHPOffice/PHPWord/pull/2727)
+- Add basic ruby text (phonetic guide) support for Word2007 and HTML Reader/Writer, RTF Writer, basic support for ODT writing by [@Deadpikle](https://github.com/Deadpikle) in [#2727](https://github.com/PHPOffice/PHPWord/pull/2727)
 
 ### Bug fixes
 

--- a/docs/usage/elements/ruby.md
+++ b/docs/usage/elements/ruby.md
@@ -1,0 +1,29 @@
+# Ruby
+
+Ruby (phonetic guide) text can be added by using the ``addRuby`` method. Ruby elements require a ``RubyProperties`` object, a ``TextRun`` for the base text, and a ``TextRun`` for the actual ruby (phonetic guide) text.
+
+Here is one example for a complete ruby element setup:
+
+``` php
+<?php
+$phpWord = new PhpWord();
+
+$section = $phpWord->addSection();
+$properties = new RubyProperties();
+$properties->setAlignment(RubyProperties::ALIGNMENT_RIGHT_VERTICAL);
+$properties->setFontFaceSize(10);
+$properties->setFontPointsAboveBaseText(4);
+$properties->setFontSizeForBaseText(18);
+$properties->setLanguageId('ja-JP');
+
+$baseTextRun = new TextRun(null);
+$baseTextRun->addText('私');
+$rubyTextRun = new TextRun(null);
+$rubyTextRun->addText('わたし');
+
+$section->addRuby($baseTextRun, $rubyTextRun, $properties);
+```
+
+- ``$baseTextRun``. ``TextRun`` to be used for the base text.
+- ``$rubyTextRun``. ``TextRun`` to be used for the ruby text.
+- ``$properties``. ``RubyProperties`` properties object for the ruby text.

--- a/docs/usage/elements/ruby.md
+++ b/docs/usage/elements/ruby.md
@@ -27,3 +27,31 @@ $section->addRuby($baseTextRun, $rubyTextRun, $properties);
 - ``$baseTextRun``. ``TextRun`` to be used for the base text.
 - ``$rubyTextRun``. ``TextRun`` to be used for the ruby text.
 - ``$properties``. ``RubyProperties`` properties object for the ruby text.
+
+A title with a phonetic guide is a little more complex, but still possible. Make sure you add the appropraite title style to your document.
+
+```php
+$phpWord = new PhpWord();
+$fontStyle = new Font();
+$fontStyle->setAllCaps(true);
+$fontStyle->setBold(true);
+$fontStyle->setSize(24);
+$phpWord->addTitleStyle(1, ['name' => 'Arial', 'size' => 24, 'bold' => true, 'color' => '990000']);
+
+$section = $phpWord->addSection();
+$properties = new RubyProperties();
+$properties->setAlignment(RubyProperties::ALIGNMENT_RIGHT_VERTICAL);
+$properties->setFontFaceSize(10);
+$properties->setFontPointsAboveBaseText(4);
+$properties->setFontSizeForBaseText(18);
+$properties->setLanguageId('ja-JP');
+
+$baseTextRun = new TextRun(null);
+$baseTextRun->addText('私');
+$rubyTextRun = new TextRun(null);
+$rubyTextRun->addText('わたし');
+
+$textRun = new TextRun();
+$textRun->addRuby($baseTextRun, $rubyTextRun, $properties);
+$section->addTitle($textRun, 1);
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
       - OLE Object: 'usage/elements/oleobject.md'
       - Page Break: 'usage/elements/pagebreak.md'
       - Preserve Text: 'usage/elements/preservetext.md'
+      - Ruby: 'usage/elements/ruby.md'
       - Text: 'usage/elements/text.md'
       - TextBox: 'usage/elements/textbox.md'
       - Text Break: 'usage/elements/textbreak.md'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -431,6 +431,11 @@ parameters:
 			path: src/PhpWord/Shared/Html.php
 
 		-
+			message: "#^Method PhpOffice\\\\PhpWord\\\\Shared\\\\Html\\:\\:parseRuby\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/PhpWord/Shared/Html.php
+
+		-
 			message: "#^Method PhpOffice\\\\PhpWord\\\\Shared\\\\Html\\:\\:parseStyleDeclarations\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/PhpWord/Shared/Html.php
@@ -442,7 +447,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$attribute of static method PhpOffice\\\\PhpWord\\\\Shared\\\\Html\\:\\:parseStyle\\(\\) expects DOMAttr, DOMNode given\\.$#"
-			count: 1
+			count: 3
 			path: src/PhpWord/Shared/Html.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1689,6 +1689,11 @@ parameters:
 			message: "#^Cannot access property \\$length on DOMNodeList\\<DOMNode\\>\\|false\\.$#"
 			count: 9
 			path: tests/PhpWordTests/Writer/HTML/ElementTest.php
+			
+		-
+			message: "#^Cannot access property \\$length on DOMNodeList\\<DOMNode\\>\\|false\\.$#"
+			count: 2
+			path: tests/PhpWordTests/Writer/HTML/Element/RubyTest.php
 
 		-
 			message: "#^Cannot call method item\\(\\) on DOMNodeList\\<DOMNode\\>\\|false\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1056,14 +1056,14 @@ parameters:
 			path: src/PhpWord/Writer/ODText/Element/Table.php
 
 		-
-			message: "#^Method PhpOffice\\\\PhpWord\\\\Writer\\\\ODText\\\\Element\\\\Text\\:\\:replacetabs\\(\\) has parameter \\$text with no type specified\\.$#"
+			message: "#^Method PhpOffice\\\\PhpWord\\\\Writer\\\\ODText\\\\Element\\\\AbstractElement\\:\\:replaceTabs\\(\\) has parameter \\$text with no type specified\\.$#"
 			count: 1
-			path: src/PhpWord/Writer/ODText/Element/Text.php
+			path: src/PhpWord/Writer/ODText/Element/AbstractElement.php
 
 		-
-			message: "#^Method PhpOffice\\\\PhpWord\\\\Writer\\\\ODText\\\\Element\\\\Text\\:\\:replacetabs\\(\\) has parameter \\$xmlWriter with no type specified\\.$#"
+			message: "#^Method PhpOffice\\\\PhpWord\\\\Writer\\\\ODText\\\\Element\\\\AbstractElement\\:\\:replaceTabs\\(\\) has parameter \\$xmlWriter with no type specified\\.$#"
 			count: 1
-			path: src/PhpWord/Writer/ODText/Element/Text.php
+			path: src/PhpWord/Writer/ODText/Element/AbstractElement.php
 
 		-
 			message: "#^Method PhpOffice\\\\PhpWord\\\\Writer\\\\ODText\\\\Element\\\\Text\\:\\:writeChangeInsertion\\(\\) has parameter \\$start with no type specified\\.$#"

--- a/samples/Sample_46_RubyPhoneticGuide.php
+++ b/samples/Sample_46_RubyPhoneticGuide.php
@@ -31,6 +31,12 @@ $textRun->addRuby($baseTextRun, $rubyTextRun, $properties);
 $textRun->addText(' word.');
 
 $textRun = $section->addTextRun();
+$properties = new RubyProperties();
+$properties->setAlignment(RubyProperties::ALIGNMENT_CENTER);
+$properties->setFontFaceSize(10);
+$properties->setFontPointsAboveBaseText(20);
+$properties->setFontSizeForBaseText(18);
+$properties->setLanguageId('ja-JP');
 $textRun->addText('Here is a demonstration of ruby text for Japanese text: ');
 $baseTextRun = new TextRun(null);
 $baseTextRun->addText('私');
@@ -44,10 +50,10 @@ $phpWord->addTitleStyle(1, ['name' => 'Arial', 'size' => 24, 'bold' => true, 'co
 
 $properties = new RubyProperties();
 $properties->setAlignment(RubyProperties::ALIGNMENT_CENTER);
-$properties->setFontFaceSize(18);
+$properties->setFontFaceSize(10);
 $properties->setFontPointsAboveBaseText(50);
 $properties->setFontSizeForBaseText(18);
-$properties->setLanguageId('en-US');
+$properties->setLanguageId('ja-JP');
 
 $baseTextRun = new TextRun(null);
 $baseTextRun->addText('私');

--- a/samples/Sample_46_RubyPhoneticGuide.php
+++ b/samples/Sample_46_RubyPhoneticGuide.php
@@ -12,7 +12,7 @@ $phpWord = new PhpOffice\PhpWord\PhpWord();
 // Section for demonstrating ruby (phonetic guide) features
 $section = $phpWord->addSection();
 
-$section->addText("Here is some normal text with no ruby (phonetic guide) text.");
+$section->addText('Here is some normal text with no ruby (phonetic guide) text.');
 
 $properties = new RubyProperties();
 $properties->setAlignment(RubyProperties::ALIGNMENT_CENTER);
@@ -22,16 +22,16 @@ $properties->setFontSizeForBaseText(18);
 $properties->setLanguageId('en-US');
 
 $textRun = $section->addTextRun();
-$textRun->addText("Here is a demonstration of ruby text for ");
+$textRun->addText('Here is a demonstration of ruby text for ');
 $baseTextRun = new TextRun(null);
 $baseTextRun->addText('this');
 $rubyTextRun = new TextRun(null);
 $rubyTextRun->addText('ruby-text');
 $textRun->addRuby($baseTextRun, $rubyTextRun, $properties);
-$textRun->addText(" word.");
+$textRun->addText(' word.');
 
 $textRun = $section->addTextRun();
-$textRun->addText("Here is a demonstration of ruby text for Japanese text: ");
+$textRun->addText('Here is a demonstration of ruby text for Japanese text: ');
 $baseTextRun = new TextRun(null);
 $baseTextRun->addText('私');
 $rubyTextRun = new TextRun(null);

--- a/samples/Sample_46_RubyPhoneticGuide.php
+++ b/samples/Sample_46_RubyPhoneticGuide.php
@@ -12,7 +12,7 @@ $phpWord = new PhpOffice\PhpWord\PhpWord();
 // Section for demonstrating ruby (phonetic guide) features
 $section = $phpWord->addSection();
 
-$section->addText('Here is some normal text with no ruby (phonetic guide) text.');
+$section->addText('Here is some normal text with no ruby, also known as "phonetic guide", text.');
 
 $properties = new RubyProperties();
 $properties->setAlignment(RubyProperties::ALIGNMENT_CENTER);

--- a/samples/Sample_46_RubyPhoneticGuide.php
+++ b/samples/Sample_46_RubyPhoneticGuide.php
@@ -1,0 +1,64 @@
+<?php
+
+use PhpOffice\PhpWord\ComplexType\RubyProperties;
+use PhpOffice\PhpWord\Element\TextRun;
+
+include_once 'Sample_Header.php';
+
+// New Word Document
+echo date('H:i:s'), ' Create sample for Ruby (Phonetic Guide) use', EOL;
+$phpWord = new PhpOffice\PhpWord\PhpWord();
+
+// Section for demonstrating ruby (phonetic guide) features
+$section = $phpWord->addSection();
+
+$section->addText("Here is some normal text with no ruby (phonetic guide) text.");
+
+$properties = new RubyProperties();
+$properties->setAlignment(RubyProperties::ALIGNMENT_CENTER);
+$properties->setFontFaceSize(10);
+$properties->setFontPointsAboveBaseText(20);
+$properties->setFontSizeForBaseText(18);
+$properties->setLanguageId('en-US');
+
+$textRun = $section->addTextRun();
+$textRun->addText("Here is a demonstration of ruby text for ");
+$baseTextRun = new TextRun(null);
+$baseTextRun->addText('this');
+$rubyTextRun = new TextRun(null);
+$rubyTextRun->addText('ruby-text');
+$textRun->addRuby($baseTextRun, $rubyTextRun, $properties);
+$textRun->addText(" word.");
+
+$textRun = $section->addTextRun();
+$textRun->addText("Here is a demonstration of ruby text for Japanese text: ");
+$baseTextRun = new TextRun(null);
+$baseTextRun->addText('私');
+$rubyTextRun = new TextRun(null);
+$rubyTextRun->addText('わたし');
+$textRun->addRuby($baseTextRun, $rubyTextRun, $properties);
+
+$section->addText('You can also have ruby text for titles:');
+
+$phpWord->addTitleStyle(1, ['name' => 'Arial', 'size' => 24, 'bold' => true, 'color' => '000099']);
+
+$properties = new RubyProperties();
+$properties->setAlignment(RubyProperties::ALIGNMENT_CENTER);
+$properties->setFontFaceSize(18);
+$properties->setFontPointsAboveBaseText(50);
+$properties->setFontSizeForBaseText(18);
+$properties->setLanguageId('en-US');
+
+$baseTextRun = new TextRun(null);
+$baseTextRun->addText('私');
+$rubyTextRun = new TextRun(null);
+$rubyTextRun->addText('わたし');
+$textRun = new TextRun();
+$textRun->addRuby($baseTextRun, $rubyTextRun, $properties);
+$section->addTitle($textRun, 1);
+
+// Save file
+echo write($phpWord, basename(__FILE__, '.php'), $writers);
+if (!CLI) {
+    include_once 'Sample_Footer.php';
+}

--- a/src/PhpWord/ComplexType/RubyProperties.php
+++ b/src/PhpWord/ComplexType/RubyProperties.php
@@ -70,6 +70,20 @@ class RubyProperties
     private $languageId;
 
     /**
+     * Create a new RubyProperties object.
+     */
+    public function __construct()
+    {
+        // these defaults came from opening a new Word doc, adding some ruby text to some 
+        // Japanese text, and copying out the defaults.
+        $this->alignment = self::ALIGNMENT_DISTRIBUTE_SPACE;
+        $this->fontFaceSize = 12;
+        $this->fontPointsAboveText = 22;
+        $this->languageId = 'ja-JP';
+        $this->baseTextFontSize = 24;
+    }
+
+    /**
      * Get the ruby alignment.
      */
     public function getAlignment(): string

--- a/src/PhpWord/ComplexType/RubyProperties.php
+++ b/src/PhpWord/ComplexType/RubyProperties.php
@@ -94,7 +94,7 @@ final class RubyProperties
             self::ALIGNMENT_DISTRIBUTE_SPACE,
             self::ALIGNMENT_LEFT,
             self::ALIGNMENT_RIGHT,
-            self::ALIGNMENT_RIGHT_VERTICAL
+            self::ALIGNMENT_RIGHT_VERTICAL,
         ];
 
         if (in_array($alignment, $alignmentTypes)) {

--- a/src/PhpWord/ComplexType/RubyProperties.php
+++ b/src/PhpWord/ComplexType/RubyProperties.php
@@ -74,7 +74,7 @@ class RubyProperties
      */
     public function __construct()
     {
-        // these defaults came from opening a new Word doc, adding some ruby text to some 
+        // these defaults came from opening a new Word doc, adding some ruby text to some
         // Japanese text, and copying out the defaults.
         $this->alignment = self::ALIGNMENT_DISTRIBUTE_SPACE;
         $this->fontFaceSize = 12;

--- a/src/PhpWord/ComplexType/RubyProperties.php
+++ b/src/PhpWord/ComplexType/RubyProperties.php
@@ -63,11 +63,11 @@ final class RubyProperties
     private $baseTextFontSize;
 
     /**
-     * Ruby type/language (w:lid).
+     * Ruby type/language id (w:lid).
      *
      * @var string
      */
-    private $language;
+    private $languageId;
 
     /**
      * Get the ruby alignment.
@@ -179,25 +179,25 @@ final class RubyProperties
     }
 
     /**
-     * Get the ruby language.
+     * Get the ruby language id.
      *
      * @return string
      */
-    public function getLanguage()
+    public function getLanguageId()
     {
-        return $this->language;
+        return $this->languageId;
     }
 
     /**
-     * Set the ruby language.
+     * Set the ruby language id.
      *
-     * @param string $language
+     * @param string $langId
      *
      * @return self
      */
-    public function setLanguage($lang)
+    public function setLanguageId($langId)
     {
-        $this->language = $lang;
+        $this->languageId = $langId;
 
         return $this;
     }

--- a/src/PhpWord/ComplexType/RubyProperties.php
+++ b/src/PhpWord/ComplexType/RubyProperties.php
@@ -25,7 +25,7 @@ use InvalidArgumentException;
  *
  * @see https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.rubyproperties?view=openxml-3.0.1
  */
-final class RubyProperties
+class RubyProperties
 {
     const ALIGNMENT_CENTER = 'center';
     const ALIGNMENT_DISTRIBUTE_LETTER = 'distributeLetter';
@@ -44,21 +44,21 @@ final class RubyProperties
     /**
      * Ruby font face size (w:hps).
      *
-     * @var float|int
+     * @var float
      */
     private $fontFaceSize;
 
     /**
      * Ruby font points above base text (w:hpsRaise).
      *
-     * @var float|int
+     * @var float
      */
     private $fontPointsAboveText;
 
     /**
      * Ruby font size for base text (w:hpsBaseText).
      *
-     * @var float|int
+     * @var float
      */
     private $baseTextFontSize;
 
@@ -71,22 +71,16 @@ final class RubyProperties
 
     /**
      * Get the ruby alignment.
-     *
-     * @return string
      */
-    public function getAlignment()
+    public function getAlignment(): string
     {
         return $this->alignment;
     }
 
     /**
      * Set the Ruby Alignment (center, distributeLetter, distributeSpace, left, right, rightVertical).
-     *
-     * @param string $alignment
-     *
-     * @return self
      */
-    public function setAlignment($alignment)
+    public function setAlignment(string $alignment): self
     {
         $alignmentTypes = [
             self::ALIGNMENT_CENTER,
@@ -108,22 +102,16 @@ final class RubyProperties
 
     /**
      * Get the ruby font face size.
-     *
-     * @return float|int
      */
-    public function getFontFaceSize()
+    public function getFontFaceSize(): float
     {
         return $this->fontFaceSize;
     }
 
     /**
      * Set the ruby font face size.
-     *
-     * @param float|int $size
-     *
-     * @return self
      */
-    public function setFontFaceSize($size)
+    public function setFontFaceSize(float $size): self
     {
         $this->fontFaceSize = $size;
 
@@ -132,22 +120,16 @@ final class RubyProperties
 
     /**
      * Get the ruby font points above base text.
-     *
-     * @return float|int
      */
-    public function getFontPointsAboveBaseText()
+    public function getFontPointsAboveBaseText(): float
     {
         return $this->fontPointsAboveText;
     }
 
     /**
      * Set the ruby font points above base text.
-     *
-     * @param float|int $size
-     *
-     * @return self
      */
-    public function setFontPointsAboveBaseText($size)
+    public function setFontPointsAboveBaseText(float $size): self
     {
         $this->fontPointsAboveText = $size;
 
@@ -156,22 +138,16 @@ final class RubyProperties
 
     /**
      * Get the ruby font size for base text.
-     *
-     * @return float|int
      */
-    public function getFontSizeForBaseText()
+    public function getFontSizeForBaseText(): float
     {
         return $this->baseTextFontSize;
     }
 
     /**
      * Set the ruby font size for base text.
-     *
-     * @param float|int $size
-     *
-     * @return self
      */
-    public function setFontSizeForBaseText($size)
+    public function setFontSizeForBaseText(float $size): self
     {
         $this->baseTextFontSize = $size;
 
@@ -180,22 +156,16 @@ final class RubyProperties
 
     /**
      * Get the ruby language id.
-     *
-     * @return string
      */
-    public function getLanguageId()
+    public function getLanguageId(): string
     {
         return $this->languageId;
     }
 
     /**
      * Set the ruby language id.
-     *
-     * @param string $langId
-     *
-     * @return self
      */
-    public function setLanguageId($langId)
+    public function setLanguageId(string $langId): self
     {
         $this->languageId = $langId;
 

--- a/src/PhpWord/ComplexType/RubyProperties.php
+++ b/src/PhpWord/ComplexType/RubyProperties.php
@@ -1,0 +1,204 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\ComplexType;
+
+use InvalidArgumentException;
+
+/**
+ * Ruby properties.
+ *
+ * @see https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.rubyproperties?view=openxml-3.0.1
+ */
+final class RubyProperties
+{
+    const ALIGNMENT_CENTER = 'center';
+    const ALIGNMENT_DISTRIBUTE_LETTER = 'distributeLetter';
+    const ALIGNMENT_DISTRIBUTE_SPACE = 'distributeSpace';
+    const ALIGNMENT_LEFT = 'left';
+    const ALIGNMENT_RIGHT = 'right';
+    const ALIGNMENT_RIGHT_VERTICAL = 'rightVertical';
+
+    /**
+     * Ruby alignment (w:rubyAlign).
+     *
+     * @var string
+     */
+    private $alignment;
+
+    /**
+     * Ruby font face size (w:hps).
+     *
+     * @var float|int
+     */
+    private $fontFaceSize;
+
+    /**
+     * Ruby font points above base text (w:hpsRaise).
+     *
+     * @var float|int
+     */
+    private $fontPointsAboveText;
+
+    /**
+     * Ruby font size for base text (w:hpsBaseText).
+     *
+     * @var float|int
+     */
+    private $baseTextFontSize;
+
+    /**
+     * Ruby type/language (w:lid).
+     *
+     * @var string
+     */
+    private $language;
+
+    /**
+     * Get the ruby alignment.
+     *
+     * @return string
+     */
+    public function getAlignment()
+    {
+        return $this->alignment;
+    }
+
+    /**
+     * Set the Ruby Alignment (center, distributeLetter, distributeSpace, left, right, rightVertical).
+     *
+     * @param string $alignment
+     *
+     * @return self
+     */
+    public function setAlignment($alignment)
+    {
+        $alignmentTypes = [
+            self::ALIGNMENT_CENTER,
+            self::ALIGNMENT_DISTRIBUTE_LETTER,
+            self::ALIGNMENT_DISTRIBUTE_SPACE,
+            self::ALIGNMENT_LEFT,
+            self::ALIGNMENT_RIGHT,
+            self::ALIGNMENT_RIGHT_VERTICAL
+        ];
+
+        if (in_array($alignment, $alignmentTypes)) {
+            $this->alignment = $alignment;
+        } else {
+            throw new InvalidArgumentException('Invalid value, alignments of ' . implode(', ', $alignmentTypes) . ' possible');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the ruby font face size.
+     *
+     * @return float|int
+     */
+    public function getFontFaceSize()
+    {
+        return $this->fontFaceSize;
+    }
+
+    /**
+     * Set the ruby font face size.
+     *
+     * @param float|int $size
+     *
+     * @return self
+     */
+    public function setFontFaceSize($size)
+    {
+        $this->fontFaceSize = $size;
+
+        return $this;
+    }
+
+    /**
+     * Get the ruby font points above base text.
+     *
+     * @return float|int
+     */
+    public function getFontPointsAboveBaseText()
+    {
+        return $this->fontPointsAboveText;
+    }
+
+    /**
+     * Set the ruby font points above base text.
+     *
+     * @param float|int $size
+     *
+     * @return self
+     */
+    public function setFontPointsAboveBaseText($size)
+    {
+        $this->fontPointsAboveText = $size;
+
+        return $this;
+    }
+
+    /**
+     * Get the ruby font size for base text.
+     *
+     * @return float|int
+     */
+    public function getFontSizeForBaseText()
+    {
+        return $this->baseTextFontSize;
+    }
+
+    /**
+     * Set the ruby font size for base text.
+     *
+     * @param float|int $size
+     *
+     * @return self
+     */
+    public function setFontSizeForBaseText($size)
+    {
+        $this->baseTextFontSize = $size;
+
+        return $this;
+    }
+
+    /**
+     * Get the ruby language.
+     *
+     * @return string
+     */
+    public function getLanguage()
+    {
+        return $this->language;
+    }
+
+    /**
+     * Set the ruby language.
+     *
+     * @param string $language
+     *
+     * @return self
+     */
+    public function setLanguage($lang)
+    {
+        $this->language = $lang;
+
+        return $this;
+    }
+}

--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -50,7 +50,7 @@ use ReflectionClass;
  * @method FormField addFormField(string $type, mixed $fStyle = null, mixed $pStyle = null)
  * @method SDT addSDT(string $type)
  * @method Formula addFormula(Math $math)
- * @method Ruby addRuby(TextRun $baseText, TextRun $rubyText, RubyProperties $properties)
+ * @method Ruby addRuby(TextRun $baseText, TextRun $rubyText, \PhpOffice\PhpWord\ComplexType\RubyProperties $properties)
  * @method \PhpOffice\PhpWord\Element\OLEObject addObject(string $source, mixed $style = null) deprecated, use addOLEObject instead
  *
  * @since 0.10.0

--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -92,7 +92,7 @@ abstract class AbstractContainer extends AbstractElement
             'Footnote', 'Endnote', 'CheckBox', 'TextBox', 'Field',
             'Line', 'Shape', 'Title', 'TOC', 'PageBreak',
             'Chart', 'FormField', 'SDT', 'Comment',
-            'Formula', 'Ruby'
+            'Formula', 'Ruby',
         ];
         $functions = [];
         foreach ($elements as $element) {

--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -50,6 +50,7 @@ use ReflectionClass;
  * @method FormField addFormField(string $type, mixed $fStyle = null, mixed $pStyle = null)
  * @method SDT addSDT(string $type)
  * @method Formula addFormula(Math $math)
+ * @method Ruby addRuby(TextRun $baseText, TextRun $rubyText, RubyProperties $properties)
  * @method \PhpOffice\PhpWord\Element\OLEObject addObject(string $source, mixed $style = null) deprecated, use addOLEObject instead
  *
  * @since 0.10.0
@@ -91,7 +92,7 @@ abstract class AbstractContainer extends AbstractElement
             'Footnote', 'Endnote', 'CheckBox', 'TextBox', 'Field',
             'Line', 'Shape', 'Title', 'TOC', 'PageBreak',
             'Chart', 'FormField', 'SDT', 'Comment',
-            'Formula',
+            'Formula', 'Ruby'
         ];
         $functions = [];
         foreach ($elements as $element) {

--- a/src/PhpWord/Element/Ruby.php
+++ b/src/PhpWord/Element/Ruby.php
@@ -22,7 +22,7 @@ use PhpOffice\PhpWord\ComplexType\RubyProperties;
 
 /**
  * Ruby element.
- * 
+ *
  * @see https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.ruby?view=openxml-3.0.1
  */
 class Ruby extends AbstractElement

--- a/src/PhpWord/Element/Ruby.php
+++ b/src/PhpWord/Element/Ruby.php
@@ -50,12 +50,8 @@ class Ruby extends AbstractElement
 
     /**
      * Create a new Ruby Element.
-     *
-     * @param TextRun $baseTextRun
-     * @param TextRun $rubyTextRun
-     * @param RubyProperties $properties
      */
-    public function __construct($baseTextRun, $rubyTextRun, $properties)
+    public function __construct(TextRun $baseTextRun, TextRun $rubyTextRun, RubyProperties $properties)
     {
         $this->baseTextRun = $baseTextRun;
         $this->rubyTextRun = $rubyTextRun;
@@ -64,30 +60,24 @@ class Ruby extends AbstractElement
 
     /**
      * Get base text run.
-     *
-     * @return TextRun
      */
-    public function getBaseTextRun()
+    public function getBaseTextRun(): TextRun
     {
         return $this->baseTextRun;
     }
 
     /**
      * Get ruby text run.
-     *
-     * @return TextRun
      */
-    public function getRubyTextRun()
+    public function getRubyTextRun(): TextRun
     {
         return $this->rubyTextRun;
     }
 
     /**
      * Get properties.
-     *
-     * @return RubyProperties
      */
-    public function getProperties()
+    public function getProperties(): RubyProperties
     {
         return $this->properties;
     }

--- a/src/PhpWord/Element/Ruby.php
+++ b/src/PhpWord/Element/Ruby.php
@@ -67,6 +67,16 @@ class Ruby extends AbstractElement
     }
 
     /**
+     * Set the base text run.
+     */
+    public function setBaseTextRun(TextRun $textRun): self
+    {
+        $this->baseTextRun = $textRun;
+
+        return $this;
+    }
+
+    /**
      * Get ruby text run.
      */
     public function getRubyTextRun(): TextRun
@@ -75,10 +85,30 @@ class Ruby extends AbstractElement
     }
 
     /**
-     * Get properties.
+     * Set the ruby text run.
+     */
+    public function setRubyTextRun(TextRun $textRun): self
+    {
+        $this->rubyTextRun = $textRun;
+
+        return $this;
+    }
+
+    /**
+     * Get ruby properties.
      */
     public function getProperties(): RubyProperties
     {
         return $this->properties;
+    }
+
+    /**
+     * Set the ruby properties.
+     */
+    public function setProperties(RubyProperties $properties): self
+    {
+        $this->properties = $properties;
+
+        return $this;
     }
 }

--- a/src/PhpWord/Element/Ruby.php
+++ b/src/PhpWord/Element/Ruby.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Element;
+
+use PhpOffice\PhpWord\ComplexType\RubyProperties;
+
+/**
+ * Ruby element.
+ * 
+ * @see https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.ruby?view=openxml-3.0.1
+ */
+class Ruby extends AbstractElement
+{
+    /**
+     * Ruby properties.
+     *
+     * @var RubyProperties
+     */
+    protected $properties;
+
+    /**
+     * Ruby text run.
+     *
+     * @var TextRun
+     */
+    protected $rubyTextRun;
+
+    /**
+     * Ruby base text run.
+     *
+     * @var TextRun
+     */
+    protected $baseTextRun;
+
+    /**
+     * Create a new Ruby Element.
+     *
+     * @param TextRun $baseTextRun
+     * @param TextRun $rubyTextRun
+     * @param RubyProperties $properties
+     */
+    public function __construct($baseTextRun, $rubyTextRun, $properties)
+    {
+        $this->baseTextRun = $baseTextRun;
+        $this->rubyTextRun = $rubyTextRun;
+        $this->properties = $properties;
+    }
+
+    /**
+     * Get base text run.
+     *
+     * @return TextRun
+     */
+    public function getBaseTextRun()
+    {
+        return $this->baseTextRun;
+    }
+
+    /**
+     * Get ruby text run.
+     *
+     * @return TextRun
+     */
+    public function getRubyTextRun()
+    {
+        return $this->rubyTextRun;
+    }
+
+    /**
+     * Get properties.
+     *
+     * @return RubyProperties
+     */
+    public function getProperties()
+    {
+        return $this->properties;
+    }
+}

--- a/src/PhpWord/Element/TextRun.php
+++ b/src/PhpWord/Element/TextRun.php
@@ -86,6 +86,9 @@ class TextRun extends AbstractContainer
         foreach ($this->getElements() as $element) {
             if ($element instanceof Text) {
                 $outstr .= $element->getText();
+            } elseif ($element instanceof Ruby) {
+                $outstr .= $element->getBaseTextRun()->getText() .
+                    ' (' . $element->getRubyTextRun()->getText() . ')';
             }
         }
 

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -300,8 +300,8 @@ abstract class AbstractPart
         if ($headingDepth !== null) {
             $textContent = null;
             $nodes = $xmlReader->getElements('w:r|w:hyperlink', $domNode);
-            $rubyNodes = $xmlReader->getElements('w:r/w:ruby', $domNode);
-            if ($nodes->length === 1 && count($rubyNodes) == 0) {
+            $hasRubyElement = $xmlReader->elementExists('w:r/w:ruby', $domNode);
+            if ($nodes->length === 1 && !$hasRubyElement) {
                 $textContent = htmlspecialchars($xmlReader->getValue('w:t', $nodes->item(0)), ENT_QUOTES, 'UTF-8');
             } else {
                 $textContent = new TextRun($paragraphStyle);

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -621,9 +621,9 @@ abstract class AbstractPart
         $rubyLid = $xmlReader->getElement('w:lid', $domNode)->getAttribute('w:val'); // type of ruby
         $properties = new RubyProperties();
         $properties->setAlignment($rubyAlignment);
-        $properties->setFontFaceSize(floatval($rubyHps));
-        $properties->setFontPointsAboveBaseText(floatval($rubyHpsRaise));
-        $properties->setFontSizeForBaseText(floatval($rubyHpsBaseText));
+        $properties->setFontFaceSize((float) $rubyHps);
+        $properties->setFontPointsAboveBaseText((float) $rubyHpsRaise);
+        $properties->setFontSizeForBaseText((float) $rubyHpsBaseText);
         $properties->setLanguageId($rubyLid);
 
         return $properties;

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -300,7 +300,8 @@ abstract class AbstractPart
         if ($headingDepth !== null) {
             $textContent = null;
             $nodes = $xmlReader->getElements('w:r|w:hyperlink', $domNode);
-            if ($nodes->length === 1) {
+            $rubyNodes = $xmlReader->getElements('w:r/w:ruby', $domNode);
+            if ($nodes->length === 1 && count($rubyNodes) == 0) {
                 $textContent = htmlspecialchars($xmlReader->getValue('w:t', $nodes->item(0)), ENT_QUOTES, 'UTF-8');
             } else {
                 $textContent = new TextRun($paragraphStyle);

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -621,9 +621,9 @@ abstract class AbstractPart
         $rubyLid = $xmlReader->getElement('w:lid', $domNode)->getAttribute('w:val'); // type of ruby
         $properties = new RubyProperties();
         $properties->setAlignment($rubyAlignment);
-        $properties->setFontFaceSize($rubyHps);
-        $properties->setFontPointsAboveBaseText($rubyHpsRaise);
-        $properties->setFontSizeForBaseText($rubyHpsBaseText);
+        $properties->setFontFaceSize(floatval($rubyHps));
+        $properties->setFontPointsAboveBaseText(floatval($rubyHpsRaise));
+        $properties->setFontSizeForBaseText(floatval($rubyHpsBaseText));
         $properties->setLanguageId($rubyLid);
 
         return $properties;

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -624,7 +624,7 @@ abstract class AbstractPart
         $properties->setFontFaceSize($rubyHps);
         $properties->setFontPointsAboveBaseText($rubyHpsRaise);
         $properties->setFontSizeForBaseText($rubyHpsBaseText);
-        $properties->setLanguage($rubyLid);
+        $properties->setLanguageId($rubyLid);
         return $properties;
     }
 

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -22,10 +22,13 @@ use DateTime;
 use DOMElement;
 use InvalidArgumentException;
 use PhpOffice\Math\Reader\OfficeMathML;
+use PhpOffice\PhpWord\ComplexType\RubyProperties;
 use PhpOffice\PhpWord\ComplexType\TblWidth as TblWidthComplexType;
 use PhpOffice\PhpWord\Element\AbstractContainer;
 use PhpOffice\PhpWord\Element\AbstractElement;
 use PhpOffice\PhpWord\Element\FormField;
+use PhpOffice\PhpWord\Element\Ruby;
+use PhpOffice\PhpWord\Element\Text;
 use PhpOffice\PhpWord\Element\TextRun;
 use PhpOffice\PhpWord\Element\TrackChange;
 use PhpOffice\PhpWord\PhpWord;
@@ -585,7 +588,44 @@ abstract class AbstractPart
             }
         } elseif ($node->nodeName == 'w:softHyphen') {
             $element = $parent->addText("\u{200c}", $fontStyle, $paragraphStyle);
+        } else if ($node->nodeName == 'w:ruby') {
+            $rubyPropertiesNode = $xmlReader->getElement('w:rubyPr', $node);
+            $properties = $this->readRubyProperties($xmlReader, $rubyPropertiesNode);
+            // read base text node
+            $baseText = new TextRun($paragraphStyle);
+            $baseTextNode = $xmlReader->getElement('w:rubyBase/w:r', $node);
+            $this->readRun($xmlReader, $baseTextNode, $baseText, $docPart, $paragraphStyle);
+            // read the actual ruby text (e.g. furigana in Japanese)
+            $rubyText = new TextRun($paragraphStyle);
+            $rubyTextNode = $xmlReader->getElement('w:rt/w:r', $node);
+            $this->readRun($xmlReader, $rubyTextNode, $rubyText, $docPart, $paragraphStyle);
+            // add element to parent
+            $parent->addRuby($baseText, $rubyText, $properties);
         }
+    }
+
+    /**
+     * Read w:rubyPr element.
+     *
+     * @param XMLReader $xmlReader reader for XML
+     * @param DOMElement $domNode w:RubyPr element
+     *
+     * @return RubyProperties ruby properties from element
+     */
+    protected function readRubyProperties(XMLReader $xmlReader, DOMElement $domNode): RubyProperties
+    {
+        $rubyAlignment = $xmlReader->getElement('w:rubyAlign', $domNode)->getAttribute('w:val');
+        $rubyHps = $xmlReader->getElement('w:hps', $domNode)->getAttribute('w:val'); // font face
+        $rubyHpsRaise = $xmlReader->getElement('w:hpsRaise', $domNode)->getAttribute('w:val'); // pts above base text
+        $rubyHpsBaseText = $xmlReader->getElement('w:hpsBaseText', $domNode)->getAttribute('w:val'); // base text size
+        $rubyLid = $xmlReader->getElement('w:lid', $domNode)->getAttribute('w:val'); // type of ruby
+        $properties = new RubyProperties();
+        $properties->setAlignment($rubyAlignment);
+        $properties->setFontFaceSize($rubyHps);
+        $properties->setFontPointsAboveBaseText($rubyHpsRaise);
+        $properties->setFontSizeForBaseText($rubyHpsBaseText);
+        $properties->setLanguage($rubyLid);
+        return $properties;
     }
 
     /**

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -588,7 +588,7 @@ abstract class AbstractPart
             }
         } elseif ($node->nodeName == 'w:softHyphen') {
             $element = $parent->addText("\u{200c}", $fontStyle, $paragraphStyle);
-        } else if ($node->nodeName == 'w:ruby') {
+        } elseif ($node->nodeName == 'w:ruby') {
             $rubyPropertiesNode = $xmlReader->getElement('w:rubyPr', $node);
             $properties = $this->readRubyProperties($xmlReader, $rubyPropertiesNode);
             // read base text node
@@ -625,6 +625,7 @@ abstract class AbstractPart
         $properties->setFontPointsAboveBaseText($rubyHpsRaise);
         $properties->setFontSizeForBaseText($rubyHpsBaseText);
         $properties->setLanguageId($rubyLid);
+
         return $properties;
     }
 

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -23,9 +23,11 @@ use DOMDocument;
 use DOMNode;
 use DOMXPath;
 use Exception;
+use PhpOffice\PhpWord\ComplexType\RubyProperties;
 use PhpOffice\PhpWord\Element\AbstractContainer;
 use PhpOffice\PhpWord\Element\Row;
 use PhpOffice\PhpWord\Element\Table;
+use PhpOffice\PhpWord\Element\TextRun;
 use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\SimpleType\Jc;
 use PhpOffice\PhpWord\SimpleType\NumberFormat;
@@ -239,6 +241,7 @@ class Html
             'a' => ['Link',        $node,  $element,   $styles,    null,   null,           null],
             'input' => ['Input',       $node,  $element,   $styles,    null,   null,           null],
             'hr' => ['HorizRule',   $node,  $element,   $styles,    null,   null,           null],
+            'ruby' => ['Ruby',   $node,  $element,   $styles,    null,   null,           null],
         ];
 
         $newElement = null;
@@ -302,7 +305,7 @@ class Html
      * @param AbstractContainer $element
      * @param array &$styles
      *
-     * @return \PhpOffice\PhpWord\Element\PageBreak|\PhpOffice\PhpWord\Element\TextRun
+     * @return \PhpOffice\PhpWord\Element\PageBreak|TextRun
      */
     protected static function parseParagraph($node, $element, &$styles)
     {
@@ -346,7 +349,7 @@ class Html
      * @param array &$styles
      * @param string $argument1 Name of heading style
      *
-     * @return \PhpOffice\PhpWord\Element\TextRun
+     * @return TextRun
      *
      * @todo Think of a clever way of defining header styles, now it is only based on the assumption, that
      * Heading1 - Heading6 are already defined somewhere
@@ -464,7 +467,7 @@ class Html
      * @param Table $element
      * @param array &$styles
      *
-     * @return \PhpOffice\PhpWord\Element\Cell|\PhpOffice\PhpWord\Element\TextRun $element
+     * @return \PhpOffice\PhpWord\Element\Cell|TextRun $element
      */
     protected static function parseCell($node, $element, &$styles)
     {
@@ -704,6 +707,10 @@ class Html
                     break;
                 case 'text-align':
                     $styles['alignment'] = self::mapAlign($value, $bidi);
+
+                    break;
+                case 'ruby-align':
+                    $styles['rubyAlignment'] = self::mapRubyAlign($value);
 
                     break;
                 case 'display':
@@ -1104,6 +1111,23 @@ class Html
     }
 
     /**
+     * Transforms a HTML/CSS ruby alignment into a \PhpOffice\PhpWord\SimpleType\Jc.
+     */
+    protected static function mapRubyAlign(string $cssRubyAlignment): string
+    {
+        switch ($cssRubyAlignment) {
+            case 'center':
+                return RubyProperties::ALIGNMENT_CENTER;
+            case 'start':
+                return RubyProperties::ALIGNMENT_LEFT;
+            case 'space-between':
+                return RubyProperties::ALIGNMENT_DISTRIBUTE_SPACE;
+            default:
+                return '';
+        }
+    }
+
+    /**
      * Transforms a HTML/CSS vertical alignment.
      *
      * @param string $alignment
@@ -1229,6 +1253,59 @@ class Html
         // - table - throws error "cannot be inside textruns", e.g. lists
         // - line - that is a shape, has different behaviour
         // - repeated text, e.g. underline "_", because of unpredictable line wrapping
+    }
+
+    /**
+     * Parse ruby node.
+     *
+     * @param DOMNode $node
+     * @param AbstractContainer $element
+     * @param array $styles
+     */
+    protected static function parseRuby($node, $element, &$styles)
+    {
+        $rubyProperties = new RubyProperties();
+        $baseTextRun = new TextRun($styles['paragraph']);
+        $rubyTextRun = new TextRun(null);
+        if ($node->hasAttributes()) {
+            $langAttr = $node->attributes->getNamedItem('lang');
+            if ($langAttr !== null) {
+                $rubyProperties->setLanguageId($langAttr->textContent);
+            }
+            $styleAttr = $node->attributes->getNamedItem('style');
+            if ($styleAttr !== null) {
+                $styles = self::parseStyle($styleAttr, $styles['paragraph']);
+                if (isset($styles['rubyAlignment']) && $styles['rubyAlignment'] !== '') {
+                    $rubyProperties->setAlignment($styles['rubyAlignment']);
+                }
+                if (isset($styles['size']) && $styles['size'] !== '') {
+                    $rubyProperties->setFontSizeForBaseText($styles['size']);
+                }
+                $baseTextRun->setParagraphStyle($styles);
+            }
+        }
+        foreach ($node->childNodes as $child) {
+            if ($child->nodeName === '#text') {
+                $content = trim($child->textContent);
+                if ($content !== '') {
+                    $baseTextRun->addText($content);
+                }
+            } elseif ($child->nodeName === 'rt') {
+                $rubyTextRun->addText(trim($child->textContent));
+                if ($child->hasAttributes()) {
+                    $styleAttr = $child->attributes->getNamedItem('style');
+                    if ($styleAttr !== null) {
+                        $styles = self::parseStyle($styleAttr, []);
+                        if (isset($styles['size']) && $styles['size'] !== '') {
+                            $rubyProperties->setFontFaceSize($styles['size']);
+                        }
+                        $rubyTextRun->setParagraphStyle($styles);
+                    }
+                }
+            }
+        }
+
+        return $element->addRuby($baseTextRun, $rubyTextRun, $rubyProperties);
     }
 
     private static function convertRgb(string $rgb): string

--- a/src/PhpWord/Writer/HTML/Element/Ruby.php
+++ b/src/PhpWord/Writer/HTML/Element/Ruby.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\HTML\Element;
+
+use PhpOffice\PhpWord\ComplexType\RubyProperties;
+use PhpOffice\PhpWord\Element\TextRun;
+use PhpOffice\PhpWord\Style\Paragraph;
+use PhpOffice\PhpWord\Writer\HTML\Style\Paragraph as ParagraphStyleWriter;
+
+/**
+ * Ruby element HTML writer.
+ */
+class Ruby extends AbstractElement
+{
+    /**
+     * Write text.
+     *
+     * @return string
+     */
+    public function write()
+    {
+        // $this->processFontStyle();
+
+        /** @var \PhpOffice\PhpWord\Element\Ruby $element Type hint */
+        $element = $this->element;
+
+        $baseText = $this->parentWriter->escapeHTML($element->getBaseTextRun()->getText());
+        $rubyText = $this->parentWriter->escapeHTML($element->getRubyTextRun()->getText());
+
+        $rubyTagPropertyCSS = $this->getPropertyCssForRubyTag($element->getProperties());
+        $lang = $element->getProperties()->getLanguageId();
+        $content = "<ruby {$this->getParagraphStyleForTextRun($element->getBaseTextRun(), $rubyTagPropertyCSS)} lang=\"{$lang}\">";
+        $content .= $baseText;
+        $content .= ' <rp>(</rp>';
+        $rtTagPropertyCSS = $this->getPropertyCssForRtTag($element->getProperties());
+        $content .= "<rt {$this->getParagraphStyleForTextRun($element->getRubyTextRun(), $rtTagPropertyCSS)}>";
+        $content .= $rubyText;
+        $content .= '</rt>';
+        $content .= '<rp>)</rp>';
+        $content .= '</ruby>';
+
+        return $content;
+    }
+
+    /**
+     * Get property CSS for the <ruby> tag.
+     */
+    private function getPropertyCssForRubyTag(RubyProperties $properties): string
+    {
+        // alignment CSS: https://developer.mozilla.org/en-US/docs/Web/CSS/ruby-align
+        $alignment = 'space-between';
+        switch ($properties->getAlignment()) {
+            case RubyProperties::ALIGNMENT_CENTER:
+                $alignment = 'center';
+
+                break;
+            case RubyProperties::ALIGNMENT_LEFT:
+                $alignment = 'start';
+
+                break;
+            default:
+                $alignment = 'space-between';
+
+                break;
+        }
+
+        return
+            'font-size:' . $properties->getFontSizeForBaseText() . 'pt' . ';' .
+            'ruby-align:' . $alignment . ';';
+    }
+
+    /**
+     * Get property CSS for the <rt> tag.
+     */
+    private function getPropertyCssForRtTag(RubyProperties $properties): string
+    {
+        // alignment CSS: https://developer.mozilla.org/en-US/docs/Web/CSS/ruby-align
+        return 'font-size:' . $properties->getFontFaceSize() . 'pt' . ';';
+    }
+
+    /**
+     * Write paragraph style for a given TextRun.
+     */
+    private function getParagraphStyleForTextRun(TextRun $textRun, string $extraCSS): string
+    {
+        $style = '';
+        if (!method_exists($textRun, 'getParagraphStyle')) {
+            return $style;
+        }
+
+        $paragraphStyle = $textRun->getParagraphStyle();
+        $pStyleIsObject = ($paragraphStyle instanceof Paragraph);
+        if ($pStyleIsObject) {
+            $styleWriter = new ParagraphStyleWriter($paragraphStyle);
+            $styleWriter->setParentWriter($this->parentWriter);
+            $style = $styleWriter->write();
+        } elseif (is_string($paragraphStyle)) {
+            $style = $paragraphStyle;
+        }
+        if ($style !== null && $style !== '') {
+            if ($pStyleIsObject) {
+                // CSS pairs (style="...")
+                $style = " style=\"{$style}{$extraCSS}\"";
+            } else {
+                // class name; need to append extra styles manually
+                $style = " class=\"{$style}\" style=\"{$extraCSS}\"";
+            }
+        } elseif ($extraCSS !== '') {
+            $style = " style=\"{$extraCSS}\"";
+        }
+
+        return $style;
+    }
+}

--- a/src/PhpWord/Writer/ODText/Element/AbstractElement.php
+++ b/src/PhpWord/Writer/ODText/Element/AbstractElement.php
@@ -27,4 +27,32 @@ use PhpOffice\PhpWord\Writer\Word2007\Element\AbstractElement as Word2007Abstrac
  */
 abstract class AbstractElement extends Word2007AbstractElement
 {
+    protected function replaceTabs($text, $xmlWriter): void
+    {
+        if (preg_match('/^ +/', $text, $matches)) {
+            $num = strlen($matches[0]);
+            $xmlWriter->startElement('text:s');
+            $xmlWriter->writeAttributeIf($num > 1, 'text:c', "$num");
+            $xmlWriter->endElement();
+            $text = preg_replace('/^ +/', '', $text);
+        }
+        preg_match_all('/([\\s\\S]*?)(\\t|  +| ?$)/', $text, $matches, PREG_SET_ORDER);
+        foreach ($matches as $match) {
+            $this->writeText($match[1]);
+            if ($match[2] === '') {
+                break;
+            } elseif ($match[2] === "\t") {
+                $xmlWriter->writeElement('text:tab');
+            } elseif ($match[2] === ' ') {
+                $xmlWriter->writeElement('text:s');
+
+                break;
+            } else {
+                $num = strlen($match[2]);
+                $xmlWriter->startElement('text:s');
+                $xmlWriter->writeAttributeIf($num > 1, 'text:c', "$num");
+                $xmlWriter->endElement();
+            }
+        }
+    }
 }

--- a/src/PhpWord/Writer/ODText/Element/Ruby.php
+++ b/src/PhpWord/Writer/ODText/Element/Ruby.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\ODText\Element;
+
+/**
+ * Ruby element writer.
+ * NOTE: This class will write out a Ruby element in the format {baseText} ({rubyText})
+ * just like RTF; however, ODT files natively support Ruby text elements.
+ * This implementation should be changed in the future to support ODT's native
+ * Ruby elements and usage.
+ */
+class Ruby extends AbstractElement
+{
+    /**
+     * Write element.
+     */
+    public function write(): void
+    {
+        $xmlWriter = $this->getXmlWriter();
+        $element = $this->getElement();
+        if (!$element instanceof \PhpOffice\PhpWord\Element\Ruby) {
+            return;
+        }
+        $paragraphStyle = $element->getBaseTextRun()->getParagraphStyle();
+
+        if (!$this->withoutP) {
+            $xmlWriter->startElement('text:p'); // text:p
+        }
+        if (empty($paragraphStyle)) {
+            if (!$this->withoutP) {
+                $xmlWriter->writeAttribute('text:style-name', 'Normal');
+            }
+        } elseif (is_string($paragraphStyle)) {
+            if (!$this->withoutP) {
+                $xmlWriter->writeAttribute('text:style-name', $paragraphStyle);
+            }
+        }
+
+        $this->replaceTabs($element->getBaseTextRun()->getText(), $xmlWriter);
+        $this->writeText(' (');
+        $this->replaceTabs($element->getRubyTextRun()->getText(), $xmlWriter);
+        $this->writeText(')');
+
+        if (!$this->withoutP) {
+            $xmlWriter->endElement(); // text:p
+        }
+    }
+}

--- a/src/PhpWord/Writer/ODText/Element/Text.php
+++ b/src/PhpWord/Writer/ODText/Element/Text.php
@@ -89,35 +89,6 @@ class Text extends AbstractElement
         }
     }
 
-    private function replacetabs($text, $xmlWriter): void
-    {
-        if (preg_match('/^ +/', $text, $matches)) {
-            $num = strlen($matches[0]);
-            $xmlWriter->startElement('text:s');
-            $xmlWriter->writeAttributeIf($num > 1, 'text:c', "$num");
-            $xmlWriter->endElement();
-            $text = preg_replace('/^ +/', '', $text);
-        }
-        preg_match_all('/([\\s\\S]*?)(\\t|  +| ?$)/', $text, $matches, PREG_SET_ORDER);
-        foreach ($matches as $match) {
-            $this->writeText($match[1]);
-            if ($match[2] === '') {
-                break;
-            } elseif ($match[2] === "\t") {
-                $xmlWriter->writeElement('text:tab');
-            } elseif ($match[2] === ' ') {
-                $xmlWriter->writeElement('text:s');
-
-                break;
-            } else {
-                $num = strlen($match[2]);
-                $xmlWriter->startElement('text:s');
-                $xmlWriter->writeAttributeIf($num > 1, 'text:c', "$num");
-                $xmlWriter->endElement();
-            }
-        }
-    }
-
     private function writeChangeInsertion($start = true, ?TrackChange $trackChange = null): void
     {
         if ($trackChange == null || $trackChange->getChangeType() != TrackChange::INSERTED) {

--- a/src/PhpWord/Writer/RTF/Element/Ruby.php
+++ b/src/PhpWord/Writer/RTF/Element/Ruby.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\RTF\Element;
+
+/**
+ * Ruby element RTF writer. Writes {baseText} ({rubyText}) in current paragraph style
+ * because RTF does not natively support ruby text.
+ */
+class Ruby extends AbstractElement
+{
+    /**
+     * Write element.
+     *
+     * @return string
+     */
+    public function write()
+    {
+        /** @var \PhpOffice\PhpWord\Element\Ruby $element */
+        $element = $this->element;
+        $elementClass = str_replace('\\Writer\\RTF', '', static::class);
+        if (!$element instanceof $elementClass || !is_string($element->getBaseTextRun()->getText())) {
+            return '';
+        }
+
+        $this->getStyles();
+
+        $content = '';
+        $content .= $this->writeOpening();
+        $content .= '{';
+        $content .= $this->writeFontStyle();
+        $content .= $this->writeText($element->getBaseTextRun()->getText());
+        $rubyText = $element->getRubyTextRun()->getText();
+        if ($rubyText !== '') {
+            $content .= ' (';
+            $content .= $this->writeText($rubyText);
+            $content .= ')';
+        }
+        $content .= '}';
+        $content .= $this->writeClosing();
+
+        return $content;
+    }
+}

--- a/src/PhpWord/Writer/RTF/Element/Title.php
+++ b/src/PhpWord/Writer/RTF/Element/Title.php
@@ -59,8 +59,13 @@ class Title extends Text
         /** @var \PhpOffice\PhpWord\Element\Title $element Type hint */
         $element = $this->element;
         $elementClass = str_replace('\\Writer\\RTF', '', static::class);
-        if (!$element instanceof $elementClass || !is_string($element->getText())) {
+        if (!$element instanceof $elementClass) {
             return '';
+        }
+
+        $textToWrite = $element->getText();
+        if ($textToWrite instanceof \PhpOffice\PhpWord\Element\TextRun) {
+            $textToWrite = $textToWrite->getText(); // gets text from TextRun
         }
 
         $this->getStyles();
@@ -83,7 +88,7 @@ class Title extends Text
 
         $content .= '{';
         $content .= $this->writeFontStyle();
-        $content .= $this->writeText($element->getText());
+        $content .= $this->writeText($textToWrite);
         $content .= '}';
         $content .= $this->writeClosing();
         $content .= $endout;

--- a/src/PhpWord/Writer/Word2007/Element/Ruby.php
+++ b/src/PhpWord/Writer/Word2007/Element/Ruby.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\Word2007\Element;
+
+use PhpOffice\PhpWord\Element\TrackChange;
+
+/**
+ * Ruby element writer.
+ */
+class Ruby extends AbstractElement
+{
+    /**
+     * Write ruby element.
+     */
+    public function write(): void
+    {
+        $xmlWriter = $this->getXmlWriter();
+        $element = $this->getElement();
+        if (!$element instanceof \PhpOffice\PhpWord\Element\Ruby) {
+            return;
+        }
+        /** @var \PhpOffice\PhpWord\Element\Ruby $element */
+        $this->startElementP();
+
+        $xmlWriter->startElement('w:r');
+        $xmlWriter->startElement('w:ruby');
+
+        // write properties
+        $xmlWriter->startElement('w:rubyPr');
+        $properties = $element->getProperties();
+        $xmlWriter->startElement('w:rubyAlign');
+        $xmlWriter->writeAttribute('w:val', $properties->getAlignment());
+        $xmlWriter->endElement(); // w:rubyAlign
+        $xmlWriter->startElement('w:hps');
+        $xmlWriter->writeAttribute('w:val', $properties->getFontFaceSize());
+        $xmlWriter->endElement(); // w:hps
+        $xmlWriter->startElement('w:hpsRaise');
+        $xmlWriter->writeAttribute('w:val', $properties->getFontPointsAboveBaseText());
+        $xmlWriter->endElement(); // w:hpsRaise
+        $xmlWriter->startElement('w:hpsBaseText');
+        $xmlWriter->writeAttribute('w:val', $properties->getFontSizeForBaseText());
+        $xmlWriter->endElement(); // w:hpsBaseText
+        $xmlWriter->startElement('w:lid');
+        $xmlWriter->writeAttribute('w:val', $properties->getLanguageId());
+        $xmlWriter->endElement(); // w:lid
+
+        $xmlWriter->endElement(); // w:rubyPr
+
+        // write ruby text
+        $xmlWriter->startElement('w:rt');
+        $rubyTextRun = $element->getRubyTextRun();
+        $textRunWriter = new TextRun($xmlWriter, $rubyTextRun, true);
+        $textRunWriter->write();
+        $xmlWriter->endElement(); // w:rt
+        // write base text
+        $xmlWriter->startElement('w:rubyBase');
+        $baseTextRun = $element->getBaseTextRun();
+        $textRunWriter = new TextRun($xmlWriter, $baseTextRun, true);
+        $textRunWriter->write();
+        $xmlWriter->endElement(); // w:rubyBase
+
+        $xmlWriter->endElement(); // w:ruby
+        $xmlWriter->endElement(); // w:r
+
+        $this->endElementP();
+    }
+}

--- a/src/PhpWord/Writer/Word2007/Element/Ruby.php
+++ b/src/PhpWord/Writer/Word2007/Element/Ruby.php
@@ -18,8 +18,6 @@
 
 namespace PhpOffice\PhpWord\Writer\Word2007\Element;
 
-use PhpOffice\PhpWord\Element\TrackChange;
-
 /**
  * Ruby element writer.
  */

--- a/tests/PhpWordTests/ComplexType/RubyPropertiesTest.php
+++ b/tests/PhpWordTests/ComplexType/RubyPropertiesTest.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWordTests\ComplexType;
+
+use InvalidArgumentException;
+use PhpOffice\PhpWord\ComplexType\RubyProperties;
+
+/**
+ * Test class for PhpOffice\PhpWord\ComplexType\RubyProperties.
+ *
+ * @runTestsInSeparateProcesses
+ */
+class RubyPropertiesTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test new instance.
+     */
+    public function testConstruct(): void
+    {
+        $properties = new RubyProperties();
+        self::assertInstanceOf('PhpOffice\\PhpWord\\ComplexType\\RubyProperties', $properties);
+
+        self::assertIsString($properties->getAlignment());
+        self::assertTrue($properties->getAlignment() !== '' && $properties->getAlignment() !== null);
+        self::assertIsFloat($properties->getFontFaceSize());
+        self::assertIsFloat($properties->getFontPointsAboveBaseText());
+        self::assertIsFloat($properties->getFontSizeForBaseText());
+        self::assertIsString($properties->getLanguageId());
+        self::assertTrue($properties->getLanguageId() !== '' && $properties->getLanguageId() !== null);
+    }
+
+    /**
+     * Get/set alignment.
+     */
+    public function testAlignment(): void
+    {
+        $properties = new RubyProperties();
+        self::assertIsString($properties->getAlignment());
+        self::assertTrue($properties->getAlignment() !== '' && $properties->getAlignment() !== null);
+        $properties->setAlignment(RubyProperties::ALIGNMENT_RIGHT_VERTICAL);
+        self::assertEquals(RubyProperties::ALIGNMENT_RIGHT_VERTICAL, $properties->getAlignment());
+    }
+
+    /**
+     * Set valid alignments. Make sure we can set all valid types - should not throw exception.
+     */
+    public function testValidAlignments(): void
+    {
+        $properties = new RubyProperties();
+        $types = [
+            RubyProperties::ALIGNMENT_CENTER,
+            RubyProperties::ALIGNMENT_DISTRIBUTE_LETTER,
+            RubyProperties::ALIGNMENT_DISTRIBUTE_SPACE,
+            RubyProperties::ALIGNMENT_LEFT,
+            RubyProperties::ALIGNMENT_RIGHT,
+            RubyProperties::ALIGNMENT_RIGHT_VERTICAL,
+        ];
+        foreach ($types as $type) {
+            $properties->setAlignment($type);
+            self::assertEquals($type, $properties->getAlignment());
+        }
+    }
+
+    /**
+     * Test throws exception on invalid alignment type.
+     */
+    public function testInvalidAlignment(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $properties = new RubyProperties();
+        $properties->setAlignment('invalid alignment type');
+    }
+
+    /**
+     * Get/set font face size.
+     */
+    public function testFontFaceSize(): void
+    {
+        $properties = new RubyProperties();
+
+        self::assertTrue($properties->getFontFaceSize() > 0);
+        $properties->setFontFaceSize(42.42);
+        self::assertEqualsWithDelta(42.42, $properties->getFontFaceSize(), 0.00001); // use delta as it is a float compare
+        self::assertIsFloat($properties->getFontFaceSize());
+    }
+
+    /**
+     * Get/set font points above base text.
+     */
+    public function testFontPointsAboveBaseText(): void
+    {
+        $properties = new RubyProperties();
+
+        self::assertTrue($properties->getFontPointsAboveBaseText() > 0);
+        $properties->setFontPointsAboveBaseText(43.42);
+        self::assertEqualsWithDelta(43.42, $properties->getFontPointsAboveBaseText(), 0.00001); // use delta as it is a float compare
+        self::assertIsFloat($properties->getFontPointsAboveBaseText());
+    }
+
+    /**
+     * Get/set font size for base text.
+     */
+    public function testFontSizeForBaseText(): void
+    {
+        $properties = new RubyProperties();
+
+        self::assertTrue($properties->getFontSizeForBaseText() > 0);
+        $properties->setFontSizeForBaseText(45.42);
+        self::assertEqualsWithDelta(45.42, $properties->getFontSizeForBaseText(), 0.00001); // use delta as it is a float compare
+        self::assertIsFloat($properties->getFontSizeForBaseText());
+    }
+
+    /**
+     * Get/set language id.
+     */
+    public function testLanguageId(): void
+    {
+        $properties = new RubyProperties();
+
+        self::assertTrue($properties->getLanguageId() !== '' && $properties->getLanguageId() !== null);
+        $properties->setLanguageId('en-US');
+        self::assertIsString($properties->getLanguageId());
+        self::assertEquals('en-US', $properties->getLanguageId());
+    }
+}

--- a/tests/PhpWordTests/Element/RubyTest.php
+++ b/tests/PhpWordTests/Element/RubyTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWordTests\Element;
+
+use PhpOffice\PhpWord\ComplexType\RubyProperties;
+use PhpOffice\PhpWord\Element\Ruby;
+use PhpOffice\PhpWord\Element\TextRun;
+
+/**
+ * Test class for PhpOffice\PhpWord\Element\Text.
+ *
+ * @runTestsInSeparateProcesses
+ */
+class RubyTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test new instance.
+     */
+    public function testConstruct(): void
+    {
+        $ruby = new Ruby(new TextRun(), new TextRun(), new RubyProperties());
+
+        self::assertInstanceOf('PhpOffice\\PhpWord\\Element\\Ruby', $ruby);
+        self::assertEquals('', $ruby->getBaseTextRun()->getText());
+        self::assertInstanceOf('PhpOffice\\PhpWord\\Element\\TextRun', $ruby->getBaseTextRun());
+        self::assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $ruby->getBaseTextRun()->getParagraphStyle());
+        self::assertEquals('', $ruby->getRubyTextRun()->getText());
+        self::assertInstanceOf('PhpOffice\\PhpWord\\Element\\TextRun', $ruby->getRubyTextRun());
+        self::assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $ruby->getRubyTextRun()->getParagraphStyle());
+        self::assertInstanceOf('PhpOffice\\PhpWord\\ComplexType\\RubyProperties', $ruby->getProperties());
+        self::assertEquals(RubyProperties::ALIGNMENT_DISTRIBUTE_SPACE, $ruby->getProperties()->getAlignment());
+    }
+
+    /**
+     * Get/set base text.
+     */
+    public function testBaseText(): void
+    {
+        $ruby = new Ruby(new TextRun(), new TextRun(), new RubyProperties());
+
+        self::assertEquals('', $ruby->getBaseTextRun()->getText());
+        $tr = new TextRun();
+        $tr->addText('Hello, world');
+        $ruby->setBaseTextRun($tr);
+        self::assertInstanceOf('PhpOffice\\PhpWord\\Element\\TextRun', $ruby->getBaseTextRun());
+        self::assertEquals('Hello, world', $ruby->getBaseTextRun()->getText());
+    }
+
+    /**
+     * Get/set ruby text.
+     */
+    public function testRubyText(): void
+    {
+        $ruby = new Ruby(new TextRun(), new TextRun(), new RubyProperties());
+
+        self::assertEquals('', $ruby->getRubyTextRun()->getText());
+        $tr = new TextRun();
+        $tr->addText('Hello, ruby');
+        $ruby->setRubyTextRun($tr);
+        self::assertInstanceOf('PhpOffice\\PhpWord\\Element\\TextRun', $ruby->getRubyTextRun());
+        self::assertEquals('Hello, ruby', $ruby->getRubyTextRun()->getText());
+    }
+
+    /**
+     * Get/set ruby properties.
+     */
+    public function testRubyProperties(): void
+    {
+        $ruby = new Ruby(new TextRun(), new TextRun(), new RubyProperties());
+
+        self::assertEquals(RubyProperties::ALIGNMENT_DISTRIBUTE_SPACE, $ruby->getProperties()->getAlignment());
+
+        $properties = new RubyProperties();
+        $properties->setAlignment(RubyProperties::ALIGNMENT_RIGHT_VERTICAL);
+        $properties->setFontFaceSize(1);
+        $properties->setFontPointsAboveBaseText(2);
+        $properties->setFontSizeForBaseText(3);
+        $properties->setLanguageId('en-US');
+        $ruby->setProperties($properties);
+
+        self::assertInstanceOf('PhpOffice\\PhpWord\\ComplexType\\RubyProperties', $ruby->getProperties());
+        self::assertEquals(RubyProperties::ALIGNMENT_RIGHT_VERTICAL, $ruby->getProperties()->getAlignment());
+        self::assertEquals(1, $ruby->getProperties()->getFontFaceSize());
+        self::assertEquals(2, $ruby->getProperties()->getFontPointsAboveBaseText());
+        self::assertEquals(3, $ruby->getProperties()->getFontSizeForBaseText());
+        self::assertEquals('en-US', $ruby->getProperties()->getLanguageId());
+    }
+}

--- a/tests/PhpWordTests/Element/TextRunTest.php
+++ b/tests/PhpWordTests/Element/TextRunTest.php
@@ -18,6 +18,7 @@
 
 namespace PhpOffice\PhpWordTests\Element;
 
+use PhpOffice\PhpWord\ComplexType\RubyProperties;
 use PhpOffice\PhpWord\Element\TextRun;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\SimpleType\Jc;
@@ -182,5 +183,25 @@ class TextRunTest extends \PHPUnit\Framework\TestCase
 
         $oText->setParagraphStyle(['alignment' => Jc::CENTER, 'spaceAfter' => 100]);
         self::assertInstanceOf('PhpOffice\\PhpWord\\Style\\Paragraph', $oText->getParagraphStyle());
+    }
+
+    /**
+     * Add ruby element and get raw text.
+     */
+    public function testRubyElementGetText(): void
+    {
+        $oTextRun = new TextRun();
+        $oTextRun->setPhpWord(new PhpWord());
+
+        $properties = new RubyProperties();
+        $baseTextRun = new TextRun(null);
+        $baseTextRun->addText('私');
+        $rubyTextRun = new TextRun(null);
+        $rubyTextRun->addText('わたし');
+        $element = $oTextRun->addRuby($baseTextRun, $rubyTextRun, $properties);
+
+        self::assertInstanceOf('PhpOffice\\PhpWord\\Element\\Ruby', $element);
+        self::assertCount(1, $oTextRun->getElements());
+        self::assertEquals('私 (わたし)', $oTextRun->getText());
     }
 }

--- a/tests/PhpWordTests/Reader/Word2007/ElementTest.php
+++ b/tests/PhpWordTests/Reader/Word2007/ElementTest.php
@@ -19,6 +19,7 @@
 namespace PhpOffice\PhpWordTests\Reader\Word2007;
 
 use PhpOffice\PhpWord\ComplexType\RubyProperties;
+use PhpOffice\PhpWord\Element\Ruby;
 use PhpOffice\PhpWord\Element\Text;
 use PhpOffice\PhpWord\Element\TrackChange;
 use PhpOffice\PhpWord\Style\Font;
@@ -654,19 +655,25 @@ class ElementTest extends AbstractTestReader
         $phpWord = $this->getDocumentFromString(['document' => $documentXml]);
         $elements = $phpWord->getSection(0)->getElements();
         self::assertInstanceOf('PhpOffice\PhpWord\Element\Title', $elements[0]);
-        $subElements = $elements[0]->getText()->getElements(); // <w:ruby>
+        /** @var \PhpOffice\PhpWord\Element\Title $title */
+        $title = $elements[0];
+        /** @var \PhpOffice\PhpWord\Element\TextRun $textRun */
+        $textRun = $title->getText();
+        $subElements = $textRun->getElements(); // <w:ruby>
         self::assertInstanceOf('PhpOffice\PhpWord\Element\Ruby', $subElements[0]);
+        /** @var Ruby $ruby */
+        $ruby = $subElements[0];
         /** @var RubyProperties $rubyProperties */
-        $rubyProperties = $subElements[0]->getProperties();
+        $rubyProperties = $ruby->getProperties();
         self::assertEquals(RubyProperties::ALIGNMENT_DISTRIBUTE_SPACE, $rubyProperties->getAlignment());
         self::assertEquals(20, $rubyProperties->getFontFaceSize());
         self::assertEquals(38, $rubyProperties->getFontPointsAboveBaseText());
         self::assertEquals(40, $rubyProperties->getFontSizeForBaseText());
         self::assertEquals('ja-JP', $rubyProperties->getLanguageId());
         /** @var \PhpOffice\PhpWord\Element\TextRun $textRun */
-        $textRun = $subElements[0]->getBaseTextRun();
+        $textRun = $ruby->getBaseTextRun();
         self::assertEquals('神', $textRun->getText());
-        $textRun = $subElements[0]->getRubyTextRun();
+        $textRun = $ruby->getRubyTextRun();
         self::assertEquals('かみ', $textRun->getText());
     }
 }

--- a/tests/PhpWordTests/Reader/Word2007/ElementTest.php
+++ b/tests/PhpWordTests/Reader/Word2007/ElementTest.php
@@ -592,7 +592,7 @@ class ElementTest extends AbstractTestReader
         $subElements = $elements[0]->getElements(); // <w:ruby>
         self::assertInstanceOf('PhpOffice\PhpWord\Element\Ruby', $subElements[0]);
         /** @var RubyProperties $rubyProperties */
-        $rubyProperties = $subElements[0]->getProperties(); 
+        $rubyProperties = $subElements[0]->getProperties();
         self::assertEquals(RubyProperties::ALIGNMENT_DISTRIBUTE_SPACE, $rubyProperties->getAlignment());
         self::assertEquals(12, $rubyProperties->getFontFaceSize());
         self::assertEquals(22, $rubyProperties->getFontPointsAboveBaseText());

--- a/tests/PhpWordTests/Reader/Word2007/ElementTest.php
+++ b/tests/PhpWordTests/Reader/Word2007/ElementTest.php
@@ -597,11 +597,11 @@ class ElementTest extends AbstractTestReader
         self::assertEquals(12, $rubyProperties->getFontFaceSize());
         self::assertEquals(22, $rubyProperties->getFontPointsAboveBaseText());
         self::assertEquals(24, $rubyProperties->getFontSizeForBaseText());
-        self::assertEquals("ja-JP", $rubyProperties->getLanguage());
+        self::assertEquals('ja-JP', $rubyProperties->getLanguageId());
         /** @var \PhpOffice\PhpWord\Element\TextRun $textRun */
         $textRun = $subElements[0]->getBaseTextRun();
-        self::assertEquals("私", $textRun->getText());
+        self::assertEquals('私', $textRun->getText());
         $textRun = $subElements[0]->getRubyTextRun();
-        self::assertEquals("わたし", $textRun->getText());
+        self::assertEquals('わたし', $textRun->getText());
     }
 }

--- a/tests/PhpWordTests/Reader/Word2007/ElementTest.php
+++ b/tests/PhpWordTests/Reader/Word2007/ElementTest.php
@@ -604,4 +604,69 @@ class ElementTest extends AbstractTestReader
         $textRun = $subElements[0]->getRubyTextRun();
         self::assertEquals('わたし', $textRun->getText());
     }
+
+    /**
+     * Test reading of ruby title.
+     */
+    public function testReadRubyTitle(): void
+    {
+        $documentXml = '<w:p
+             w:rsidR="00CB4855"
+             w:rsidRDefault="00AA542C"
+             w:rsidP="00AA542C">
+            <w:pPr>
+                <w:pStyle w:val="Heading1" />
+            </w:pPr>
+            <w:r>
+                <w:ruby>
+                    <w:rubyPr>
+                        <w:rubyAlign w:val="distributeSpace" />
+                        <w:hps w:val="20" />
+                        <w:hpsRaise w:val="38" />
+                        <w:hpsBaseText w:val="40" />
+                        <w:lid w:val="ja-JP" />
+                    </w:rubyPr>
+                    <w:rt>
+                        <w:r w:rsidR="00AA542C"
+                             w:rsidRPr="00AA542C">
+                            <w:rPr>
+                                <w:rFonts w:ascii="Yu Gothic Light"
+                                          w:eastAsia="Yu Gothic Light"
+                                          w:hAnsi="Yu Gothic Light"
+                                          w:hint="eastAsia" />
+                                <w:sz w:val="20" />
+                            </w:rPr>
+                            <w:t>かみ</w:t>
+                        </w:r>
+                    </w:rt>
+                    <w:rubyBase>
+                        <w:r w:rsidR="00AA542C">
+                            <w:rPr>
+                                <w:rFonts w:hint="eastAsia" />
+                            </w:rPr>
+                            <w:t>神</w:t>
+                        </w:r>
+                    </w:rubyBase>
+                </w:ruby>
+            </w:r>
+        </w:p>';
+
+        $phpWord = $this->getDocumentFromString(['document' => $documentXml]);
+        $elements = $phpWord->getSection(0)->getElements();
+        self::assertInstanceOf('PhpOffice\PhpWord\Element\Title', $elements[0]);
+        $subElements = $elements[0]->getText()->getElements(); // <w:ruby>
+        self::assertInstanceOf('PhpOffice\PhpWord\Element\Ruby', $subElements[0]);
+        /** @var RubyProperties $rubyProperties */
+        $rubyProperties = $subElements[0]->getProperties();
+        self::assertEquals(RubyProperties::ALIGNMENT_DISTRIBUTE_SPACE, $rubyProperties->getAlignment());
+        self::assertEquals(20, $rubyProperties->getFontFaceSize());
+        self::assertEquals(38, $rubyProperties->getFontPointsAboveBaseText());
+        self::assertEquals(40, $rubyProperties->getFontSizeForBaseText());
+        self::assertEquals('ja-JP', $rubyProperties->getLanguageId());
+        /** @var \PhpOffice\PhpWord\Element\TextRun $textRun */
+        $textRun = $subElements[0]->getBaseTextRun();
+        self::assertEquals('神', $textRun->getText());
+        $textRun = $subElements[0]->getRubyTextRun();
+        self::assertEquals('かみ', $textRun->getText());
+    }
 }

--- a/tests/PhpWordTests/Shared/HtmlTest.php
+++ b/tests/PhpWordTests/Shared/HtmlTest.php
@@ -19,6 +19,7 @@
 namespace PhpOffice\PhpWordTests\Shared;
 
 use Exception;
+use PhpOffice\PhpWord\ComplexType\RubyProperties;
 use PhpOffice\PhpWord\Element\Section;
 use PhpOffice\PhpWord\Element\Table;
 use PhpOffice\PhpWord\PhpWord;
@@ -1316,5 +1317,52 @@ HTML;
             ['300px', 4500, TblWidth::TWIP],
             ['400', 6000, TblWidth::TWIP],
         ];
+    }
+
+    /**
+     * Test ruby.
+     */
+    public function testParseRubyHtml(): void
+    {
+        $html = <<<HTML
+        <ruby lang="en-US" style="line-height: 8pt;font-size:20pt;ruby-align:center;">
+            base text
+            <rp>(</rp>
+            <rt style="line-height: 4pt;font-size:10pt">ruby text</rt>
+            <rp>)</rp>
+        </ruby>
+        HTML;
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby'));
+        self::assertEquals('ruby text', $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rt/w:r/w:t')->textContent);
+        self::assertEquals(
+            'base text',
+            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyBase/w:r/w:t')->textContent
+        );
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr'));
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:rubyAlign'));
+        self::assertEquals(
+            RubyProperties::ALIGNMENT_CENTER,
+            $doc->getElementAttribute('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:rubyAlign', 'w:val')
+        );
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hps'));
+        self::assertEquals(
+            10,
+            $doc->getElementAttribute('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hps', 'w:val')
+        );
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hpsBaseText'));
+        self::assertEquals(
+            20,
+            $doc->getElementAttribute('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hpsBaseText', 'w:val')
+        );
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:lid'));
+        self::assertEquals(
+            'en-US',
+            $doc->getElementAttribute('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:lid', 'w:val')
+        );
     }
 }

--- a/tests/PhpWordTests/Shared/HtmlTest.php
+++ b/tests/PhpWordTests/Shared/HtmlTest.php
@@ -1325,13 +1325,13 @@ HTML;
     public function testParseRubyHtml(): void
     {
         $html = <<<HTML
-        <ruby lang="en-US" style="line-height: 8pt;font-size:20pt;ruby-align:center;">
-            base text
-            <rp>(</rp>
-            <rt style="line-height: 4pt;font-size:10pt">ruby text</rt>
-            <rp>)</rp>
-        </ruby>
-        HTML;
+<ruby lang="en-US" style="line-height: 8pt;font-size:20pt;ruby-align:center;">
+    base text
+    <rp>(</rp>
+    <rt style="line-height: 4pt;font-size:10pt">ruby text</rt>
+    <rp>)</rp>
+</ruby>
+HTML;
         $phpWord = new PhpWord();
         $section = $phpWord->addSection();
         Html::addHtml($section, $html);

--- a/tests/PhpWordTests/Writer/HTML/Element/RubyTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/RubyTest.php
@@ -18,7 +18,6 @@
 
 namespace PhpOffice\PhpWordTests\Writer\HTML\Element;
 
-use Countable;
 use DOMXPath;
 use PhpOffice\PhpWord\ComplexType\RubyProperties;
 use PhpOffice\PhpWord\Element\TextRun;

--- a/tests/PhpWordTests/Writer/HTML/Element/RubyTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/RubyTest.php
@@ -50,9 +50,7 @@ class RubyTest extends TestCase
 
         $dom = Helper::getAsHTML($phpWord, '', '', ['ruby', 'rt', 'rp']);
         $xpath = new DOMXPath($dom);
-        $nodeList = $xpath->query('/html/body/div/ruby');
-        /** @var Countable $nodeList */
-        self::assertEquals(1, $nodeList->count());
+        self::assertEquals(1, $xpath->query('/html/body/div/ruby')->length);
         // ensure text is right
         $rubyElement = $dom->getElementsByTagName('ruby')->item(0);
         $rtElement = $dom->getElementsByTagName('rt')->item(0);
@@ -87,9 +85,7 @@ class RubyTest extends TestCase
 
         $dom = Helper::getAsHTML($phpWord, '', '', ['ruby', 'rt', 'rp']);
         $xpath = new DOMXPath($dom);
-        $nodeList = $xpath->query('/html/body/div/ruby');
-        /** @var Countable $nodeList */
-        self::assertEquals(1, $nodeList->count());
+        self::assertEquals(1, $xpath->query('/html/body/div/ruby')->length);
         // ensure text is right
         $rubyElement = $dom->getElementsByTagName('ruby')->item(0);
         $rtElement = $dom->getElementsByTagName('rt')->item(0);

--- a/tests/PhpWordTests/Writer/HTML/Element/RubyTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/RubyTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWordTests\Writer\HTML\Element;
+
+use Countable;
+use DOMXPath;
+use PhpOffice\PhpWord\ComplexType\RubyProperties;
+use PhpOffice\PhpWord\Element\TextRun;
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWordTests\Writer\HTML\Helper;
+use PHPUnit\Framework\TestCase;
+
+class RubyTest extends TestCase
+{
+    /**
+     * Tests writing ruby HTML.
+     */
+    public function testWriteRubyHtml(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $properties = new RubyProperties();
+        $properties->setAlignment(RubyProperties::ALIGNMENT_CENTER);
+        $properties->setFontFaceSize(10);
+        $properties->setFontPointsAboveBaseText(4);
+        $properties->setFontSizeForBaseText(20);
+        $properties->setLanguageId('ja-JP');
+
+        $baseTextRun = new TextRun(null);
+        $baseTextRun->addText('私');
+        $rubyTextRun = new TextRun(null);
+        $rubyTextRun->addText('わたし');
+        $section->addRuby($baseTextRun, $rubyTextRun, $properties);
+
+        $dom = Helper::getAsHTML($phpWord, '', '', ['ruby', 'rt', 'rp']);
+        $xpath = new DOMXPath($dom);
+        $nodeList = $xpath->query('/html/body/div/ruby');
+        /** @var Countable $nodeList */
+        self::assertEquals(1, $nodeList->count());
+        // ensure text is right
+        $rubyElement = $dom->getElementsByTagName('ruby')->item(0);
+        $rtElement = $dom->getElementsByTagName('rt')->item(0);
+        self::assertNotNull($rubyElement);
+        self::assertNotNull($rtElement);
+        self::assertEquals($baseTextRun->getText() . ' (' . $rubyTextRun->getText() . ')', $rubyElement->textContent);
+        self::assertEquals($rubyTextRun->getText(), $rtElement->textContent);
+        // check style
+        self::assertEquals('font-size:20pt;ruby-align:center;', $rubyElement->attributes->getNamedItem('style')->textContent);
+        self::assertEquals('font-size:10pt;', $rtElement->attributes->getNamedItem('style')->textContent);
+    }
+
+    /**
+     * Tests writing ruby HTML.
+     */
+    public function testWriteRubyHtmlParagraphStyle(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $properties = new RubyProperties();
+        $properties->setAlignment(RubyProperties::ALIGNMENT_CENTER);
+        $properties->setFontFaceSize(10);
+        $properties->setFontPointsAboveBaseText(4);
+        $properties->setFontSizeForBaseText(20);
+        $properties->setLanguageId('ja-JP');
+
+        $baseTextRun = new TextRun(['lineHeight' => '8']);
+        $baseTextRun->addText('私');
+        $rubyTextRun = new TextRun(['lineHeight' => '4']);
+        $rubyTextRun->addText('わたし');
+        $section->addRuby($baseTextRun, $rubyTextRun, $properties);
+
+        $dom = Helper::getAsHTML($phpWord, '', '', ['ruby', 'rt', 'rp']);
+        $xpath = new DOMXPath($dom);
+        $nodeList = $xpath->query('/html/body/div/ruby');
+        /** @var Countable $nodeList */
+        self::assertEquals(1, $nodeList->count());
+        // ensure text is right
+        $rubyElement = $dom->getElementsByTagName('ruby')->item(0);
+        $rtElement = $dom->getElementsByTagName('rt')->item(0);
+        self::assertNotNull($rubyElement);
+        self::assertNotNull($rtElement);
+        self::assertEquals($baseTextRun->getText() . ' (' . $rubyTextRun->getText() . ')', $rubyElement->textContent);
+        self::assertEquals($rubyTextRun->getText(), $rtElement->textContent);
+        // check style
+        self::assertEquals('line-height: 8;font-size:20pt;ruby-align:center;', $rubyElement->attributes->getNamedItem('style')->textContent);
+        self::assertEquals('line-height: 4;font-size:10pt;', $rtElement->attributes->getNamedItem('style')->textContent);
+    }
+}

--- a/tests/PhpWordTests/Writer/HTML/Helper.php
+++ b/tests/PhpWordTests/Writer/HTML/Helper.php
@@ -20,6 +20,8 @@ namespace PhpOffice\PhpWordTests\Writer\HTML;
 
 use DOMDocument;
 use DOMXPath;
+use Exception;
+use LibXMLError;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Writer\HTML;
 
@@ -85,13 +87,41 @@ class Helper extends \PHPUnit\Framework\TestCase
         return $returnVal;
     }
 
-    public static function getAsHTML(PhpWord $phpWord, string $defaultWhiteSpace = '', string $defaultGenericFont = ''): DOMDocument
+    public static function getAsHTML(PhpWord $phpWord, string $defaultWhiteSpace = '', string $defaultGenericFont = '', array $validTags = []): DOMDocument
     {
         $htmlWriter = new HTML($phpWord);
         $htmlWriter->setDefaultWhiteSpace($defaultWhiteSpace);
         $htmlWriter->setDefaultGenericFont($defaultGenericFont);
         $dom = new DOMDocument();
+        // DOMDocument does not always accept HTML5 tags like <ruby>
+        // So, we can manually filter out those errors for testing purposes ONLY.
+        $original = libxml_use_internal_errors(true);
         $dom->loadHTML($htmlWriter->getContent());
+        $errors = libxml_get_errors();
+        $errorsToReport = [];
+        foreach ($errors as $error) {
+            /** @var LibXMLError $error */
+            if ($error->code === 801) {
+                $didFindValidTag = false;
+                foreach ($validTags as $tag) {
+                    if (trim($error->message) === ('Tag ' . $tag . ' invalid')) {
+                        $didFindValidTag = true;
+
+                        break;
+                    }
+                }
+                if (!$didFindValidTag) {
+                    $errorsToReport[] = $error;
+                }
+            } else {
+                $errorsToReport[] = $error;
+            }
+        }
+        libxml_clear_errors();
+        libxml_use_internal_errors($original);
+        if (count($errorsToReport) > 0) {
+            throw new Exception('Errors when loading DOMDocument: ' . print_r($errors, true));
+        }
 
         return $dom;
     }

--- a/tests/PhpWordTests/Writer/ODText/ElementTest.php
+++ b/tests/PhpWordTests/Writer/ODText/ElementTest.php
@@ -203,7 +203,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $section = $phpWord->addSection();
         $section->addTitle('Text Title', 1);
         $section->addText('Text following Text Title');
-        $textRun = new \PhpOffice\PhpWord\Element\TextRun();
+        $textRun = new TextRun();
         $textRun->addText('Text Run');
         $textRun->addText(' Title');
         $section->addTitle($textRun, 1);

--- a/tests/PhpWordTests/Writer/ODText/ElementTest.php
+++ b/tests/PhpWordTests/Writer/ODText/ElementTest.php
@@ -19,6 +19,8 @@
 namespace PhpOffice\PhpWordTests\Writer\ODText;
 
 use DateTime;
+use PhpOffice\PhpWord\ComplexType\RubyProperties;
+use PhpOffice\PhpWord\Element\TextRun;
 use PhpOffice\PhpWord\Element\TrackChange;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Shared\XMLWriter;
@@ -327,5 +329,37 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         self::AssertEquals($tc2id, $doc->getElementAttribute($element, 'text:change-id'));
         $element = "$p2t/text:change";
         self::AssertEquals($tc3id, $doc->getElementAttribute($element, 'text:change-id'));
+    }
+
+    /**
+     * Test ruby output.
+     * Note that this test will need to be updated when ODT Ruby output supports
+     * ODT's native ruby functionality.
+     */
+    public function testRubyText(): void
+    {
+        $esc = \PhpOffice\PhpWord\Settings::isOutputEscapingEnabled();
+        \PhpOffice\PhpWord\Settings::setOutputEscapingEnabled(true);
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $properties = new RubyProperties();
+        $properties->setAlignment(RubyProperties::ALIGNMENT_RIGHT_VERTICAL);
+        $properties->setFontFaceSize(10);
+        $properties->setFontPointsAboveBaseText(4);
+        $properties->setFontSizeForBaseText(18);
+        $properties->setLanguageId('ja-JP');
+
+        $baseTextRun = new TextRun(null);
+        $baseTextRun->addText('私');
+        $rubyTextRun = new TextRun(null);
+        $rubyTextRun->addText('わたし');
+        $section->addRuby($baseTextRun, $rubyTextRun, $properties);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        \PhpOffice\PhpWord\Settings::setOutputEscapingEnabled($esc);
+        $p2t = '/office:document-content/office:body/office:text/text:section';
+        $element = "$p2t/text:p[2]";
+        self::assertTrue($doc->elementExists($element));
+        self::assertEquals('私 (わたし)', $doc->getElement($element)->nodeValue);
     }
 }

--- a/tests/PhpWordTests/Writer/RTF/ElementTest.php
+++ b/tests/PhpWordTests/Writer/RTF/ElementTest.php
@@ -175,4 +175,45 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $expect = "\\pard\\nowidctlpar \\sb0\\sa0{\\outlinelevel0{\\cf0\\f0 First Heading}\\par\n}";
         self::assertEquals($expect, $this->removeCr($elwrite));
     }
+
+    public function testRuby(): void
+    {
+        $parentWriter = new RTF();
+        $properties = new \PhpOffice\PhpWord\ComplexType\RubyProperties();
+        $baseTextRun = new \PhpOffice\PhpWord\Element\TextRun(null);
+        $baseTextRun->addText('base text');
+        $rubyTextRun = new \PhpOffice\PhpWord\Element\TextRun(null);
+        $rubyTextRun->addText('ruby');
+        $element = new \PhpOffice\PhpWord\Element\TextRun();
+        $element->addRuby($baseTextRun, $rubyTextRun, $properties);
+
+        $textrun = new RTF\Element\TextRun($parentWriter, $element);
+        $expect = "\\pard\\nowidctlpar {{base text (ruby)}}\\par\n";
+        self::assertEquals($expect, $this->removeCr($textrun));
+    }
+
+    public function testRubyTitle(): void
+    {
+        $parentWriter = new RTF();
+        $properties = new \PhpOffice\PhpWord\ComplexType\RubyProperties();
+        $baseTextRun = new \PhpOffice\PhpWord\Element\TextRun(null);
+        $baseTextRun->addText('base text');
+        $rubyTextRun = new \PhpOffice\PhpWord\Element\TextRun(null);
+        $rubyTextRun->addText('ruby');
+        $textRun = new \PhpOffice\PhpWord\Element\TextRun();
+        $textRun->addRuby($baseTextRun, $rubyTextRun, $properties);
+
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord->addTitleStyle(
+            1,
+            ['size' => 24, 'bold' => true, 'color' => '000099'],
+            ['spaceBefore' => 0, 'spaceAfter' => 2]
+        );
+        $section = $phpWord->addSection();
+        $element = $section->addTitle($textRun, 1);
+        $elwrite = new RTF\Element\Title($parentWriter, $element);
+
+        $expect = "\\pard\\nowidctlpar \\sb0\\sa2{\\outlinelevel0{\\cf0\\f0\\fs48\\b base text (ruby)}\\par\n}";
+        self::assertEquals($expect, $this->removeCr($elwrite));
+    }
 }

--- a/tests/PhpWordTests/Writer/Word2007/ElementTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/ElementTest.php
@@ -564,23 +564,23 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr'));
         self::assertEquals(
             RubyProperties::ALIGNMENT_RIGHT_VERTICAL,
-            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:rubyAlign')->getAttribute('w:val')
+            $doc->getElementAttribute('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:rubyAlign', 'w:val')
         );
         self::assertEquals(
             10,
-            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hps')->getAttribute('w:val')
+            $doc->getElementAttribute('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hps', 'w:val')
         );
         self::assertEquals(
             4,
-            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hpsRaise')->getAttribute('w:val')
+            $doc->getElementAttribute('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hpsRaise', 'w:val')
         );
         self::assertEquals(
             18,
-            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hpsBaseText')->getAttribute('w:val')
+            $doc->getElementAttribute('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hpsBaseText', 'w:val')
         );
         self::assertEquals(
             'ja-JP',
-            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:lid')->getAttribute('w:val')
+            $doc->getElementAttribute('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:lid', 'w:val')
         );
         // check ruby text
         self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rt/w:r/w:t'));

--- a/tests/PhpWordTests/Writer/Word2007/ElementTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/ElementTest.php
@@ -21,6 +21,7 @@ namespace PhpOffice\PhpWordTests\Writer\Word2007;
 use DateTime;
 use PhpOffice\PhpWord\ComplexType\RubyProperties;
 use PhpOffice\PhpWord\Element\Comment;
+use PhpOffice\PhpWord\Element\Ruby;
 use PhpOffice\PhpWord\Element\TextRun;
 use PhpOffice\PhpWord\Element\TrackChange;
 use PhpOffice\PhpWord\PhpWord;
@@ -560,6 +561,75 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $doc = TestHelperDOCX::getDocument($phpWord);
         self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby'));
         // check props
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr'));
+        self::assertEquals(
+            RubyProperties::ALIGNMENT_RIGHT_VERTICAL,
+            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:rubyAlign')->getAttribute('w:val')
+        );
+        self::assertEquals(
+            10,
+            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hps')->getAttribute('w:val')
+        );
+        self::assertEquals(
+            4,
+            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hpsRaise')->getAttribute('w:val')
+        );
+        self::assertEquals(
+            18,
+            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hpsBaseText')->getAttribute('w:val')
+        );
+        self::assertEquals(
+            'ja-JP',
+            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:lid')->getAttribute('w:val')
+        );
+        // check ruby text
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rt/w:r/w:t'));
+        self::assertEquals(
+            'わたし',
+            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rt/w:r/w:t')->nodeValue
+        );
+        // check base text
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rubyBase/w:r/w:t'));
+        self::assertEquals(
+            '私',
+            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyBase/w:r/w:t')->nodeValue
+        );
+    }
+
+    /**
+     * Test Ruby title writing.
+     */
+    public function testRubyTitleWriting(): void
+    {
+        $phpWord = new PhpWord();
+        $phpWord->addTitleStyle(1, ['name' => 'Arial', 'size' => 24, 'bold' => true, 'color' => '990000']);
+
+        $section = $phpWord->addSection();
+        $properties = new RubyProperties();
+        $properties->setAlignment(RubyProperties::ALIGNMENT_RIGHT_VERTICAL);
+        $properties->setFontFaceSize(10);
+        $properties->setFontPointsAboveBaseText(4);
+        $properties->setFontSizeForBaseText(18);
+        $properties->setLanguageId('ja-JP');
+
+        $baseTextRun = new TextRun(null);
+        $baseTextRun->addText('私');
+        $rubyTextRun = new TextRun(null);
+        $rubyTextRun->addText('わたし');
+
+        $textRun = new TextRun();
+        $textRun->addRuby($baseTextRun, $rubyTextRun, $properties);
+        $section->addTitle($textRun, 1);
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+        // make sure style made it in
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:pPr/w:pStyle'));
+        self::assertEquals(
+            'Heading1',
+            $doc->getElement('/w:document/w:body/w:p/w:pPr/w:pStyle')->getAttribute('w:val')
+        );
+        // check ruby props
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby'));
         self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr'));
         self::assertEquals(
             RubyProperties::ALIGNMENT_RIGHT_VERTICAL,

--- a/tests/PhpWordTests/Writer/Word2007/ElementTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/ElementTest.php
@@ -562,29 +562,35 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         // check props
         self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr'));
         self::assertEquals(
-            RubyProperties::ALIGNMENT_RIGHT_VERTICAL, 
+            RubyProperties::ALIGNMENT_RIGHT_VERTICAL,
             $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:rubyAlign')->getAttribute('w:val')
         );
-        self::assertEquals(10, 
+        self::assertEquals(
+            10,
             $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hps')->getAttribute('w:val')
         );
-        self::assertEquals(4, 
+        self::assertEquals(
+            4,
             $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hpsRaise')->getAttribute('w:val')
         );
-        self::assertEquals(18, 
+        self::assertEquals(
+            18,
             $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hpsBaseText')->getAttribute('w:val')
         );
-        self::assertEquals('ja-JP', 
+        self::assertEquals(
+            'ja-JP',
             $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:lid')->getAttribute('w:val')
         );
         // check ruby text
         self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rt/w:r/w:t'));
-        self::assertEquals('わたし', 
+        self::assertEquals(
+            'わたし',
             $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rt/w:r/w:t')->nodeValue
         );
         // check base text
         self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rubyBase/w:r/w:t'));
-        self::assertEquals('私', 
+        self::assertEquals(
+            '私',
             $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyBase/w:r/w:t')->nodeValue
         );
     }

--- a/tests/PhpWordTests/Writer/Word2007/ElementTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/ElementTest.php
@@ -19,6 +19,7 @@
 namespace PhpOffice\PhpWordTests\Writer\Word2007;
 
 use DateTime;
+use PhpOffice\PhpWord\ComplexType\RubyProperties;
 use PhpOffice\PhpWord\Element\Comment;
 use PhpOffice\PhpWord\Element\TextRun;
 use PhpOffice\PhpWord\Element\TrackChange;
@@ -533,5 +534,58 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         self::assertEquals('List item', $doc->getElement('/w:document/w:body/w:p/w:r[1]/w:t')->nodeValue);
         self::assertEquals(' in bold', $doc->getElement('/w:document/w:body/w:p/w:r[2]/w:t')->nodeValue);
         self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r[2]/w:rPr/w:b'));
+    }
+
+    /**
+     * Test Ruby writing.
+     */
+    public function testRubyWriting(): void
+    {
+        $phpWord = new PhpWord();
+
+        $section = $phpWord->addSection();
+        $properties = new RubyProperties();
+        $properties->setAlignment(RubyProperties::ALIGNMENT_RIGHT_VERTICAL);
+        $properties->setFontFaceSize(10);
+        $properties->setFontPointsAboveBaseText(4);
+        $properties->setFontSizeForBaseText(18);
+        $properties->setLanguageId('ja-JP');
+
+        $baseTextRun = new TextRun(null);
+        $baseTextRun->addText('私');
+        $rubyTextRun = new TextRun(null);
+        $rubyTextRun->addText('わたし');
+        $section->addRuby($baseTextRun, $rubyTextRun, $properties);
+
+        $doc = TestHelperDOCX::getDocument($phpWord);
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby'));
+        // check props
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr'));
+        self::assertEquals(
+            RubyProperties::ALIGNMENT_RIGHT_VERTICAL, 
+            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:rubyAlign')->getAttribute('w:val')
+        );
+        self::assertEquals(10, 
+            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hps')->getAttribute('w:val')
+        );
+        self::assertEquals(4, 
+            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hpsRaise')->getAttribute('w:val')
+        );
+        self::assertEquals(18, 
+            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:hpsBaseText')->getAttribute('w:val')
+        );
+        self::assertEquals('ja-JP', 
+            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyPr/w:lid')->getAttribute('w:val')
+        );
+        // check ruby text
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rt/w:r/w:t'));
+        self::assertEquals('わたし', 
+            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rt/w:r/w:t')->nodeValue
+        );
+        // check base text
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:ruby/w:rubyBase/w:r/w:t'));
+        self::assertEquals('私', 
+            $doc->getElement('/w:document/w:body/w:p/w:r/w:ruby/w:rubyBase/w:r/w:t')->nodeValue
+        );
     }
 }


### PR DESCRIPTION
### Description

Right now, PHPWord does not support ruby text elements (phonetic guides) at all. You can see some documentation (of a sort) on this type of element here: https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.ruby?view=openxml-3.0.1 and some how-to-use [here](https://support.microsoft.com/en-us/office/add-phonetic-guides-to-east-asian-text-c03ad8e4-799b-499e-89a2-c749fc5397e8)

A ruby (phonetic guide) element allows you to do things like this:

<img width="557" alt="Screenshot 2025-01-23 at 8 30 35 PM" src="https://github.com/user-attachments/assets/71b737eb-274d-4c30-9200-4cf96a737ceb" />

This PR adds both reading and writing support for ruby elements to `Word2007` files. Basic text support has been checked along with Titles. Other elements may or may not be supported at this time (in other words, I didn't test literally every element with ruby); as long as the code eventually gets into `readRunChild`, the ruby should be read properly.

Please note: This is my first contribution to this repository. I may have missed something when trying to match current style guidelines, etc. Please correct me and point me in the right direction if needed. Thank you!

(Update: This PR now supports reading/writing HTML as well as writing support for RTF and basic writing support for ODT.)

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)
