### PR TITLE
Writer HTML: Support Default font color

### DIFF
--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -11,7 +11,8 @@
 - Writer Word2007: Support for padding in Table Cell by [@Azamat8405](https://github.com/Azamat8405) in [#2697](https://github.com/PHPOffice/PHPWord/pull/2697)
 - Added support for PHP 8.4 by [@Progi1984](https://github.com/Progi1984) in [#2660](https://github.com/PHPOffice/PHPWord/pull/2660)
 - Autoload : Allow to use PHPWord without Composer fixing [#2543](https://github.com/PHPOffice/PHPWord/issues/2543), [#2552](https://github.com/PHPOffice/PHPWord/issues/2552), [#2716](https://github.com/PHPOffice/PHPWord/issues/2716), [#2717](https://github.com/PHPOffice/PHPWord/issues/2717) in [#2722](https://github.com/PHPOffice/PHPWord/pull/2722)
-- Add Default font color for Word by [@Collie-IT](https://github.com/Collie-IT) in [#2700](https://github.com/PHPOffice/PHPWord/pull/2700)
+- Writer Word2007: Support Default font color by [@Collie-IT](https://github.com/Collie-IT) in [#2700](https://github.com/PHPOffice/PHPWord/pull/2700)
+- Writer HTML: Support Default font color by [@MichaelPFrey](https://github.com/MichaelPFrey)
 
 ### Bug fixes
 

--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -11,7 +11,7 @@
 - Writer Word2007: Support for padding in Table Cell by [@Azamat8405](https://github.com/Azamat8405) in [#2697](https://github.com/PHPOffice/PHPWord/pull/2697)
 - Added support for PHP 8.4 by [@Progi1984](https://github.com/Progi1984) in [#2660](https://github.com/PHPOffice/PHPWord/pull/2660)
 - Autoload : Allow to use PHPWord without Composer fixing [#2543](https://github.com/PHPOffice/PHPWord/issues/2543), [#2552](https://github.com/PHPOffice/PHPWord/issues/2552), [#2716](https://github.com/PHPOffice/PHPWord/issues/2716), [#2717](https://github.com/PHPOffice/PHPWord/issues/2717) in [#2722](https://github.com/PHPOffice/PHPWord/pull/2722)
-- Writer Word2007: Support Default font color by [@Collie-IT](https://github.com/Collie-IT) in [#2700](https://github.com/PHPOffice/PHPWord/pull/2700)
+- Add Default font color for Word by [@Collie-IT](https://github.com/Collie-IT) in [#2700](https://github.com/PHPOffice/PHPWord/pull/2700)
 - Writer HTML: Support Default font color by [@MichaelPFrey](https://github.com/MichaelPFrey)
 
 ### Bug fixes

--- a/src/PhpWord/Writer/HTML/Part/Body.php
+++ b/src/PhpWord/Writer/HTML/Part/Body.php
@@ -23,7 +23,7 @@ use PhpOffice\PhpWord\Writer\HTML\Element\TextRun as TextRunWriter;
 use PhpOffice\PhpWord\Writer\PDF\TCPDF;
 
 /**
- * RTF body part writer.
+ * HTML body part writer.
  *
  * @since 0.11.0
  */

--- a/src/PhpWord/Writer/HTML/Part/Head.php
+++ b/src/PhpWord/Writer/HTML/Part/Head.php
@@ -30,7 +30,7 @@ use PhpOffice\PhpWord\Writer\HTML\Style\Paragraph as ParagraphStyleWriter;
 use PhpOffice\PhpWord\Writer\HTML\Style\Table as TableStyleWriter;
 
 /**
- * RTF head part writer.
+ * HTML head part writer.
  *
  * @since 0.11.0
  */
@@ -85,11 +85,12 @@ class Head extends AbstractPart
     private function writeStyles(): string
     {
         $css = '<style>' . PHP_EOL;
-
+        $defaultFontColor = Settings::getDefaultFontColor();
         // Default styles
         $astarray = [
             'font-family' => $this->getFontFamily(Settings::getDefaultFontName(), $this->getParentWriter()->getDefaultGenericFont()),
             'font-size' => Settings::getDefaultFontSize() . 'pt',
+            'color' => "#{$defaultFontColor}",
         ];
         // Mpdf sometimes needs separate tag for body; doesn't harm others.
         $bodyarray = $astarray;

--- a/tests/PhpWordTests/Writer/HTML/FontTest.php
+++ b/tests/PhpWordTests/Writer/HTML/FontTest.php
@@ -57,6 +57,37 @@ class FontTest extends \PHPUnit\Framework\TestCase
         Settings::setDefaultFontColor($this->defaultFontColor);
     }
 
+    public function testDefaultDefaults(): void
+    {
+        $phpWord = new PhpWord();
+
+        $dom = Helper::getAsHTML($phpWord);
+        $xpath = new DOMXPath($dom);
+        $style = Helper::getTextContent($xpath, '/html/head/style[1]');
+
+        $prg = preg_match('/body {(.*?)}/', $style, $matches);
+        self::assertNotEmpty($matches);
+        self::assertNotFalse($prg);
+        self::assertEquals('body {font-family: \'Arial\'; font-size: 12pt; color: #000000;}', $matches[0]);
+    }
+
+    public function testSettingDefaultFontColor(): void
+    {
+        $phpWord = new PhpWord();
+
+        $defaultFontColor = '00FF00';
+        $phpWord->setDefaultFontColor($defaultFontColor);
+
+        $dom = Helper::getAsHTML($phpWord);
+        $xpath = new DOMXPath($dom);
+        $style = Helper::getTextContent($xpath, '/html/head/style[1]');
+
+        $prg = preg_match('/body {(.*?)}/', $style, $matches);
+        self::assertNotEmpty($matches);
+        self::assertNotFalse($prg);
+        self::assertEquals('body {font-family: \'Arial\'; font-size: 12pt; color: #00FF00;}', $matches[0]);
+    }
+
     /**
      * Tests font names - without generics.
      */
@@ -93,7 +124,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
         $prg = preg_match('/^[*][^\\r\\n]*/m', $style, $matches);
         self::assertNotEmpty($matches);
         self::assertNotFalse($prg);
-        self::assertEquals('* {font-family: \'Courier New\'; font-size: 12pt;}', $matches[0]);
+        self::assertEquals('* {font-family: \'Courier New\'; font-size: 12pt; color: #000000;}', $matches[0]);
         $prg = preg_match('/^[.]style1[^\\r\\n]*/m', $style, $matches);
         self::assertNotEmpty($matches);
         self::assertNotFalse($prg);
@@ -149,7 +180,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
         $prg = preg_match('/^[*][^\\r\\n]*/m', $style, $matches);
         self::assertNotEmpty($matches);
         self::assertNotFalse($prg);
-        self::assertEquals('* {font-family: \'Courier New\'; font-size: 12pt;}', $matches[0]);
+        self::assertEquals('* {font-family: \'Courier New\'; font-size: 12pt; color: #000000;}', $matches[0]);
         $prg = preg_match('/^[.]style1[^\\r\\n]*/m', $style, $matches);
         self::assertNotEmpty($matches);
         self::assertNotFalse($prg);
@@ -201,7 +232,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
         $prg = preg_match('/^[*][^\\r\\n]*/m', $style, $matches);
         self::assertNotEmpty($matches);
         self::assertNotFalse($prg);
-        self::assertEquals('* {font-family: \'Courier New\', monospace; font-size: 12pt;}', $matches[0]);
+        self::assertEquals('* {font-family: \'Courier New\', monospace; font-size: 12pt; color: #000000;}', $matches[0]);
         $prg = preg_match('/^[.]style1[^\\r\\n]*/m', $style, $matches);
         self::assertNotEmpty($matches);
         self::assertNotFalse($prg);
@@ -244,7 +275,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
 
         $style = Helper::getTextContent($xpath, '/html/head/style');
         self::assertNotFalse(preg_match('/^[*][^\\r\\n]*/m', $style, $matches));
-        self::assertEquals('* {font-family: \'Arial\'; font-size: 12pt; white-space: pre-wrap;}', $matches[0]);
+        self::assertEquals('* {font-family: \'Arial\'; font-size: 12pt; color: #000000; white-space: pre-wrap;}', $matches[0]);
         $prg = preg_match('/^[.]style1[^\\r\\n]*/m', $style, $matches);
         self::assertNotEmpty($matches);
         self::assertNotFalse($prg);


### PR DESCRIPTION
### Description

add Support for Default font color in Writer HTML. This expands upon #2700

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)
