### PR TITLE
Writer ODText: Support Default font color

### DIFF
--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -12,8 +12,8 @@
 - Added support for PHP 8.4 by [@Progi1984](https://github.com/Progi1984) in [#2660](https://github.com/PHPOffice/PHPWord/pull/2660)
 - Autoload : Allow to use PHPWord without Composer fixing [#2543](https://github.com/PHPOffice/PHPWord/issues/2543), [#2552](https://github.com/PHPOffice/PHPWord/issues/2552), [#2716](https://github.com/PHPOffice/PHPWord/issues/2716), [#2717](https://github.com/PHPOffice/PHPWord/issues/2717) in [#2722](https://github.com/PHPOffice/PHPWord/pull/2722)
 - Add Default font color for Word by [@Collie-IT](https://github.com/Collie-IT) in [#2700](https://github.com/PHPOffice/PHPWord/pull/2700)
-- Writer HTML: Support Default font color by [@MichaelPFrey](https://github.com/MichaelPFrey) in [#2773](https://github.com/PHPOffice/PHPWord/pull/2773)
-- Writer ODText: Support Default font color by [@MichaelPFrey](https://github.com/MichaelPFrey)
+- Writer HTML: Support Default font color by [@MichaelPFrey](https://github.com/MichaelPFrey) in [#2731](https://github.com/PHPOffice/PHPWord/pull/2731)
+- Writer ODText: Support Default font color by [@MichaelPFrey](https://github.com/MichaelPFrey) in [#2735](https://github.com/PHPOffice/PHPWord/pull/2735)
 - Add basic ruby text (phonetic guide) support for Word2007 and HTML Reader/Writer, RTF Writer, basic support for ODT writing by [@Deadpikle](https://github.com/Deadpikle) in [#2727](https://github.com/PHPOffice/PHPWord/pull/2727)
 
 ### Bug fixes
@@ -37,8 +37,8 @@
 
 ### BC Breaks
 
-### Note
-- Writer ODText previously used to set 'style:use-window-font-color' to 'true', now it is set to 'false'.
+### Notes
+- Writer ODText previously used to set 'style:use-window-font-color' to 'true', now it is set to 'false'. (see [#2735](https://github.com/PHPOffice/PHPWord/pull/2735))
   The effect of this attribute is "implementation dependent" (if implemented at all).
   Setting it to false allows setting a default font color and improves interoperabilt,
   but may break certain specific use cases.

--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -12,7 +12,8 @@
 - Added support for PHP 8.4 by [@Progi1984](https://github.com/Progi1984) in [#2660](https://github.com/PHPOffice/PHPWord/pull/2660)
 - Autoload : Allow to use PHPWord without Composer fixing [#2543](https://github.com/PHPOffice/PHPWord/issues/2543), [#2552](https://github.com/PHPOffice/PHPWord/issues/2552), [#2716](https://github.com/PHPOffice/PHPWord/issues/2716), [#2717](https://github.com/PHPOffice/PHPWord/issues/2717) in [#2722](https://github.com/PHPOffice/PHPWord/pull/2722)
 - Add Default font color for Word by [@Collie-IT](https://github.com/Collie-IT) in [#2700](https://github.com/PHPOffice/PHPWord/pull/2700)
-- Writer HTML: Support Default font color by [@MichaelPFrey](https://github.com/MichaelPFrey)
+- Writer HTML: Support Default font color by [@MichaelPFrey](https://github.com/MichaelPFrey) in [#2773](https://github.com/PHPOffice/PHPWord/pull/2773)
+- Writer ODText: Support Default font color by [@MichaelPFrey](https://github.com/MichaelPFrey)
 - Add basic ruby text (phonetic guide) support for Word2007 and HTML Reader/Writer, RTF Writer, basic support for ODT writing by [@Deadpikle](https://github.com/Deadpikle) in [#2727](https://github.com/PHPOffice/PHPWord/pull/2727)
 
 ### Bug fixes
@@ -35,3 +36,9 @@
 - Deprecate `PhpOffice\PhpWord\Style\Paragraph::setIndent()` : Use `PhpOffice\PhpWord\Style\Paragraph::setIndentLeft()`
 
 ### BC Breaks
+
+### Note
+- Writer ODText previously used to set 'style:use-window-font-color' to 'true', now it is set to 'false'.
+  The effect of this attribute is "implementation dependent" (if implemented at all).
+  Setting it to false allows setting a default font color and improves interoperabilt,
+  but may break certain specific use cases.

--- a/src/PhpWord/Writer/ODText/Part/Styles.php
+++ b/src/PhpWord/Writer/ODText/Part/Styles.php
@@ -92,11 +92,12 @@ class Styles extends AbstractPart
 
         // Font
         $xmlWriter->startElement('style:text-properties');
-        $xmlWriter->writeAttribute('style:use-window-font-color', 'true');
+        $xmlWriter->writeAttribute('style:use-window-font-color', 'false');
         $xmlWriter->writeAttribute('style:font-name', Settings::getDefaultFontName());
         $xmlWriter->writeAttribute('fo:font-size', Settings::getDefaultFontSize() . 'pt');
         $xmlWriter->writeAttribute('fo:language', $latinLang[0]);
         $xmlWriter->writeAttribute('fo:country', $latinLang[1]);
+        $xmlWriter->writeAttribute('fo:color', '#' . Settings::getDefaultFontColor());
         $xmlWriter->writeAttribute('style:letter-kerning', 'true');
         $xmlWriter->writeAttribute('style:font-name-asian', Settings::getDefaultFontName() . '2');
         $xmlWriter->writeAttribute('style:font-size-asian', Settings::getDefaultFontSize() . 'pt');

--- a/tests/PhpWordTests/Writer/ODText/Style/FontTest.php
+++ b/tests/PhpWordTests/Writer/ODText/Style/FontTest.php
@@ -34,6 +34,45 @@ class FontTest extends \PHPUnit\Framework\TestCase
         TestHelperDOCX::clear();
     }
 
+    public function testDefaultDefaults(): void
+    {
+        //$doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+
+        //$phpWord->setDefaultFontColor($defaultFontColor);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+
+        $file = 'styles.xml';
+
+        $path = '/office:document-styles/office:styles/style:default-style/style:text-properties';
+        self::assertTrue($doc->elementExists($path, $file));
+        $element = $doc->getElement($path, $file);
+
+        self::assertEquals('#000000', $element->getAttribute('fo:color'));
+    }
+
+    public function testSettingDefaults(): void
+    {
+        //$doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+
+        $defaultFontColor = '00FF00';
+        $phpWord->setDefaultFontColor($defaultFontColor);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+
+        $file = 'styles.xml';
+
+        $path = '/office:document-styles/office:styles/style:default-style/style:text-properties';
+        self::assertTrue($doc->elementExists($path, $file));
+        $element = $doc->getElement($path, $file);
+
+        self::assertEquals('#' . $defaultFontColor, $element->getAttribute('fo:color'));
+    }
+
     /**
      * Test colors.
      */

--- a/tests/PhpWordTests/Writer/ODText/Style/FontTest.php
+++ b/tests/PhpWordTests/Writer/ODText/Style/FontTest.php
@@ -47,6 +47,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
         $element = $doc->getElement($path, $file);
 
         self::assertEquals('#000000', $element->getAttribute('fo:color'));
+        self::assertEquals('false', $element->getAttribute('style:use-window-font-color')); //has to be set to false so that fo:color can take effect
     }
 
     public function testSettingDefaults(): void

--- a/tests/PhpWordTests/Writer/ODText/Style/FontTest.php
+++ b/tests/PhpWordTests/Writer/ODText/Style/FontTest.php
@@ -36,11 +36,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
 
     public function testDefaultDefaults(): void
     {
-        //$doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
-
         $phpWord = new \PhpOffice\PhpWord\PhpWord();
-
-        //$phpWord->setDefaultFontColor($defaultFontColor);
 
         $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
 
@@ -55,8 +51,6 @@ class FontTest extends \PHPUnit\Framework\TestCase
 
     public function testSettingDefaults(): void
     {
-        //$doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
-
         $phpWord = new \PhpOffice\PhpWord\PhpWord();
 
         $defaultFontColor = '00FF00';


### PR DESCRIPTION
### Description

Writer ODText: Support Default font color. This is continuation of #2731 #2700

Fixes # (issue)

#### style:use-window-font-color
Setting a default font-color is only possible, when` style:use-window-font-color` is either not set or set to false.

To see the effect of  style:use-window-font-color, see the attachments of [kde/kword bug 231659](https://bugs.kde.org/show_bug.cgi?id=231659).

The definition of this attribute can be found in the [OpenDocument Standard](https://docs.oasis-open.org/office/OpenDocument/v1.4/csd01/part3-schema/OpenDocument-v1.4-csd01-part3-schema.html#__RefHeading__1420234_253892949), where the most relevant phrase for this discussion are:

> The determination of light or dark color is implementation-defined.
> 
> ...
> 
> false: the foreground color is specified by the fo:color attribute.  

kword did not support this attribute  [kde/kword bug 231659](https://bugs.kde.org/show_bug.cgi?id=231659)

> [Status](https://bugs.kde.org/page.cgi?id=fields.html#bug_status): 	RESOLVED UNMAINTAINED
>
> The "KOffice" application suite is no longer maintained, and all tickets are now closed.

The support in Microsoft office can be described as ["partial"](https://learn.microsoft.com/en-us/search/?terms=style%3Ause-window-font-color) for  [example:](https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oodf/dd93d359-6500-4718-8e83-906128b957d3)

> 2.1.632 Section 15.4.4, Window Font Color
> This attribute is supported in core Word 2007.
> This attribute is not supported on save for text in SmartArt and chart titles and labels.
> This attribute is not supported in core Excel 2007.

 Properly implementing `use-window-font-color` would be a task separate from allowing setting a default font color. 

Setting `use-window-font-color` in ODText, but not Word is inconsistent.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)
