### PR TITLE
Writer HTML: Fixed null string for Text Elements

### DIFF
--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -16,8 +16,7 @@
 - Writer ODText: Support Default font color by [@MichaelPFrey](https://github.com/MichaelPFrey) in [#2735](https://github.com/PHPOffice/PHPWord/pull/2735)
 - Add basic ruby text (phonetic guide) support for Word2007 and HTML Reader/Writer, RTF Writer, basic support for ODT writing by [@Deadpikle](https://github.com/Deadpikle) in [#2727](https://github.com/PHPOffice/PHPWord/pull/2727)
 - Reader HTML: Support font styles for h1/h6 by [@Progi1984](https://github.com/Progi1984) fixing [#2619](https://github.com/PHPOffice/PHPWord/issues/2619) in [#2737](https://github.com/PHPOffice/PHPWord/pull/2737)
-
-- Added Support for Writer Epub3 by [@Sambit003](https://github.com/Sambit003) in [#2724](https://github.com/PHPOffice/PHPWord/pull/2724)
+- Writer EPub3: Basic support by [@Sambit003](https://github.com/Sambit003) fixing [#55](https://github.com/PHPOffice/PHPWord/issues/55) in [#2724](https://github.com/PHPOffice/PHPWord/pull/2724)
   
 ### Bug fixes
 
@@ -27,6 +26,7 @@
 - Reader Word2007: Respect paragraph indent units by [@tugmaks](https://github.com/tugmaks) & [@Progi1984](https://github.com/Progi1984) fixing [#507](https://github.com/PHPOffice/PHPWord/issues/507) in [#2726](https://github.com/PHPOffice/PHPWord/pull/2726)
 - Reader Word2007: Support Header elements within Title elements by [@SpraxDev](https://github.com/SpraxDev) fixing [#2616](https://github.com/PHPOffice/PHPWord/issues/2616), [#2426](https://github.com/PHPOffice/PHPWord/issues/2426) in [#2674](https://github.com/PHPOffice/PHPWord/pull/2674)
 - Reader HTML: Support for inherit value for property line-height by [@Progi1984](https://github.com/Progi1984) fixing [#2683](https://github.com/PHPOffice/PHPWord/issues/2683) in [#2733](https://github.com/PHPOffice/PHPWord/pull/2733)
+- Writer HTML: Fixed null string for Text Elements by [@armagedon007](https://github.com/armagedon007) and [@Progi1984](https://github.com/Progi1984) in [#2738](https://github.com/PHPOffice/PHPWord/pull/2738)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Element/Link.php
+++ b/src/PhpWord/Element/Link.php
@@ -99,10 +99,8 @@ class Link extends AbstractElement
 
     /**
      * Get link text.
-     *
-     * @return string
      */
-    public function getText()
+    public function getText(): string
     {
         return $this->text;
     }

--- a/src/PhpWord/Element/Text.php
+++ b/src/PhpWord/Element/Text.php
@@ -147,10 +147,8 @@ class Text extends AbstractElement
 
     /**
      * Get Text content.
-     *
-     * @return ?string
      */
-    public function getText()
+    public function getText(): ?string
     {
         return $this->text;
     }

--- a/src/PhpWord/Writer/HTML/Element/Text.php
+++ b/src/PhpWord/Writer/HTML/Element/Text.php
@@ -73,7 +73,7 @@ class Text extends AbstractElement
         /** @var \PhpOffice\PhpWord\Element\Text $element Type hint */
         $element = $this->element;
 
-        $text = $this->parentWriter->escapeHTML($element->getText());
+        $text = $this->parentWriter->escapeHTML($element->getText() ?? '');
         if (!$this->withoutP && !trim($text)) {
             $text = '&nbsp;';
         }

--- a/tests/PhpWordTests/Writer/HTML/Element/TextTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/TextTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWordTests\Writer\HTML\Element;
+
+use PhpOffice\PhpWord\Element\Text as BaseText;
+use PhpOffice\PhpWord\Writer\HTML;
+use PhpOffice\PhpWord\Writer\HTML\Element\Text;
+use PHPUnit\Framework\TestCase;
+
+class TextTest extends TestCase
+{
+    public function testHTMLNullString(): void
+    {
+        $writer = new HTML();
+        $object = new Text($writer, new BaseText());
+
+        self::assertEquals('<p>&nbsp;</p>' . PHP_EOL, $object->write());
+    }
+
+    public function testHTMLEmptyString(): void
+    {
+        $writer = new HTML();
+        $object = new Text($writer, new BaseText(''));
+
+        self::assertEquals('<p>&nbsp;</p>' . PHP_EOL, $object->write());
+    }
+}


### PR DESCRIPTION
### Description

Superseeded by #2629 by @armagedon007 

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)
