### PR TITLE
test the reader with the writer

### DIFF
--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -35,6 +35,7 @@
 - Bump dompdf/dompdf from 2.0.4 to 3.0.0 by [@dependabot](https://github.com/dependabot) fixing [#2621](https://github.com/PHPOffice/PHPWord/issues/2621) in [#2666](https://github.com/PHPOffice/PHPWord/pull/2666)
 - Add test case to make sure vMerge defaults to 'continue' by [@SpraxDev](https://github.com/SpraxDev) in [#2677](https://github.com/PHPOffice/PHPWord/pull/2677)
 - Adding the possibility to use iterate search and replace with setValues by [@moghwan](https://github.com/moghwan) in [#2632](https://github.com/PHPOffice/PHPWord/pull/2640)
+- Add test cases that test the ODTText and Word2007 reader using the corresponding writer, increasing test coverage by [@MichaelPFrey](https://github.com/MichaelPFrey) in [#2745](https://github.com/PHPOffice/PHPWord/pull/2745)
 
 ### Deprecations
 - Deprecate `PhpOffice\PhpWord\Style\Paragraph::getIndent()` : Use `PhpOffice\PhpWord\Style\Paragraph::getIndentLeft()`

--- a/tests/PhpWordTests/WriteReadback/ODTextTest.php
+++ b/tests/PhpWordTests/WriteReadback/ODTextTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWordTests\WriteReadback;
+
+use PhpOffice\PhpWord\Element\TextRun;
+use PhpOffice\PhpWord\IOFactory;
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Writer\ODText;
+
+/**
+ * Test class for PhpOffice\PhpWord\Reader\ODText and PhpOffice\PhpWord\Writer\ODText.
+ *
+ * @coversDefaultClass \PhpOffice\PhpWord\Reader\ODText
+ *
+ * @runTestsInSeparateProcesses
+ */
+class ODTextTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test a document with one section and text.
+     */
+    public function testOneSectionWithText(): void
+    {
+        $phpWordWriter = new PhpWord();
+        $testText = 'Hello World!';
+        $sectionWriter = $phpWordWriter->addSection();
+        $sectionWriter->addText($testText);
+
+        $writer = new ODText($phpWordWriter);
+        $file = __DIR__ . '/../_files/temp.odt';
+        $writer->save($file);
+
+        self::assertFileExists($file);
+
+        $phpWordReader = IOFactory::load($file, 'ODText');
+
+        self::assertCount(1, $phpWordReader->getSections());
+        self::assertCount(1, $phpWordReader->getSections()[0]->getElements());
+        self::assertInstanceOf(TextRun::class, $phpWordReader->getSections()[0]->getElements()[0]);
+        self::assertEquals($testText, $phpWordReader->getSections()[0]->getElements()[0]->getText());
+        unlink($file);
+    }
+}

--- a/tests/PhpWordTests/WriteReadback/Word2007Test.php
+++ b/tests/PhpWordTests/WriteReadback/Word2007Test.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWordTests\WriteReadback;
+
+use PhpOffice\PhpWord\Element\TextRun;
+use PhpOffice\PhpWord\IOFactory;
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Style\Font;
+use PhpOffice\PhpWord\Writer\Word2007;
+
+/**
+ * Test class for PhpOffice\PhpWord\Reader\Word2007 and PhpOffice\PhpWord\Writer\Word2007.
+ *
+ * @coversDefaultClass \PhpOffice\PhpWord\Reader\Word2007
+ *
+ * @runTestsInSeparateProcesses
+ */
+class Word2007Test extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test default font name.
+     */
+    public function testDefaultFontName(): void
+    {
+        $phpWordWriter = new PhpWord();
+        $testDefaultFontName = 'Times New Roman';
+        $phpWordWriter->setDefaultFontName($testDefaultFontName);
+
+        $writer = new Word2007($phpWordWriter);
+        $file = __DIR__ . '/../_files/temp.docx';
+        $writer->save($file);
+
+        self::assertFileExists($file);
+
+        $phpWordReader = IOFactory::load($file, 'Word2007');
+
+        self::assertEquals($testDefaultFontName, $phpWordReader->getDefaultFontName());
+
+        unlink($file);
+    }
+
+    /**
+     * Test default Asian font name.
+     */
+    public function testDefaultAsianFontName(): void
+    {
+        $phpWordWriter = new PhpWord();
+        $testDefaultFontName = '標楷體';
+        $phpWordWriter->setDefaultAsianFontName($testDefaultFontName);
+
+        $writer = new Word2007($phpWordWriter);
+        $file = __DIR__ . '/../_files/temp.docx';
+        $writer->save($file);
+
+        self::assertFileExists($file);
+
+        $phpWordReader = IOFactory::load($file, 'Word2007');
+
+        self::assertEquals($testDefaultFontName, $phpWordReader->getDefaultAsianFontName());
+
+        unlink($file);
+    }
+
+    /**
+     * Test default font size.
+     */
+    public function testDefaulFontSize(): void
+    {
+        $phpWordWriter = new PhpWord();
+        $testDefaultFontSize = 144;
+        $phpWordWriter->setDefaultFontSize($testDefaultFontSize);
+
+        $writer = new Word2007($phpWordWriter);
+        $file = __DIR__ . '/../_files/temp.docx';
+        $writer->save($file);
+
+        self::assertFileExists($file);
+
+        $phpWordReader = IOFactory::load($file, 'Word2007');
+
+        self::assertEquals($testDefaultFontSize, $phpWordReader->getDefaultFontSize());
+
+        unlink($file);
+    }
+
+    /**
+     * Test default font color.
+     */
+    public function testDefaultFontColor(): void
+    {
+        $phpWordWriter = new PhpWord();
+        $testDefaultFontColor = '00FF00';
+        $phpWordWriter->setDefaultFontColor($testDefaultFontColor);
+
+        $writer = new Word2007($phpWordWriter);
+        $file = __DIR__ . '/../_files/temp.docx';
+        $writer->save($file);
+
+        self::assertFileExists($file);
+
+        $phpWordReader = IOFactory::load($file, 'Word2007');
+
+        self::assertEquals($testDefaultFontColor, $phpWordReader->getDefaultFontColor());
+
+        unlink($file);
+    }
+
+    /**
+     * Test Zoom.
+     */
+    public function testZoom(): void
+    {
+        $phpWordWriter = new PhpWord();
+        $zoomLevel = 75;
+        $phpWordWriter->getSettings()->setZoom($zoomLevel);
+
+        $writer = new Word2007($phpWordWriter);
+        $file = __DIR__ . '/../_files/temp.docx';
+        $writer->save($file);
+
+        self::assertFileExists($file);
+
+        $phpWordReader = IOFactory::load($file, 'Word2007');
+
+        self::assertEquals($zoomLevel, $phpWordReader->getSettings()->getZoom());
+
+        unlink($file);
+    }
+
+    /**
+     * Test a document with one section and text.
+     */
+    public function testOneSectionWithText(): void
+    {
+        $phpWordWriter = new PhpWord();
+        $testText = 'Hello World!';
+        $sectionWriter = $phpWordWriter->addSection();
+        $sectionWriter->addText($testText);
+
+        $writer = new Word2007($phpWordWriter);
+        $file = __DIR__ . '/../_files/temp.docx';
+        $writer->save($file);
+
+        self::assertFileExists($file);
+
+        $phpWordReader = IOFactory::load($file, 'Word2007');
+
+        self::assertCount(1, $phpWordReader->getSections());
+        self::assertCount(1, $phpWordReader->getSections()[0]->getElements());
+        self::assertInstanceOf(TextRun::class, $phpWordReader->getSections()[0]->getElements()[0]);
+        self::assertEquals($testText, $phpWordReader->getSections()[0]->getElements()[0]->getText());
+        unlink($file);
+    }
+}


### PR DESCRIPTION
### Description

I think that currently, there are only few good tests for the reader. (see for e.g. #2700 where the reader and writer where modified, but only the writer is actually covered by a test)

Creating and adding artifacts (docx and odt) is not ideal, as they are hard to verify and will contain random other artifacts.

By dynamically creating the test-file using the writer and reading it back in with the reader, we can simply test the reader against the writer.

In general, a WYSWYG word processor is assumed to read and save files without loosing anything. For a project like PHPOffice, the focus is stronger on the writer then the reader. With this setup, it is a lot easier to work on the reader, as a test driven development purely in PHP gets enabled - the need to use a word processor for verification gets significantly reduced.

There is also simply charm in self testing, as a simple to read test makes a literal "end to end" test, covering a lot of complex code with a few lines of simple code.

Fixes # (issue)

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)

This are literal test. They do not effect the production code. So the checklist does not directly apply.