### PR TITLE
Template Processor: Fix 0 considered as empty string

### DIFF
--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -27,6 +27,7 @@
 - Reader Word2007: Support Header elements within Title elements by [@SpraxDev](https://github.com/SpraxDev) fixing [#2616](https://github.com/PHPOffice/PHPWord/issues/2616), [#2426](https://github.com/PHPOffice/PHPWord/issues/2426) in [#2674](https://github.com/PHPOffice/PHPWord/pull/2674)
 - Reader HTML: Support for inherit value for property line-height by [@Progi1984](https://github.com/Progi1984) fixing [#2683](https://github.com/PHPOffice/PHPWord/issues/2683) in [#2733](https://github.com/PHPOffice/PHPWord/pull/2733)
 - Writer HTML: Fixed null string for Text Elements by [@armagedon007](https://github.com/armagedon007) and [@Progi1984](https://github.com/Progi1984) in [#2738](https://github.com/PHPOffice/PHPWord/pull/2738)
+- TemplateProcessor: Fix 0 considered as empty string. Fixing [#2572](https://github.com/PHPOffice/PHPWord/issues/2572) in [#2617](https://github.com/PHPOffice/PHPWord/pull/2617)
 
 ### Miscellaneous
 

--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -27,7 +27,7 @@
 - Reader Word2007: Support Header elements within Title elements by [@SpraxDev](https://github.com/SpraxDev) fixing [#2616](https://github.com/PHPOffice/PHPWord/issues/2616), [#2426](https://github.com/PHPOffice/PHPWord/issues/2426) in [#2674](https://github.com/PHPOffice/PHPWord/pull/2674)
 - Reader HTML: Support for inherit value for property line-height by [@Progi1984](https://github.com/Progi1984) fixing [#2683](https://github.com/PHPOffice/PHPWord/issues/2683) in [#2733](https://github.com/PHPOffice/PHPWord/pull/2733)
 - Writer HTML: Fixed null string for Text Elements by [@armagedon007](https://github.com/armagedon007) and [@Progi1984](https://github.com/Progi1984) in [#2738](https://github.com/PHPOffice/PHPWord/pull/2738)
-- TemplateProcessor: Fix 0 considered as empty string. Fixing [#2572](https://github.com/PHPOffice/PHPWord/issues/2572) in [#2617](https://github.com/PHPOffice/PHPWord/pull/2617)
+- Template Processor: Fix 0 considered as empty string by [@cavasinf](https://github.com/cavasinf), [@SnipsMine](https://github.com/SnipsMine) and [@Progi1984](https://github.com/Progi1984) fixing [#2572](https://github.com/PHPOffice/PHPWord/issues/2572), [#2703](https://github.com/PHPOffice/PHPWord/issues/2703) in [#2748](https://github.com/PHPOffice/PHPWord/pull/2748)
 
 ### Miscellaneous
 

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -269,7 +269,7 @@ class TemplateProcessor
      */
     protected static function ensureUtf8Encoded($subject)
     {
-        return $subject ? Text::toUTF8($subject) : '';
+        return (null !== $subject) ? Text::toUTF8($subject) : '';
     }
 
     /**

--- a/tests/PhpWordTests/TemplateProcessorTest.php
+++ b/tests/PhpWordTests/TemplateProcessorTest.php
@@ -1641,4 +1641,101 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
         $templateProcessor->setUpdateFields(false);
         self::assertStringContainsString('<w:updateFields w:val="false"/>', $templateProcessor->getSettingsPart());
     }
+
+    public function testEnsureUtf8Encoded(): void
+    {
+        $mainPart = '<w:tbl>
+            <w:tr>
+                <w:tc>
+                    <w:tcPr>
+                        <w:vMerge w:val="restart"/>
+                    </w:tcPr>
+                    <w:p>
+                        <w:r>
+                            <w:t t=1>${stringZero}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:p>
+                        <w:r>
+                            <w:t t=2>${intZero}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:p>
+                        <w:r>
+                            <w:t t=3>${stringTest}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:p>
+                        <w:r>
+                            <w:t t=4>${null}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:p>
+                        <w:r>
+                            <w:t t=5>${floatZero}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:p>
+                        <w:r>
+                            <w:t t=6>${intTen}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:p>
+                        <w:r>
+                            <w:t t=7>${boolFalse}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+                <w:tc>
+                    <w:p>
+                        <w:r>
+                            <w:t t=8>${boolTrue}</w:t>
+                        </w:r>
+                    </w:p>
+                </w:tc>
+            </w:tr>
+        </w:tbl>';
+        $templateProcessor = new TestableTemplateProcesor($mainPart);
+
+        self::assertEquals(
+            ['stringZero', 'intZero', 'stringTest', 'null', 'floatZero', 'intTen', 'boolFalse', 'boolTrue'],
+            $templateProcessor->getVariables()
+        );
+
+        $templateProcessor->setValue('stringZero', '0');
+        self::assertStringContainsString('<w:t t=1>0</w:t>', $templateProcessor->getMainPart());
+
+        $templateProcessor->setValue('intZero', 0);
+        self::assertStringContainsString('<w:t t=2>0</w:t>', $templateProcessor->getMainPart());
+
+        $templateProcessor->setValue('stringTest', 'test');
+        self::assertStringContainsString('<w:t t=3>test</w:t>', $templateProcessor->getMainPart());
+
+        $templateProcessor->setValue('null', null);
+        self::assertStringContainsString('<w:t t=4></w:t>', $templateProcessor->getMainPart());
+
+        $templateProcessor->setValue('floatZero', 0.00);
+        self::assertStringContainsString('<w:t t=5>0</w:t>', $templateProcessor->getMainPart());
+
+        $templateProcessor->setValue('intTen', 10);
+        self::assertStringContainsString('<w:t t=6>10</w:t>', $templateProcessor->getMainPart());
+
+        $templateProcessor->setValue('boolFalse', false);
+        self::assertStringContainsString('<w:t t=7></w:t>', $templateProcessor->getMainPart());
+
+        $templateProcessor->setValue('boolTrue', true);
+        self::assertStringContainsString('<w:t t=8>1</w:t>', $templateProcessor->getMainPart());
+    }
 }


### PR DESCRIPTION
### Description

Template Processor: Fix 0 considered as empty string

Fixes #2572
Fixes #2703

Thanks @cavasinf & @SnipsMine

### Checklist:

- [ ] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)
