### PR TITLE
improvement in DefaultFont handling in Reader ODText & Word2017

### DIFF
--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -4,7 +4,12 @@
 
 ## Enhancements
 
-- Default Font: Allow specify Asisn font and Latin font separately
+- Default Font: Allow specify Asian font and Latin font separately
+-- in the datastructures in [#2714](https://github.com/PHPOffice/PHPWord/pull/2714)
+-- Writer Word2007 in [#2714](https://github.com/PHPOffice/PHPWord/pull/2714)
+-- Reader Word2007 in [#](https://github.com/PHPOffice/PHPWord/pull/)
+-- Writer ODText in [#](https://github.com/PHPOffice/PHPWord/pull/)
+-- Reader ODText in [#](https://github.com/PHPOffice/PHPWord/pull/)
 
 - Writer ODText: Support for ListItemRun by [@Progi1984](https://github.com/Progi1984) fixing [#2159](https://github.com/PHPOffice/PHPWord/issues/2159), [#2620](https://github.com/PHPOffice/PHPWord/issues/2620) in [#2669](https://github.com/PHPOffice/PHPWord/pull/2669)
 - Writer HTML: Support for vAlign in Tables by [@SpraxDev](https://github.com/SpraxDev) in [#2675](https://github.com/PHPOffice/PHPWord/pull/2675)
@@ -18,6 +23,7 @@
 - Reader HTML: Support font styles for h1/h6 by [@Progi1984](https://github.com/Progi1984) fixing [#2619](https://github.com/PHPOffice/PHPWord/issues/2619) in [#2737](https://github.com/PHPOffice/PHPWord/pull/2737)
 - Writer EPub3: Basic support by [@Sambit003](https://github.com/Sambit003) fixing [#55](https://github.com/PHPOffice/PHPWord/issues/55) in [#2724](https://github.com/PHPOffice/PHPWord/pull/2724)
 - Writer2007: Added support for background and border color transparency in Text Box element [@chudy20007](https://github.com/Chudy20007) in [#2555](https://github.com/PHPOffice/PHPWord/pull/2555)
+- Reader ODText: addded (limited) support for reading default font styles by [@MichaelPFrey](https://github.com/MichaelPFrey) in [#(https://github.com/PHPOffice/PHPWord/pull/)
 
 ### Bug fixes
 

--- a/src/PhpWord/Reader/ODText.php
+++ b/src/PhpWord/Reader/ODText.php
@@ -43,6 +43,7 @@ class ODText extends AbstractReader implements ReaderInterface
         $readerParts = [
             'content.xml' => 'Content',
             'meta.xml' => 'Meta',
+            'styles.xml' => 'Styles',
         ];
 
         foreach ($readerParts as $xmlFile => $partName) {

--- a/src/PhpWord/Reader/ODText/Styles.php
+++ b/src/PhpWord/Reader/ODText/Styles.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Reader\ODText;
+
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Shared\XMLReader;
+use PhpOffice\PhpWord\Style\Language;
+
+/**
+ * Styles reader.
+ *
+ * @since 1.4.0
+ */
+class Styles extends AbstractPart
+{
+    /**
+     * Read styles.xml.
+     */
+    public function read(PhpWord $phpWord): void
+    {
+        $xmlReader = new XMLReader();
+        $xmlReader->getDomFromZip($this->docFile, $this->xmlFile);
+        $fontDefaults = $xmlReader->getElement('office:styles/style:default-style/style:text-properties');
+
+        if ($fontDefaults !== null) {
+            $phpWord->setDefaultFontName($fontDefaults->getAttribute('style:font-name'));
+            $phpWord->setDefaultAsianFontName($fontDefaults->getAttribute('style:font-name-asian'));
+            $phpWord->setDefaultFontSize((float) (str_replace('pt', '', $fontDefaults->getAttribute('fo:font-size'))));
+            $phpWord->setDefaultFontColor(str_replace('#', '', $fontDefaults->getAttribute('fo:color')));
+            $phpWord->getSettings()->setThemeFontLang(new Language($fontDefaults->getAttribute('fo:language')));
+        }
+    }
+}

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -756,6 +756,7 @@ abstract class AbstractPart
         $styleDefs = [
             'styleName' => [self::READ_VALUE, 'w:rStyle'],
             'name' => [self::READ_VALUE, 'w:rFonts', ['w:ascii', 'w:hAnsi', 'w:eastAsia', 'w:cs']],
+            'nameEastAsia' => [self::READ_VALUE, 'w:rFonts', ['w:eastAsia', 'w:ascii', 'w:hAnsi',  'w:cs']],
             'hint' => [self::READ_VALUE, 'w:rFonts', 'w:hint'],
             'size' => [self::READ_SIZE,  ['w:sz', 'w:szCs']],
             'color' => [self::READ_VALUE, 'w:color'],

--- a/src/PhpWord/Reader/Word2007/Styles.php
+++ b/src/PhpWord/Reader/Word2007/Styles.php
@@ -44,6 +44,9 @@ class Styles extends AbstractPart
                 if (array_key_exists('name', $fontDefaultStyle)) {
                     $phpWord->setDefaultFontName($fontDefaultStyle['name']);
                 }
+                if (array_key_exists('nameEastAsia', $fontDefaultStyle)) {
+                    $phpWord->setDefaultAsianFontName($fontDefaultStyle['nameEastAsia']);
+                }
                 if (array_key_exists('size', $fontDefaultStyle)) {
                     $phpWord->setDefaultFontSize($fontDefaultStyle['size']);
                 }

--- a/src/PhpWord/Writer/ODText/Part/Styles.php
+++ b/src/PhpWord/Writer/ODText/Part/Styles.php
@@ -99,7 +99,7 @@ class Styles extends AbstractPart
         $xmlWriter->writeAttribute('fo:country', $latinLang[1]);
         $xmlWriter->writeAttribute('fo:color', '#' . Settings::getDefaultFontColor());
         $xmlWriter->writeAttribute('style:letter-kerning', 'true');
-        $xmlWriter->writeAttribute('style:font-name-asian', Settings::getDefaultFontName() . '2');
+        $xmlWriter->writeAttribute('style:font-name-asian', Settings::getDefaultAsianFontName());
         $xmlWriter->writeAttribute('style:font-size-asian', Settings::getDefaultFontSize() . 'pt');
         $xmlWriter->writeAttribute('style:language-asian', $asianLang[0]);
         $xmlWriter->writeAttribute('style:country-asian', $asianLang[1]);

--- a/tests/PhpWordTests/WriteReadback/ODTextTest.php
+++ b/tests/PhpWordTests/WriteReadback/ODTextTest.php
@@ -33,6 +33,102 @@ use PhpOffice\PhpWord\Writer\ODText;
 class ODTextTest extends \PHPUnit\Framework\TestCase
 {
     /**
+     * Test default font name.
+     */
+    public function testDefaultFontName(): void
+    {
+        $phpWordWriter = new PhpWord();
+        $testDefaultFontName = 'Times New Roman';
+        $phpWordWriter->setDefaultFontName($testDefaultFontName);
+
+        $writer = new ODText($phpWordWriter);
+        $file = __DIR__ . '/../_files/temp.odt';
+        $writer->save($file);
+
+        self::assertFileExists($file);
+
+        $phpWordWriter->setDefaultFontName('This text should not be set after reading back the file');
+
+        $phpWordReader = IOFactory::load($file, 'ODText');
+
+        self::assertEquals($testDefaultFontName, $phpWordReader->getDefaultFontName());
+
+        unlink($file);
+    }
+
+    /**
+     * Test default Asian font name.
+     */
+    public function testDefaultAsianFontName(): void
+    {
+        $phpWordWriter = new PhpWord();
+        $testDefaultFontName = '標楷體';
+        $phpWordWriter->setDefaultAsianFontName($testDefaultFontName);
+
+        $writer = new ODText($phpWordWriter);
+        $file = __DIR__ . '/../_files/temp.odt';
+        $writer->save($file);
+
+        self::assertFileExists($file);
+
+        $phpWordWriter->setDefaultAsianFontName('This text should not be set after reading back the file');
+
+        $phpWordReader = IOFactory::load($file, 'ODText');
+
+        self::assertEquals($testDefaultFontName, $phpWordReader->getDefaultAsianFontName());
+
+        unlink($file);
+    }
+
+    /**
+     * Test default font size.
+     */
+    public function testDefaulFontSize(): void
+    {
+        $phpWordWriter = new PhpWord();
+        $testDefaultFontSize = 144;
+        $phpWordWriter->setDefaultFontSize($testDefaultFontSize);
+
+        $writer = new ODText($phpWordWriter);
+        $file = __DIR__ . '/../_files/temp.odt';
+        $writer->save($file);
+
+        self::assertFileExists($file);
+
+        $phpWordWriter->setDefaultFontSize(987); //This value should not be set after reading back the file
+
+        $phpWordReader = IOFactory::load($file, 'ODText');
+
+        self::assertEquals($testDefaultFontSize, $phpWordReader->getDefaultFontSize());
+
+        unlink($file);
+    }
+
+    /**
+     * Test default font color.
+     */
+    public function testDefaultFontColor(): void
+    {
+        $phpWordWriter = new PhpWord();
+        $testDefaultFontColor = '00FF00';
+        $phpWordWriter->setDefaultFontColor($testDefaultFontColor);
+
+        $writer = new ODText($phpWordWriter);
+        $file = __DIR__ . '/../_files/temp.odt';
+        $writer->save($file);
+
+        self::assertFileExists($file);
+
+        $phpWordWriter->setDefaultFontColor('C0FFEE'); //This value should not be set after reading back the file
+
+        $phpWordReader = IOFactory::load($file, 'ODText');
+
+        self::assertEquals($testDefaultFontColor, $phpWordReader->getDefaultFontColor());
+
+        unlink($file);
+    }
+
+    /**
      * Test a document with one section and text.
      */
     public function testOneSectionWithText(): void

--- a/tests/PhpWordTests/WriteReadback/Word2007Test.php
+++ b/tests/PhpWordTests/WriteReadback/Word2007Test.php
@@ -48,6 +48,8 @@ class Word2007Test extends \PHPUnit\Framework\TestCase
 
         self::assertFileExists($file);
 
+        $phpWordWriter->setDefaultFontName('This text should not be set after reading back the file');
+
         $phpWordReader = IOFactory::load($file, 'Word2007');
 
         self::assertEquals($testDefaultFontName, $phpWordReader->getDefaultFontName());
@@ -69,6 +71,8 @@ class Word2007Test extends \PHPUnit\Framework\TestCase
         $writer->save($file);
 
         self::assertFileExists($file);
+
+        $phpWordWriter->setDefaultAsianFontName('This text should not be set after reading back the file');
 
         $phpWordReader = IOFactory::load($file, 'Word2007');
 
@@ -114,6 +118,8 @@ class Word2007Test extends \PHPUnit\Framework\TestCase
 
         self::assertFileExists($file);
 
+        $phpWordWriter->setDefaultFontColor('C0FFEE'); //This value should not be set after reading back the file
+
         $phpWordReader = IOFactory::load($file, 'Word2007');
 
         self::assertEquals($testDefaultFontColor, $phpWordReader->getDefaultFontColor());
@@ -135,6 +141,8 @@ class Word2007Test extends \PHPUnit\Framework\TestCase
         $writer->save($file);
 
         self::assertFileExists($file);
+
+        $phpWordWriter->getSettings()->setZoom(98); //This value should not be set after reading back the file
 
         $phpWordReader = IOFactory::load($file, 'Word2007');
 


### PR DESCRIPTION
### Description

improvement in DefaultFont handling in Reader ODText & Word2017 (support for more attributes).

This builds on #2745 and improves up on #2700, #2735 and #2714.

Fixes # (issue)

### Checklist:

- [ ] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [ ] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)
