### PR TITLE
[Feature] Can set min and max values for axes.

### DIFF
--- a/src/PhpWord/Style/Chart.php
+++ b/src/PhpWord/Style/Chart.php
@@ -150,6 +150,34 @@ class Chart extends AbstractStyle
     private $gridX = false;
 
     /**
+     * Min value for Y-Axis.
+     *
+     * @var null|float|int
+     */
+    private $minY;
+
+    /**
+     * Max value for X-Axis.
+     *
+     * @var null|float|int
+     */
+    private $minX;
+
+    /**
+     * Max value for Y-Axis.
+     *
+     * @var null|float|int
+     */
+    private $maxY;
+
+    /**
+     * Max value for X-Axis.
+     *
+     * @var null|float|int
+     */
+    private $maxX;
+
+    /**
      * Create a new instance.
      *
      * @param array $style
@@ -550,5 +578,69 @@ class Chart extends AbstractStyle
         $this->gridX = $this->setBoolVal($value, $this->gridX);
 
         return $this;
+    }
+
+    /**
+     * @return null|float|int
+     */
+    public function minY()
+    {
+        return $this->minY;
+    }
+
+    /**
+     * @param null|float|int $minY
+     */
+    public function setMinY($minY): void
+    {
+        $this->minY = $minY;
+    }
+
+    /**
+     * @return null|float|int
+     */
+    public function minX()
+    {
+        return $this->minX;
+    }
+
+    /**
+     * @param null|float|int $minX
+     */
+    public function setMinX($minX): void
+    {
+        $this->minX = $minX;
+    }
+
+    /**
+     * @return null|float|int
+     */
+    public function maxY()
+    {
+        return $this->maxY;
+    }
+
+    /**
+     * @param null|float|int $maxY
+     */
+    public function setMaxY($maxY): void
+    {
+        $this->maxY = $maxY;
+    }
+
+    /**
+     * @return null|float|int
+     */
+    public function maxX()
+    {
+        return $this->maxX;
+    }
+
+    /**
+     * @param null|float|int $maxX
+     */
+    public function setMaxX($maxX): void
+    {
+        $this->maxX = $maxX;
     }
 }

--- a/src/PhpWord/Writer/Word2007/Part/Chart.php
+++ b/src/PhpWord/Writer/Word2007/Part/Chart.php
@@ -387,6 +387,26 @@ class Chart extends AbstractPart
 
         $xmlWriter->startElement('c:scaling');
         $xmlWriter->writeElementBlock('c:orientation', 'val', 'minMax');
+        if ($type == 'cat' && $style->minX()) {
+            $xmlWriter->startElement('c:min');
+            $xmlWriter->writeAttribute('val', $style->minX());
+            $xmlWriter->endElement();
+        }
+        if ($type == 'cat' && $style->maxX()) {
+            $xmlWriter->startElement('c:max');
+            $xmlWriter->writeAttribute('val', $style->maxX());
+            $xmlWriter->endElement();
+        }
+        if ($type == 'val' && $style->minY()) {
+            $xmlWriter->startElement('c:min');
+            $xmlWriter->writeAttribute('val', $style->minY());
+            $xmlWriter->endElement();
+        }
+        if ($type == 'val' && $style->maxY()) {
+            $xmlWriter->startElement('c:max');
+            $xmlWriter->writeAttribute('val', $style->maxY());
+            $xmlWriter->endElement();
+        }
         $xmlWriter->endElement(); // c:scaling
 
         $this->writeShape($xmlWriter, true);


### PR DESCRIPTION


### Description

This PR allows for setting min and max values for axes in Word2007 writer, by passing 4 more style options.

Fixes #1756 and #2333 

### Checklist:

- [ ] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [ ] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)
