### PR TITLE
Writer/Reader Word2007: Added support for the firstLineChars for Indentation

### DIFF
--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -17,7 +17,8 @@
 - Add basic ruby text (phonetic guide) support for Word2007 and HTML Reader/Writer, RTF Writer, basic support for ODT writing by [@Deadpikle](https://github.com/Deadpikle) in [#2727](https://github.com/PHPOffice/PHPWord/pull/2727)
 - Reader HTML: Support font styles for h1/h6 by [@Progi1984](https://github.com/Progi1984) fixing [#2619](https://github.com/PHPOffice/PHPWord/issues/2619) in [#2737](https://github.com/PHPOffice/PHPWord/pull/2737)
 - Writer EPub3: Basic support by [@Sambit003](https://github.com/Sambit003) fixing [#55](https://github.com/PHPOffice/PHPWord/issues/55) in [#2724](https://github.com/PHPOffice/PHPWord/pull/2724)
-- Writer2007: Added support for background and border color transparency in Text Box element [@chudy20007](https://github.com/Chudy20007) in [#2555](https://github.com/PHPOffice/PHPWord/pull/2555)
+- Writer Word2007: Added support for background and border color transparency in Text Box element by [@chudy20007](https://github.com/Chudy20007) in [#2555](https://github.com/PHPOffice/PHPWord/pull/2555)
+- Writer Word2007: Added support for the firstLineChars for Indentation by [@liuzhilinux](https://github.com/liuzhilinux) & [@Progi1984](https://github.com/Progi1984) in [#2753](https://github.com/PHPOffice/PHPWord/pull/2753)
 
 ### Bug fixes
 

--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -18,7 +18,7 @@
 - Reader HTML: Support font styles for h1/h6 by [@Progi1984](https://github.com/Progi1984) fixing [#2619](https://github.com/PHPOffice/PHPWord/issues/2619) in [#2737](https://github.com/PHPOffice/PHPWord/pull/2737)
 - Writer EPub3: Basic support by [@Sambit003](https://github.com/Sambit003) fixing [#55](https://github.com/PHPOffice/PHPWord/issues/55) in [#2724](https://github.com/PHPOffice/PHPWord/pull/2724)
 - Writer Word2007: Added support for background and border color transparency in Text Box element by [@chudy20007](https://github.com/Chudy20007) in [#2555](https://github.com/PHPOffice/PHPWord/pull/2555)
-- Writer Word2007: Added support for the firstLineChars for Indentation by [@liuzhilinux](https://github.com/liuzhilinux) & [@Progi1984](https://github.com/Progi1984) in [#2753](https://github.com/PHPOffice/PHPWord/pull/2753)
+- Writer/Reader Word2007: Added support for the firstLineChars for Indentation by [@liuzhilinux](https://github.com/liuzhilinux) & [@Progi1984](https://github.com/Progi1984) in [#2753](https://github.com/PHPOffice/PHPWord/pull/2753)
 
 ### Bug fixes
 

--- a/docs/usage/styles/paragraph.md
+++ b/docs/usage/styles/paragraph.md
@@ -7,7 +7,7 @@ Available Paragraph style options:
 - ``basedOn``. Parent style.
 - ``hanging``. Hanging indentation in *half inches*.
 - ``indent``. Indent (left indentation) in *half inches*.
-- ``indentation``. An array of indentation key => value pairs in *twip*. Supports *left*, *right*, *firstLine* and *hanging* indentation.
+- ``indentation``. An array of indentation key => value pairs in *twip*. Supports *left*, *right*, *firstLine*, *firstLineChars* and *hanging* indentation.
    See ``\PhpOffice\PhpWord\Style\Indentation`` for possible identation types.
 - ``keepLines``. Keep all lines on one page, *true* or *false*.
 - ``keepNext``. Keep paragraph with next paragraph, *true* or *false*.

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -708,6 +708,7 @@ abstract class AbstractPart
             'indentRight' => [self::READ_VALUE, 'w:ind', 'w:right'],
             'indentHanging' => [self::READ_VALUE, 'w:ind', 'w:hanging'],
             'indentFirstLine' => [self::READ_VALUE, 'w:ind', 'w:firstLine'],
+            'indentFirstLineChars' => [self::READ_VALUE, 'w:ind', 'w:firstLineChars'],
             'spaceAfter' => [self::READ_VALUE, 'w:spacing', 'w:after'],
             'spaceBefore' => [self::READ_VALUE, 'w:spacing', 'w:before'],
             'widowControl' => [self::READ_FALSE, 'w:widowControl'],

--- a/src/PhpWord/Style/Indentation.php
+++ b/src/PhpWord/Style/Indentation.php
@@ -50,7 +50,7 @@ class Indentation extends AbstractStyle
     /**
      * Additional first line chars indentation (twip).
      *
-     * @var float|int
+     * @var int
      */
     private $firstLineChars = 0;
 
@@ -127,22 +127,16 @@ class Indentation extends AbstractStyle
 
     /**
      * Get first line chars.
-     *
-     * @return float|int
      */
-    public function getFirstLineChars()
+    public function getFirstLineChars(): int
     {
         return $this->firstLineChars;
     }
 
     /**
      * Set first line chars.
-     *
-     * @param float|int $value
-     *
-     * @return $this
      */
-    public function setFirstLineChars($value)
+    public function setFirstLineChars(int $value): self
     {
         $this->firstLineChars = $this->setNumericVal($value, $this->firstLineChars);
         return $this;

--- a/src/PhpWord/Style/Indentation.php
+++ b/src/PhpWord/Style/Indentation.php
@@ -48,6 +48,13 @@ class Indentation extends AbstractStyle
     private $firstLine = 0;
 
     /**
+     * Additional first line chars indentation (twip).
+     *
+     * @var float|int
+     */
+    private $firstLineChars = 0;
+
+    /**
      * Indentation removed from first line (twip).
      *
      * @var null|float
@@ -115,6 +122,29 @@ class Indentation extends AbstractStyle
     {
         $this->firstLine = $this->setNumericVal($value);
 
+        return $this;
+    }
+
+    /**
+     * Get first line chars.
+     *
+     * @return float|int
+     */
+    public function getFirstLineChars()
+    {
+        return $this->firstLineChars;
+    }
+
+    /**
+     * Set first line chars.
+     *
+     * @param float|int $value
+     *
+     * @return $this
+     */
+    public function setFirstLineChars($value)
+    {
+        $this->firstLineChars = $this->setNumericVal($value, $this->firstLineChars);
         return $this;
     }
 

--- a/src/PhpWord/Style/Indentation.php
+++ b/src/PhpWord/Style/Indentation.php
@@ -138,7 +138,8 @@ class Indentation extends AbstractStyle
      */
     public function setFirstLineChars(int $value): self
     {
-        $this->firstLineChars = $this->setNumericVal($value, $this->firstLineChars);
+        $this->firstLineChars = $this->setIntVal($value, $this->firstLineChars);
+
         return $this;
     }
 

--- a/src/PhpWord/Style/Paragraph.php
+++ b/src/PhpWord/Style/Paragraph.php
@@ -433,6 +433,14 @@ class Paragraph extends Border
     }
 
     /**
+     * Set firstlineChars indentation.
+     */
+    public function setIndentFirstLineChars(int $value = 0): self
+    {
+        return $this->setIndentation(['firstLineChars' => $value]);
+    }
+
+    /**
      * Set left indentation.
      */
     public function setIndentLeft(?float $value = null): self

--- a/src/PhpWord/Writer/Word2007/Style/Indentation.php
+++ b/src/PhpWord/Writer/Word2007/Style/Indentation.php
@@ -44,6 +44,9 @@ class Indentation extends AbstractStyle
         $firstLine = $style->getFirstLine();
         $xmlWriter->writeAttributeIf(null !== $firstLine, 'w:firstLine', $this->convertTwip($firstLine));
 
+        $firstLineChars = $style->getFirstLineChars();
+        $xmlWriter->writeAttributeIf(null !== $firstLineChars, 'w:firstLineChars', $this->convertTwip($firstLineChars));
+
         $hanging = $style->getHanging();
         $xmlWriter->writeAttributeIf(null !== $hanging, 'w:hanging', $this->convertTwip($hanging));
 

--- a/src/PhpWord/Writer/Word2007/Style/Indentation.php
+++ b/src/PhpWord/Writer/Word2007/Style/Indentation.php
@@ -45,7 +45,7 @@ class Indentation extends AbstractStyle
         $xmlWriter->writeAttributeIf(null !== $firstLine, 'w:firstLine', $this->convertTwip($firstLine));
 
         $firstLineChars = $style->getFirstLineChars();
-        $xmlWriter->writeAttributeIf(null !== $firstLineChars, 'w:firstLineChars', $this->convertTwip($firstLineChars));
+        $xmlWriter->writeAttributeIf(0 !== $firstLineChars, 'w:firstLineChars', $this->convertTwip($firstLineChars));
 
         $hanging = $style->getHanging();
         $xmlWriter->writeAttributeIf(null !== $hanging, 'w:hanging', $this->convertTwip($hanging));

--- a/tests/PhpWordTests/Element/AbstractElementTest.php
+++ b/tests/PhpWordTests/Element/AbstractElementTest.php
@@ -30,7 +30,13 @@ class AbstractElementTest extends \PHPUnit\Framework\TestCase
      */
     public function testElementIndex(): void
     {
-        $stub = $this->getMockForAbstractClass(AbstractElement::class);
+        if (method_exists($this, 'getMockForAbstractClass')) {
+            $stub = $this->getMockForAbstractClass(AbstractElement::class);
+        } else {
+            /** @var AbstractElement $stub */
+            $stub = new class() extends AbstractElement {
+            };
+        }
         $ival = mt_rand(0, 100);
         $stub->setElementIndex($ival);
         self::assertEquals($ival, $stub->getElementIndex());
@@ -41,7 +47,13 @@ class AbstractElementTest extends \PHPUnit\Framework\TestCase
      */
     public function testElementId(): void
     {
-        $stub = $this->getMockForAbstractClass(AbstractElement::class);
+        if (method_exists($this, 'getMockForAbstractClass')) {
+            $stub = $this->getMockForAbstractClass(AbstractElement::class);
+        } else {
+            /** @var AbstractElement $stub */
+            $stub = new class() extends AbstractElement {
+            };
+        }
         $stub->setElementId();
         self::assertEquals(6, strlen($stub->getElementId()));
     }

--- a/tests/PhpWordTests/Reader/Word2007/StyleTest.php
+++ b/tests/PhpWordTests/Reader/Word2007/StyleTest.php
@@ -379,7 +379,7 @@ class StyleTest extends AbstractTestReader
             488.00,
             10.0,
             490.00,
-            140
+            140,
         ];
         yield [
             '<w:ind w:left="709" w:right="488" w:hanging="10" w:firstLine="490"/>',
@@ -387,7 +387,7 @@ class StyleTest extends AbstractTestReader
             488.00,
             10.0,
             490.00,
-            0
+            0,
         ];
         yield [
             '<w:ind w:hanging="10" w:firstLine="490"/>',
@@ -395,7 +395,7 @@ class StyleTest extends AbstractTestReader
             0,
             10.0,
             490.00,
-            0
+            0,
         ];
         yield [
             '<w:ind w:left="709"/>',
@@ -403,7 +403,7 @@ class StyleTest extends AbstractTestReader
             0,
             0,
             0,
-            0
+            0,
         ];
         yield [
             '<w:ind w:right="488"/>',
@@ -411,7 +411,7 @@ class StyleTest extends AbstractTestReader
             488.00,
             0,
             0,
-            0
+            0,
         ];
     }
 }

--- a/tests/PhpWordTests/Reader/Word2007/StyleTest.php
+++ b/tests/PhpWordTests/Reader/Word2007/StyleTest.php
@@ -334,8 +334,14 @@ class StyleTest extends AbstractTestReader
     /**
      * @dataProvider providerIndentation
      */
-    public function testIndentation(string $indent, float $left, float $right, ?float $hanging, float $firstLine): void
-    {
+    public function testIndentation(
+        string $indent,
+        float $left,
+        float $right,
+        ?float $hanging,
+        float $firstLine,
+        int $firstLineChars
+    ): void {
         $documentXml = "<w:p>
             <w:pPr>
                 $indent
@@ -359,16 +365,53 @@ class StyleTest extends AbstractTestReader
         self::assertSame($right, $indentation->getRight());
         self::assertSame($hanging, $indentation->getHanging());
         self::assertSame($firstLine, $indentation->getFirstLine());
+        self::assertSame($firstLineChars, $indentation->getFirstLineChars());
     }
 
     /**
-     * @return Generator<array{0:string, 1:float, 2:float, 3:null|float, 4: float}>
+     * @return Generator<array{0:string, 1:float, 2:float, 3:null|float, 4: float, 5: int}>
      */
     public static function providerIndentation()
     {
-        yield ['<w:ind w:left="709" w:right="488" w:hanging="10" w:firstLine="490"/>', 709.00, 488.00, 10.0, 490.00];
-        yield ['<w:ind w:hanging="10" w:firstLine="490"/>', 0, 0, 10.0, 490.00];
-        yield ['<w:ind w:left="709"/>', 709.00, 0, 0, 0];
-        yield ['<w:ind w:right="488"/>', 0, 488.00, 0, 0];
+        yield [
+            '<w:ind w:left="709" w:right="488" w:hanging="10" w:firstLine="490" w:firstLineChars="140"/>',
+            709.00,
+            488.00,
+            10.0,
+            490.00,
+            140
+        ];
+        yield [
+            '<w:ind w:left="709" w:right="488" w:hanging="10" w:firstLine="490"/>',
+            709.00,
+            488.00,
+            10.0,
+            490.00,
+            0
+        ];
+        yield [
+            '<w:ind w:hanging="10" w:firstLine="490"/>',
+            0,
+            0,
+            10.0,
+            490.00,
+            0
+        ];
+        yield [
+            '<w:ind w:left="709"/>',
+            709.00,
+            0,
+            0,
+            0,
+            0
+        ];
+        yield [
+            '<w:ind w:right="488"/>',
+            0,
+            488.00,
+            0,
+            0,
+            0
+        ];
     }
 }

--- a/tests/PhpWordTests/Style/AbstractStyleTest.php
+++ b/tests/PhpWordTests/Style/AbstractStyleTest.php
@@ -20,6 +20,7 @@ namespace PhpOffice\PhpWordTests\Style;
 
 use InvalidArgumentException;
 use PhpOffice\PhpWord\SimpleType\Jc;
+use PhpOffice\PhpWord\Style\AbstractStyle;
 use PhpOffice\PhpWord\Style\Paragraph;
 use ReflectionClass;
 
@@ -35,7 +36,13 @@ class AbstractStyleTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetStyleByArray(): void
     {
-        $stub = $this->getMockForAbstractClass('\PhpOffice\PhpWord\Style\AbstractStyle');
+        if (method_exists($this, 'getMockForAbstractClass')) {
+            $stub = $this->getMockForAbstractClass(AbstractStyle::class);
+        } else {
+            /** @var AbstractStyle $stub */
+            $stub = new class() extends AbstractStyle {
+            };
+        }
         $stub->setStyleByArray(['index' => 1]);
 
         self::assertEquals(1, $stub->getIndex());
@@ -62,7 +69,13 @@ class AbstractStyleTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetValNormal(): void
     {
-        $stub = $this->getMockForAbstractClass('\PhpOffice\PhpWord\Style\AbstractStyle');
+        if (method_exists($this, 'getMockForAbstractClass')) {
+            $stub = $this->getMockForAbstractClass(AbstractStyle::class);
+        } else {
+            /** @var AbstractStyle $stub */
+            $stub = new class() extends AbstractStyle {
+            };
+        }
 
         self::assertTrue(self::callProtectedMethod($stub, 'setBoolVal', [true, false]));
         self::assertEquals(12, self::callProtectedMethod($stub, 'setIntVal', [12, 200]));
@@ -76,7 +89,13 @@ class AbstractStyleTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetValDefault(): void
     {
-        $stub = $this->getMockForAbstractClass('\PhpOffice\PhpWord\Style\AbstractStyle');
+        if (method_exists($this, 'getMockForAbstractClass')) {
+            $stub = $this->getMockForAbstractClass(AbstractStyle::class);
+        } else {
+            /** @var AbstractStyle $stub */
+            $stub = new class() extends AbstractStyle {
+            };
+        }
 
         self::assertNotTrue(self::callProtectedMethod($stub, 'setBoolVal', ['a', false]));
         self::assertEquals(200, self::callProtectedMethod($stub, 'setIntVal', ['foo', 200]));
@@ -90,7 +109,13 @@ class AbstractStyleTest extends \PHPUnit\Framework\TestCase
     public function testSetValEnumException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $stub = $this->getMockForAbstractClass('\PhpOffice\PhpWord\Style\AbstractStyle');
+        if (method_exists($this, 'getMockForAbstractClass')) {
+            $stub = $this->getMockForAbstractClass(AbstractStyle::class);
+        } else {
+            /** @var AbstractStyle $stub */
+            $stub = new class() extends AbstractStyle {
+            };
+        }
 
         self::assertEquals('b', self::callProtectedMethod($stub, 'setEnumVal', ['z', ['a', 'b'], 'b']));
     }

--- a/tests/PhpWordTests/Style/IndentationTest.php
+++ b/tests/PhpWordTests/Style/IndentationTest.php
@@ -37,6 +37,7 @@ class IndentationTest extends \PHPUnit\Framework\TestCase
             'left' => [0, 10],
             'right' => [0, 10],
             'firstLine' => [null, 20],
+            'firstLineChars' => [0, 20],
             'hanging' => [null, 20],
         ];
         foreach ($properties as $property => $value) {

--- a/tests/PhpWordTests/Writer/EPub3/Part/AbstractPartTest.php
+++ b/tests/PhpWordTests/Writer/EPub3/Part/AbstractPartTest.php
@@ -15,7 +15,16 @@ class AbstractPartTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->part = $this->getMockForAbstractClass(AbstractPart::class);
+        if (method_exists($this, 'getMockForAbstractClass')) {
+            $this->part = $this->getMockForAbstractClass(AbstractPart::class);
+        } else {
+            $this->part = new class() extends AbstractPart {
+                public function write(): string
+                {
+                    return '';
+                }
+            };
+        }
     }
 
     public function testParentWriter(): void

--- a/tests/PhpWordTests/Writer/EPub3/Style/AbstractStyleTest.php
+++ b/tests/PhpWordTests/Writer/EPub3/Style/AbstractStyleTest.php
@@ -14,7 +14,17 @@ class AbstractStyleTest extends TestCase
     public function testParentWriter(): void
     {
         $parentWriter = new EPub3();
-        $style = $this->getMockForAbstractClass(AbstractStyle::class);
+        if (method_exists($this, 'getMockForAbstractClass')) {
+            $style = $this->getMockForAbstractClass(AbstractStyle::class);
+        } else {
+            /** @var AbstractStyle $style */
+            $style = new class() extends AbstractStyle {
+                public function write(): string
+                {
+                    return '';
+                }
+            };
+        }
 
         $result = $style->setParentWriter($parentWriter);
 

--- a/tests/PhpWordTests/Writer/ODText/Part/AbstractPartTest.php
+++ b/tests/PhpWordTests/Writer/ODText/Part/AbstractPartTest.php
@@ -34,7 +34,17 @@ class AbstractPartTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetGetParentWriter(): void
     {
-        $object = $this->getMockForAbstractClass(ODText\Part\AbstractPart::class);
+        if (method_exists($this, 'getMockForAbstractClass')) {
+            $object = $this->getMockForAbstractClass(ODText\Part\AbstractPart::class);
+        } else {
+            /** @var ODText\Part\AbstractPart $object */
+            $object = new class() extends ODText\Part\AbstractPart {
+                public function write(): string
+                {
+                    return '';
+                }
+            };
+        }
         $object->setParentWriter(new ODText());
         self::assertEquals(new ODText(), $object->getParentWriter());
     }
@@ -46,7 +56,17 @@ class AbstractPartTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('No parent WriterInterface assigned.');
-        $object = $this->getMockForAbstractClass(ODText\Part\AbstractPart::class);
+        if (method_exists($this, 'getMockForAbstractClass')) {
+            $object = $this->getMockForAbstractClass(ODText\Part\AbstractPart::class);
+        } else {
+            /** @var ODText\Part\AbstractPart $object */
+            $object = new class() extends ODText\Part\AbstractPart {
+                public function write(): string
+                {
+                    return '';
+                }
+            };
+        }
         $object->getParentWriter();
     }
 }

--- a/tests/PhpWordTests/Writer/Word2007/Part/AbstractPartTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/Part/AbstractPartTest.php
@@ -32,9 +32,19 @@ class AbstractPartTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetGetParentWriter(): void
     {
-        $object = $this->getMockForAbstractClass(Word2007\Part\AbstractPart::class);
-        $object->setParentWriter(new Word2007());
-        self::assertEquals(new Word2007(), $object->getParentWriter());
+        if (method_exists($this, 'getMockForAbstractClass')) {
+            $stub = $this->getMockForAbstractClass(Word2007\Part\AbstractPart::class);
+        } else {
+            /** @var Word2007\Part\AbstractPart $stub */
+            $stub = new class() extends Word2007\Part\AbstractPart {
+                public function write(): string
+                {
+                    return '';
+                }
+            };
+        }
+        $stub->setParentWriter(new Word2007());
+        self::assertEquals(new Word2007(), $stub->getParentWriter());
     }
 
     /**
@@ -44,7 +54,17 @@ class AbstractPartTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('No parent WriterInterface assigned.');
-        $object = $this->getMockForAbstractClass(Word2007\Part\AbstractPart::class);
-        $object->getParentWriter();
+        if (method_exists($this, 'getMockForAbstractClass')) {
+            $stub = $this->getMockForAbstractClass(Word2007\Part\AbstractPart::class);
+        } else {
+            /** @var Word2007\Part\AbstractPart $stub */
+            $stub = new class() extends Word2007\Part\AbstractPart {
+                public function write(): string
+                {
+                    return '';
+                }
+            };
+        }
+        $stub->getParentWriter();
     }
 }

--- a/tests/PhpWordTests/Writer/Word2007/Style/IndentationTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/Style/IndentationTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWordTests\Writer\Word2007\Style;
+
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Settings;
+use PhpOffice\PhpWord\Shared\Html as SharedHtml;
+use PhpOffice\PhpWordTests\TestHelperDOCX;
+
+class IndentationTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Executed before each method of the class.
+     */
+    protected function tearDown(): void
+    {
+        Settings::setDefaultRtl(null);
+        TestHelperDOCX::clear();
+    }
+
+    public function testDefault(): void
+    {
+        $word = new PhpWord();
+        Settings::setDefaultRtl(true);
+        $section = $word->addSection();
+        $text = $section->addText('AA');
+        $text->getParagraphStyle()->setIndentation([]);
+        $doc = TestHelperDOCX::getDocument($word, 'Word2007');
+
+        $path = '/w:document/w:body/w:p[1]/w:pPr/w:ind';
+        self::assertTrue($doc->elementExists($path));
+        self::assertFalse($doc->hasElementAttribute($path, 'w:firstLineChars'));
+    }
+
+    public function testFirstLineChars(): void
+    {
+        $word = new PhpWord();
+        Settings::setDefaultRtl(true);
+        $section = $word->addSection();
+        $text = $section->addText('AA');
+        $text->getParagraphStyle()->setIndentation([
+            'firstLineChars' => 1440,
+        ]);
+        $doc = TestHelperDOCX::getDocument($word, 'Word2007');
+
+        $path = '/w:document/w:body/w:p[1]/w:pPr/w:ind';
+        self::assertTrue($doc->elementExists($path));
+        self::assertTrue($doc->hasElementAttribute($path, 'w:firstLineChars'));
+        self::assertSame('1440', $doc->getElementAttribute($path, 'w:firstLineChars'));
+    }
+}

--- a/tests/PhpWordTests/Writer/Word2007/Style/IndentationTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/Style/IndentationTest.php
@@ -20,7 +20,7 @@ namespace PhpOffice\PhpWordTests\Writer\Word2007\Style;
 
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Settings;
-use PhpOffice\PhpWord\Shared\Html as SharedHtml;
+use PhpOffice\PhpWord\Style\Paragraph;
 use PhpOffice\PhpWordTests\TestHelperDOCX;
 
 class IndentationTest extends \PHPUnit\Framework\TestCase
@@ -40,7 +40,9 @@ class IndentationTest extends \PHPUnit\Framework\TestCase
         Settings::setDefaultRtl(true);
         $section = $word->addSection();
         $text = $section->addText('AA');
-        $text->getParagraphStyle()->setIndentation([]);
+        $paragraphStyle = $text->getParagraphStyle();
+        self::assertInstanceOf(Paragraph::class, $paragraphStyle);
+        $paragraphStyle->setIndentation([]);
         $doc = TestHelperDOCX::getDocument($word, 'Word2007');
 
         $path = '/w:document/w:body/w:p[1]/w:pPr/w:ind';
@@ -54,7 +56,9 @@ class IndentationTest extends \PHPUnit\Framework\TestCase
         Settings::setDefaultRtl(true);
         $section = $word->addSection();
         $text = $section->addText('AA');
-        $text->getParagraphStyle()->setIndentation([
+        $paragraphStyle = $text->getParagraphStyle();
+        self::assertInstanceOf(Paragraph::class, $paragraphStyle);
+        $paragraphStyle->setIndentation([
             'firstLineChars' => 1440,
         ]);
         $doc = TestHelperDOCX::getDocument($word, 'Word2007');


### PR DESCRIPTION
### Description

Writer/Reader Word2007: Added support for the firstLineChars for Indentation

Superseeds #2667 by @liuzhilinux

### Checklist:

- [ ] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)
