### PR TITLE
Fix text extraction from PhpWord TextRun elements

### DIFF
--- a/src/PhpWord/Writer/Word2007/Element/TOC.php
+++ b/src/PhpWord/Writer/Word2007/Element/TOC.php
@@ -96,7 +96,17 @@ class TOC extends AbstractElement
         $xmlWriter->startElement('w:t');
 
         $titleText = $title->getText();
-        $this->writeText(is_string($titleText) ? $titleText : '');
+        if (get_class($titleText) === 'PhpOffice\PhpWord\Element\TextRun') {
+            $textRunElements = $title->getText()->getElements();
+            $uploadedText = '';
+            foreach ($textRunElements as $textRunElement) {
+                $uploadedText .= $textRunElement->getText();
+                $uploadedText .= ' ';
+            }
+            $this->writeText($uploadedText);
+        } else {
+            $this->writeText((is_string($titleText) ? $titleText : '');
+        }
 
         $xmlWriter->endElement(); // w:t
         $xmlWriter->endElement(); // w:r


### PR DESCRIPTION


### Description

Previously, `$title->getText()` was assumed to always return a string, but in some cases, it returns a `PhpOffice\PhpWord\Element\TextRun`. This commit adds a check to determine if the returned value is a `TextRun` and properly extracts text from its child elements.

Fixes #1625 


