### PR TITLE
Make styles to work as a instance property of PhpWord

### DIFF
--- a/src/PhpWord/Element/ListItem.php
+++ b/src/PhpWord/Element/ListItem.php
@@ -18,6 +18,7 @@
 
 namespace PhpOffice\PhpWord\Element;
 
+use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Shared\Text as SharedText;
 use PhpOffice\PhpWord\Style\ListItem as ListItemStyle;
 
@@ -67,6 +68,15 @@ class ListItem extends AbstractElement
         } else {
             $this->style = $this->setNewStyle(new ListItemStyle(), $listStyle, true);
         }
+    }
+
+    /**
+     * Set PhpWord as reference.
+     */
+    public function setPhpWord(?PhpWord $phpWord = null): void
+    {
+        parent::setPhpWord($phpWord);
+        $this->style->setPhpWord($phpWord);
     }
 
     /**

--- a/src/PhpWord/Element/ListItemRun.php
+++ b/src/PhpWord/Element/ListItemRun.php
@@ -18,6 +18,7 @@
 
 namespace PhpOffice\PhpWord\Element;
 
+use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Style\ListItem as ListItemStyle;
 
 /**
@@ -62,6 +63,15 @@ class ListItemRun extends TextRun
             $this->style = $this->setNewStyle(new ListItemStyle(), $listStyle, true);
         }
         parent::__construct($paragraphStyle);
+    }
+
+    /**
+     * Set PhpWord as reference.
+     */
+    public function setPhpWord(?PhpWord $phpWord = null): void
+    {
+        parent::setPhpWord($phpWord);
+        $this->style->setPhpWord($phpWord);
     }
 
     /**

--- a/src/PhpWord/Element/Title.php
+++ b/src/PhpWord/Element/Title.php
@@ -19,6 +19,7 @@
 namespace PhpOffice\PhpWord\Element;
 
 use InvalidArgumentException;
+use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Shared\Text as SharedText;
 use PhpOffice\PhpWord\Style;
 
@@ -79,13 +80,29 @@ class Title extends AbstractElement
         }
 
         $this->depth = $depth;
-        $styleName = $depth === 0 ? 'Title' : "Heading_{$this->depth}";
-        if (array_key_exists($styleName, Style::getStyles())) {
-            $this->style = str_replace('_', '', $styleName);
-        }
+        $this->setStyleByDepth(Style::getStyles());
 
         if ($pageNumber !== null) {
             $this->pageNumber = $pageNumber;
+        }
+    }
+
+    private function setStyleByDepth($styles)
+    {
+        $styleName = $this->depth === 0 ? 'Title' : "Heading_{$this->depth}";
+        if (array_key_exists($styleName, $styles)) {
+            $this->style = str_replace('_', '', $styleName);
+        }
+    }
+
+    /**
+     * Set PhpWord as reference.
+     */
+    public function setPhpWord(?PhpWord $phpWord = null): void
+    {
+        parent::setPhpWord($phpWord);
+        if ($phpWord instanceof PhpWord) {
+            $this->setStyleByDepth($phpWord->getStyles());
         }
     }
 

--- a/src/PhpWord/Style/ListItem.php
+++ b/src/PhpWord/Style/ListItem.php
@@ -18,6 +18,7 @@
 
 namespace PhpOffice\PhpWord\Style;
 
+use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Style;
 
 /**
@@ -36,6 +37,13 @@ class ListItem extends AbstractStyle
     const TYPE_NUMBER_NESTED = 8;
     const TYPE_ALPHANUM = 9;
 
+    /**
+     * PhpWord object.
+     *
+     * @var ?PhpWord
+     */
+    private $phpWord;
+    
     /**
      * Legacy list type.
      *
@@ -73,6 +81,30 @@ class ListItem extends AbstractStyle
         } else {
             $this->setListType();
         }
+    }
+    
+    /**
+     * Set PhpWord as reference.
+     */
+    public function setPhpWord(?PhpWord $phpWord = null): void
+    {
+        $this->phpWord = $phpWord;
+    }
+    
+    /**
+     * Get style by name.
+     *
+     * @param string $styleName
+     *
+     * @return ?AbstractStyle Paragraph|Font|Table|Numbering
+     */
+    private function getGlobalStyle($styleName)
+    {
+        if (isset($this->phpWord)) {
+            return $this->phpWord->getStyle($styleName);
+        }
+
+        return Style::getStyle($styleName);
     }
 
     /**
@@ -125,7 +157,7 @@ class ListItem extends AbstractStyle
     public function setNumStyle($value)
     {
         $this->numStyle = $value;
-        $numStyleObject = Style::getStyle($this->numStyle);
+        $numStyleObject = $this->getGlobalStyle($this->numStyle);
         if ($numStyleObject instanceof Numbering) {
             $this->numId = $numStyleObject->getIndex();
             $numStyleObject->setNumId($this->numId);
@@ -171,7 +203,7 @@ class ListItem extends AbstractStyle
             $numStyle .= 'NumId' . $this->numId;
         }
 
-        if (Style::getStyle($numStyle) !== null) {
+        if ($this->getGlobalStyle($numStyle) !== null) {
             $this->setNumStyle($numStyle);
 
             return;
@@ -281,7 +313,11 @@ class ListItem extends AbstractStyle
             }
             $style['levels'][$key] = $level;
         }
-        Style::addNumberingStyle($numStyle, $style);
+        if (isset($this->phpWord)) {
+            $this->phpWord->addNumberingStyle($numStyle, $style);
+        } else {
+            Style::addNumberingStyle($numStyle, $style);
+        }
         $this->setNumStyle($numStyle);
     }
 }

--- a/src/PhpWord/Writer/HTML/Element/Text.php
+++ b/src/PhpWord/Writer/HTML/Element/Text.php
@@ -263,7 +263,7 @@ class Text extends AbstractElement
             $attributeStyle = ' class="' . $fontStyle . '"';
             // Attribute Lang
             /** @var Font $cssClassStyle */
-            $cssClassStyle = Style::getStyle($fontStyle);
+            $cssClassStyle = $this->parentWriter->getPhpWord()->getStyle($fontStyle);
             if ($cssClassStyle !== null && method_exists($cssClassStyle, 'getLang')) {
                 $lang = $cssClassStyle->getLang();
             }

--- a/src/PhpWord/Writer/HTML/Part/Head.php
+++ b/src/PhpWord/Writer/HTML/Part/Head.php
@@ -127,7 +127,7 @@ class Head extends AbstractPart
         }
 
         // Custom styles
-        $customStyles = Style::getStyles();
+        $customStyles = $this->getParentWriter()->getPhpWord()->getStyles();
         if (is_array($customStyles)) {
             foreach ($customStyles as $name => $style) {
                 $styleParagraph = null;

--- a/src/PhpWord/Writer/ODText/Part/AbstractPart.php
+++ b/src/PhpWord/Writer/ODText/Part/AbstractPart.php
@@ -81,7 +81,7 @@ abstract class AbstractPart extends Word2007AbstractPart
     {
         $xmlWriter->startElement('office:font-face-decls');
         $fontTable = [];
-        $styles = Style::getStyles();
+        $styles = $this->getParentWriter()->getPhpWord()->getStyles();
         $numFonts = 0;
         if (count($styles) > 0) {
             foreach ($styles as $style) {

--- a/src/PhpWord/Writer/ODText/Part/Content.php
+++ b/src/PhpWord/Writer/ODText/Part/Content.php
@@ -179,7 +179,8 @@ class Content extends AbstractPart
      */
     private function writeTextStyles(XMLWriter $xmlWriter): void
     {
-        $styles = Style::getStyles();
+        $phpWord = $this->getParentWriter()->getPhpWord();
+        $styles = $phpWord->getStyles();
         $paragraphStyleCount = 0;
 
         $style = new Paragraph();
@@ -188,7 +189,7 @@ class Content extends AbstractPart
         $styleWriter = new ParagraphStyleWriter($xmlWriter, $style);
         $styleWriter->write();
 
-        $sects = $this->getParentWriter()->getPhpWord()->getSections();
+        $sects = $phpWord->getSections();
         $countsects = count($sects);
         for ($i = 0; $i < $countsects; ++$i) {
             $iplus1 = $i + 1;
@@ -265,6 +266,7 @@ class Content extends AbstractPart
      */
     private function getContainerStyle($container, &$paragraphStyleCount, &$fontStyleCount): void
     {
+        $phpWord = $this->getParentWriter()->getPhpWord();
         $elements = $container->getElements();
         foreach ($elements as $element) {
             if ($element instanceof TextRun) {
@@ -286,7 +288,7 @@ class Content extends AbstractPart
             } elseif ($element instanceof Table) {
                 $style = $element->getStyle();
                 if (is_string($style)) {
-                    $style = Style::getStyle($style);
+                    $style = $phpWord->getStyle($style);
                 }
                 if ($style === null) {
                     $style = new TableStyle();

--- a/src/PhpWord/Writer/ODText/Part/Styles.php
+++ b/src/PhpWord/Writer/ODText/Part/Styles.php
@@ -120,14 +120,15 @@ class Styles extends AbstractPart
      */
     private function writeNamed(XMLWriter $xmlWriter): void
     {
-        $styles = Style::getStyles();
+        $phpWord = $this->getParentWriter()->getPhpWord();
+        $styles = $phpWord->getStyles();
         if (count($styles) > 0) {
             foreach ($styles as $style) {
                 if ($style->isAuto() === false) {
                     $styleClass = str_replace('\\Style\\', '\\Writer\\ODText\\Style\\', get_class($style));
                     if (class_exists($styleClass)) {
                         /** @var \PhpOffice\PhpWord\Writer\ODText\Style\AbstractStyle $styleWriter Type hint */
-                        $styleWriter = new $styleClass($xmlWriter, $style);
+                        $styleWriter = new $styleClass($xmlWriter, $style, $phpWord);
                         $styleWriter->write();
                     }
                 }

--- a/src/PhpWord/Writer/ODText/Style/Paragraph.php
+++ b/src/PhpWord/Writer/ODText/Style/Paragraph.php
@@ -74,7 +74,7 @@ class Paragraph extends AbstractStyle
             } elseif (substr($styleName, 0, 2) === 'HD') {
                 $styleAuto = true;
                 $psm = 'Heading_' . substr($styleName, 2);
-                $stylep = Style::getStyle($psm);
+                $stylep = $this->getGlobalStyle($psm);
                 if ($stylep instanceof Style\Font) {
                     if (method_exists($stylep, 'getParagraph')) {
                         $stylep = $stylep->getParagraph();

--- a/src/PhpWord/Writer/PDF/TCPDF.php
+++ b/src/PhpWord/Writer/PDF/TCPDF.php
@@ -71,7 +71,7 @@ class TCPDF extends AbstractRenderer implements WriterInterface
     protected function prepareToWrite(TCPDFBase $pdf): void
     {
         $pdf->AddPage();
-        $customStyles = Style::getStyles();
+        $customStyles = $this->getParentWriter()->getPhpWord()->getStyles();
         $normal = $customStyles['Normal'] ?? null;
         if ($normal instanceof Style\Paragraph) {
             $before = $normal->getSpaceBefore();

--- a/src/PhpWord/Writer/RTF/Element/AbstractElement.php
+++ b/src/PhpWord/Writer/RTF/Element/AbstractElement.php
@@ -106,7 +106,7 @@ abstract class AbstractElement
         if (method_exists($element, 'getFontStyle')) {
             $this->fontStyle = $element->getFontStyle();
             if (is_string($this->fontStyle)) {
-                $this->fontStyle = Style::getStyle($this->fontStyle);
+                $this->fontStyle = $parentWriter->getPhpWord()->getStyle($this->fontStyle);
             }
         }
 
@@ -114,7 +114,7 @@ abstract class AbstractElement
         if (method_exists($element, 'getParagraphStyle')) {
             $this->paragraphStyle = $element->getParagraphStyle();
             if (is_string($this->paragraphStyle)) {
-                $this->paragraphStyle = Style::getStyle($this->paragraphStyle);
+                $this->paragraphStyle = $parentWriter->getPhpWord()->getStyle($this->paragraphStyle);
             }
 
             if ($this->paragraphStyle !== null && !$this->withoutP) {

--- a/src/PhpWord/Writer/RTF/Element/Table.php
+++ b/src/PhpWord/Writer/RTF/Element/Table.php
@@ -88,7 +88,7 @@ class Table extends AbstractElement
         $content = '';
         $tableStyle = $this->element->getStyle();
         if (is_string($tableStyle)) {
-            $tableStyle = Style::getStyle($tableStyle);
+            $tableStyle = $this->element->getPhpWord()->getStyle($tableStyle);
             if (!($tableStyle instanceof TableStyle)) {
                 $tableStyle = null;
             }

--- a/src/PhpWord/Writer/RTF/Element/Title.php
+++ b/src/PhpWord/Writer/RTF/Element/Title.php
@@ -31,7 +31,7 @@ class Title extends Text
         $element = $this->element;
         $style = $element->getStyle();
         $style = str_replace('Heading', 'Heading_', $style ?? '');
-        $style = \PhpOffice\PhpWord\Style::getStyle($style);
+        $style = $element->getPhpWord()->getStyle($style);
         if ($style instanceof \PhpOffice\PhpWord\Style\Font) {
             $this->fontStyle = $style;
             $pstyle = $style->getParagraph();

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -190,7 +190,7 @@ class Header extends AbstractPart
         $this->fontTable[] = Settings::getDefaultFontName();
 
         // Search named styles
-        $styles = Style::getStyles();
+        $styles = $phpWord->getStyles();
         foreach ($styles as $style) {
             $this->registerFontItems($style);
         }

--- a/src/PhpWord/Writer/Word2007/Element/AbstractElement.php
+++ b/src/PhpWord/Writer/Word2007/Element/AbstractElement.php
@@ -185,7 +185,7 @@ abstract class AbstractElement
         $styleObject = $this->element->$method();
 
         /** @var \PhpOffice\PhpWord\Writer\Word2007\Style\AbstractStyle $styleWriter Type Hint */
-        $styleWriter = new $class($this->xmlWriter, $styleObject);
+        $styleWriter = new $class($this->xmlWriter, $styleObject, $this->element->getPhpWord());
         if (method_exists($styleWriter, 'setIsInline')) {
             $styleWriter->setIsInline(true);
         }

--- a/src/PhpWord/Writer/Word2007/Element/Image.php
+++ b/src/PhpWord/Writer/Word2007/Element/Image.php
@@ -72,7 +72,7 @@ class Image extends AbstractElement
         if ($position && $style->getWrap() == FrameStyle::WRAP_INLINE) {
             $fontStyle = new FontStyle('text');
             $fontStyle->setPosition($position);
-            $fontStyleWriter = new FontStyleWriter($xmlWriter, $fontStyle);
+            $fontStyleWriter = new FontStyleWriter($xmlWriter, $fontStyle, $element->getPhpWord());
             $fontStyleWriter->write();
         }
 

--- a/src/PhpWord/Writer/Word2007/Element/ListItem.php
+++ b/src/PhpWord/Writer/Word2007/Element/ListItem.php
@@ -40,7 +40,7 @@ class ListItem extends AbstractElement
 
         $textObject = $element->getTextObject();
 
-        $styleWriter = new ParagraphStyleWriter($xmlWriter, $textObject->getParagraphStyle());
+        $styleWriter = new ParagraphStyleWriter($xmlWriter, $textObject->getParagraphStyle(), $element->getPhpWord());
         $styleWriter->setWithoutPPR(true);
         $styleWriter->setIsInline(true);
 

--- a/src/PhpWord/Writer/Word2007/Element/ListItemRun.php
+++ b/src/PhpWord/Writer/Word2007/Element/ListItemRun.php
@@ -60,7 +60,7 @@ class ListItemRun extends AbstractElement
         $xmlWriter = $this->getXmlWriter();
         $xmlWriter->startElement('w:pPr');
 
-        $styleWriter = new ParagraphStyleWriter($xmlWriter, $element->getParagraphStyle());
+        $styleWriter = new ParagraphStyleWriter($xmlWriter, $element->getParagraphStyle(), $element->getPhpWord());
         $styleWriter->setIsInline(true);
         $styleWriter->setWithoutPPR(true);
         $styleWriter->write();

--- a/src/PhpWord/Writer/Word2007/Element/TOC.php
+++ b/src/PhpWord/Writer/Word2007/Element/TOC.php
@@ -90,7 +90,7 @@ class TOC extends AbstractElement
         // Title text
         $xmlWriter->startElement('w:r');
         if ($isObject) {
-            $styleWriter = new FontStyleWriter($xmlWriter, $fontStyle);
+            $styleWriter = new FontStyleWriter($xmlWriter, $fontStyle, $element->getPhpWord());
             $styleWriter->write();
         }
         $xmlWriter->startElement('w:t');
@@ -156,7 +156,7 @@ class TOC extends AbstractElement
 
         // Paragraph
         if ($isObject && null !== $fontStyle->getParagraph()) {
-            $styleWriter = new ParagraphStyleWriter($xmlWriter, $fontStyle->getParagraph());
+            $styleWriter = new ParagraphStyleWriter($xmlWriter, $fontStyle->getParagraph(), $element->getPhpWord());
             $styleWriter->write();
         }
 

--- a/src/PhpWord/Writer/Word2007/Part/Footnotes.php
+++ b/src/PhpWord/Writer/Word2007/Part/Footnotes.php
@@ -146,7 +146,7 @@ class Footnotes extends AbstractPart
         $xmlWriter->startElement('w:p');
 
         // Paragraph style
-        $styleWriter = new ParagraphStyleWriter($xmlWriter, $element->getParagraphStyle());
+        $styleWriter = new ParagraphStyleWriter($xmlWriter, $element->getParagraphStyle(), $element->getPhpWord());
         $styleWriter->setIsInline(true);
         $styleWriter->write();
 

--- a/src/PhpWord/Writer/Word2007/Part/Numbering.php
+++ b/src/PhpWord/Writer/Word2007/Part/Numbering.php
@@ -38,7 +38,7 @@ class Numbering extends AbstractPart
     public function write()
     {
         $xmlWriter = $this->getXmlWriter();
-        $styles = Style::getStyles();
+        $styles = $this->getParentWriter()->getPhpWord()->getStyles();
         $drawingSchema = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
 
         $xmlWriter->startDocument('1.0', 'UTF-8', 'yes');

--- a/src/PhpWord/Writer/Word2007/Part/Styles.php
+++ b/src/PhpWord/Writer/Word2007/Part/Styles.php
@@ -51,7 +51,7 @@ class Styles extends AbstractPart
         $xmlWriter->writeAttribute('xmlns:w', 'http://schemas.openxmlformats.org/wordprocessingml/2006/main');
 
         // Write default styles
-        $styles = Style::getStyles();
+        $styles = $this->getParentWriter()->getPhpWord()->getStyles();
         $this->writeDefaultStyles($xmlWriter, $styles);
 
         // Write styles
@@ -132,15 +132,15 @@ class Styles extends AbstractPart
             $normalStyle = $styles['Normal'];
             // w:pPr
             if ($normalStyle instanceof FontStyle && $normalStyle->getParagraph() != null) {
-                $styleWriter = new ParagraphStyleWriter($xmlWriter, $normalStyle->getParagraph());
+                $styleWriter = new ParagraphStyleWriter($xmlWriter, $normalStyle->getParagraph(), $phpWord);
                 $styleWriter->write();
             } elseif ($normalStyle instanceof ParagraphStyle) {
-                $styleWriter = new ParagraphStyleWriter($xmlWriter, $normalStyle);
+                $styleWriter = new ParagraphStyleWriter($xmlWriter, $normalStyle, $phpWord);
                 $styleWriter->write();
             }
 
             // w:rPr
-            $styleWriter = new FontStyleWriter($xmlWriter, $normalStyle);
+            $styleWriter = new FontStyleWriter($xmlWriter, $normalStyle, $phpWord);
             $styleWriter->write();
         }
         $xmlWriter->endElement(); // w:style
@@ -216,15 +216,17 @@ class Styles extends AbstractPart
                 $xmlWriter->writeElementBlock('w:basedOn', 'w:val', $paragraphStyle->getBasedOn());
             }
         }
+        
+        $phpWord = $this->getParentWriter()->getPhpWord();
 
         // w:pPr
         if (null !== $paragraphStyle) {
-            $styleWriter = new ParagraphStyleWriter($xmlWriter, $paragraphStyle);
+            $styleWriter = new ParagraphStyleWriter($xmlWriter, $paragraphStyle, $phpWord);
             $styleWriter->write();
         }
 
         // w:rPr
-        $styleWriter = new FontStyleWriter($xmlWriter, $style);
+        $styleWriter = new FontStyleWriter($xmlWriter, $style, $phpWord);
         $styleWriter->write();
 
         $xmlWriter->endElement();
@@ -254,7 +256,7 @@ class Styles extends AbstractPart
         $xmlWriter->writeElementIf(null !== $next, 'w:next', 'w:val', $next);
 
         // w:pPr
-        $styleWriter = new ParagraphStyleWriter($xmlWriter, $style);
+        $styleWriter = new ParagraphStyleWriter($xmlWriter, $style, $this->getParentWriter()->getPhpWord());
         $styleWriter->write();
 
         $xmlWriter->endElement();

--- a/src/PhpWord/Writer/Word2007/Style/AbstractStyle.php
+++ b/src/PhpWord/Writer/Word2007/Style/AbstractStyle.php
@@ -18,6 +18,7 @@
 
 namespace PhpOffice\PhpWord\Writer\Word2007\Style;
 
+use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\Shared\XMLWriter;
 
@@ -43,6 +44,13 @@ abstract class AbstractStyle
     protected $style;
 
     /**
+     * PhpWord object.
+     *
+     * @var ?PhpWord
+     */
+    private $phpWord;
+
+    /**
      * Write style.
      */
     abstract public function write();
@@ -52,10 +60,11 @@ abstract class AbstractStyle
      *
      * @param \PhpOffice\PhpWord\Style\AbstractStyle|string $style
      */
-    public function __construct(XMLWriter $xmlWriter, $style = null)
+    public function __construct(XMLWriter $xmlWriter, $style = null, ?PhpWord $phpWord = null)
     {
         $this->xmlWriter = $xmlWriter;
         $this->style = $style;
+        $this->phpWord = $phpWord;
     }
 
     /**
@@ -76,6 +85,22 @@ abstract class AbstractStyle
     protected function getStyle()
     {
         return $this->style;
+    }
+    
+    /**
+     * Get style by name.
+     *
+     * @param string $styleName
+     *
+     * @return ?AbstractStyle Paragraph|Font|Table|Numbering
+     */
+    protected function getGlobalStyle($styleName)
+    {
+        if (isset($this->phpWord)) {
+            return $this->phpWord->getStyle($styleName);
+        }
+
+        return \PhpOffice\Style::getStyle($styleName);
     }
 
     /**
@@ -116,7 +141,7 @@ abstract class AbstractStyle
             $class = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Style\\' . $name;
 
             /** @var AbstractStyle $writer */
-            $writer = new $class($xmlWriter, $value);
+            $writer = new $class($xmlWriter, $value, $this->phpWord);
             $writer->write();
         }
     }

--- a/src/PhpWord/Writer/Word2007/Style/AbstractStyle.php
+++ b/src/PhpWord/Writer/Word2007/Style/AbstractStyle.php
@@ -100,7 +100,7 @@ abstract class AbstractStyle
             return $this->phpWord->getStyle($styleName);
         }
 
-        return \PhpOffice\Style::getStyle($styleName);
+        return \PhpOffice\PhpWord\Style::getStyle($styleName);
     }
 
     /**

--- a/src/PhpWord/Writer/Word2007/Style/Font.php
+++ b/src/PhpWord/Writer/Word2007/Style/Font.php
@@ -45,7 +45,7 @@ class Font extends AbstractStyle
             $xmlWriter->startElement('w:rStyle');
             $xmlWriter->writeAttribute('w:val', $this->style);
             $xmlWriter->endElement();
-            $style = \PhpOffice\PhpWord\Style::getStyle($this->style);
+            $style = $this->getGlobalStyle($this->style);
             if ($style instanceof \PhpOffice\PhpWord\Style\Font) {
                 $xmlWriter->writeElementIf($style->isRTL(), 'w:rtl');
             }

--- a/src/PhpWord/Writer/Word2007/Style/Paragraph.php
+++ b/src/PhpWord/Writer/Word2007/Style/Paragraph.php
@@ -173,7 +173,7 @@ class Paragraph extends AbstractStyle
         $numLevel = $numbering['level'];
 
         /** @var Style\Numbering $numbering */
-        $numbering = Style::getStyle($numStyle);
+        $numbering = $this->getGlobalStyle($numStyle);
         if ($numStyle !== null && $numbering !== null) {
             $xmlWriter->startElement('w:numPr');
             $xmlWriter->startElement('w:numId');


### PR DESCRIPTION
Make styles to work as a instance property of PhpWord, and use Style::$styles as default values

Fixes https://github.com/PHPOffice/PHPWord/issues/2747

### Checklist:

- [ ] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [ ] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)
