### PR TITLE
Set writeAttribute return type

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+- Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
+
 ### Miscellaneous
 
 ### Deprecations

--- a/src/PhpWord/Shared/XMLWriter.php
+++ b/src/PhpWord/Shared/XMLWriter.php
@@ -19,7 +19,6 @@
 namespace PhpOffice\PhpWord\Shared;
 
 use Exception;
-use ReturnTypeWillChange;
 
 /**
  * XMLWriter.
@@ -173,11 +172,8 @@ class XMLWriter extends \XMLWriter
     /**
      * @param string $name
      * @param mixed $value
-     *
-     * @return bool
      */
-    #[ReturnTypeWillChange]
-    public function writeAttribute($name, $value)
+    public function writeAttribute($name, $value): bool
     {
         if (is_float($value)) {
             $value = json_encode($value);


### PR DESCRIPTION
### Description

Fixes #2204. Uses the `writeAttribute()` return type documented at https://www.php.net/manual/en/xmlwriter.writeattribute.php

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)

My CI is mostly green - it unrelatedly complains about loripsum.net being down - https://github.com/radarhere/PHPWord/actions/runs/14656574578
This specific method isn't mentioned in the docs.
Since https://github.com/PHPOffice/PHPWord/pull/2239 didn't seem to be significant enough for the changelog, I don't expect this is either.