### PR TITLE
Security fix for phpoffice/math

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
         "ext-zip": "*",
         "ext-json": "*",
         "ext-xml": "*",
-        "phpoffice/math": "^0.2"
+        "phpoffice/math": "^0.3"
     },
     "require-dev": {
         "ext-libxml": "*",

--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -32,6 +32,9 @@
 - Template Processor: Fix 0 considered as empty string by [@cavasinf](https://github.com/cavasinf), [@SnipsMine](https://github.com/SnipsMine) and [@Progi1984](https://github.com/Progi1984) fixing [#2572](https://github.com/PHPOffice/PHPWord/issues/2572), [#2703](https://github.com/PHPOffice/PHPWord/issues/2703) in [#2748](https://github.com/PHPOffice/PHPWord/pull/2748)
 - Word2007 Writer : Corrected generating TOC to fix page number missing issues [@jgiacomello](https://github.com/jgiacomello) in [#2556](https://github.com/PHPOffice/PHPWord/pull/2556)
 
+### Security fixes
+- Bump phpoffice/math from 0.2.0 to 0.3.0 by [@JonBaron78](https://github.com/JonBaron78) fixing [#2783](https://github.com/PHPOffice/PHPWord/issues/2783) in [#2782](https://github.com/PHPOffice/PHPWord/pull/2782)
+
 ### Miscellaneous
 
 - Bump dompdf/dompdf from 2.0.4 to 3.0.0 by [@dependabot](https://github.com/dependabot) fixing [#2621](https://github.com/PHPOffice/PHPWord/issues/2621) in [#2666](https://github.com/PHPOffice/PHPWord/pull/2666)


### PR DESCRIPTION
### Description
Fix for security issue on dependency phpoffice/math

Fixes #2783 

### Checklist:

- [ ] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)
