### PR TITLE
Reader HTML: Support configuring list styles

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -4,6 +4,8 @@
 
 ## Enhancements
 
+- Allow setting list style while reading HTML as input
+
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -608,9 +608,15 @@ class Html
      */
     protected static function getListStyle($isOrderedList)
     {
+        $type = $isOrderedList ? 'multilevel' : 'hybridMultilevel';
+
+        if (isset(self::$options['LIST_STYLES'][$type])) {
+            return self::$options['LIST_STYLES'][$type];
+        }
+
         if ($isOrderedList) {
             return [
-                'type' => 'multilevel',
+                'type' => $type,
                 'levels' => [
                     ['format' => NumberFormat::DECIMAL,      'text' => '%1.', 'alignment' => 'left',  'tabPos' => 720,  'left' => 720,  'hanging' => 360],
                     ['format' => NumberFormat::LOWER_LETTER, 'text' => '%2.', 'alignment' => 'left',  'tabPos' => 1440, 'left' => 1440, 'hanging' => 360],
@@ -626,7 +632,7 @@ class Html
         }
 
         return [
-            'type' => 'hybridMultilevel',
+            'type' => $type,
             'levels' => [
                 ['format' => NumberFormat::BULLET, 'text' => '•', 'alignment' => 'left', 'tabPos' => 720,  'left' => 720,  'hanging' => 360, 'font' => 'Symbol',      'hint' => 'default'],
                 ['format' => NumberFormat::BULLET, 'text' => '◦',  'alignment' => 'left', 'tabPos' => 1440, 'left' => 1440, 'hanging' => 360, 'font' => 'Courier New', 'hint' => 'default'],


### PR DESCRIPTION
### Description

While reading HTML, support specify list style options

Fixes # (issue)

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
