### PR TITLE
fix: loader temp footer and header loader

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -120,16 +120,9 @@ class TemplateProcessor
         // Temporary document content extraction
         $this->zipClass = new ZipArchive();
         $this->zipClass->open($this->tempDocumentFilename);
-        $index = 1;
-        while (false !== $this->zipClass->locateName($this->getHeaderName($index))) {
-            $this->tempDocumentHeaders[$index] = $this->readPartWithRels($this->getHeaderName($index));
-            ++$index;
-        }
-        $index = 1;
-        while (false !== $this->zipClass->locateName($this->getFooterName($index))) {
-            $this->tempDocumentFooters[$index] = $this->readPartWithRels($this->getFooterName($index));
-            ++$index;
-        }
+
+        $this->tempDocumentHeaders = $this->loadDocumentParts('word/header');
+        $this->tempDocumentFooters = $this->loadDocumentParts('word/footer');
 
         $this->tempDocumentMainPart = $this->readPartWithRels($this->getMainPartName());
         $this->tempDocumentSettingsPart = $this->readPartWithRels($this->getSettingsPartName());
@@ -1503,5 +1496,29 @@ class TemplateProcessor
     public function getTempDocumentFilename(): string
     {
         return $this->tempDocumentFilename;
+    }
+
+    /**
+     * Check existing files inside zip from prefix
+     *
+     * @param string $prefix
+     * @return array
+     */
+    private function loadDocumentParts(string $prefix): array
+    {
+        $parts = [];
+        $total = $this->zipClass->numFiles;
+
+        for ($i = 0; $i < $total; ++$i) {
+            $name = $this->zipClass->getNameIndex($i);
+
+            if (preg_match('#^' . preg_quote($prefix, '#') . '(\d+)\.xml$#', $name, $m)) {
+                $idx = (int) $m[1];
+                $parts[$idx] = $this->readPartWithRels($name);
+            }
+        }
+
+        ksort($parts);
+        return $parts;
     }
 }

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -1499,7 +1499,7 @@ class TemplateProcessor
     }
 
     /**
-     * Check existing files inside zip from prefix
+     * Check existing files inside zip from prefix.
      *
      * @param string $prefix
      * @return array

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -1500,9 +1500,6 @@ class TemplateProcessor
 
     /**
      * Check existing files inside zip from prefix.
-     *
-     * @param string $prefix
-     * @return array
      */
     private function loadDocumentParts(string $prefix): array
     {

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -1516,6 +1516,7 @@ class TemplateProcessor
         }
 
         ksort($parts);
+
         return $parts;
     }
 }


### PR DESCRIPTION
When a document starts its header or footer numbering at a value greater than 1, the library throws an error. It also fails when the indices are non-sequential—for example: `header2`, `header6`.

Fixes # (issue)

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered my new code with unit tests (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)

An example document exhibiting the problem is attached.
[documento_teste_error.docx](https://github.com/user-attachments/files/21146790/documento_teste_error.docx)
