### PR TITLE
Add TAB_LEADER to RTF

### DIFF
--- a/src/PhpWord/Writer/RTF/Element/TextBreak.php
+++ b/src/PhpWord/Writer/RTF/Element/TextBreak.php
@@ -36,6 +36,10 @@ class TextBreak extends AbstractElement
         $parentWriter = $this->parentWriter;
         $parentWriter->setLastParagraphStyle();
 
-        return '\pard\par' . PHP_EOL;
+        if ($this->withoutP) {
+            return '\line' . PHP_EOL;
+        } else {
+            return '\pard\par' . PHP_EOL;
+        }
     }
 }

--- a/src/PhpWord/Writer/RTF/Style/Tab.php
+++ b/src/PhpWord/Writer/RTF/Style/Tab.php
@@ -38,10 +38,18 @@ class Tab extends AbstractStyle
             \PhpOffice\PhpWord\Style\Tab::TAB_STOP_RIGHT => '\tqr',
             \PhpOffice\PhpWord\Style\Tab::TAB_STOP_CENTER => '\tqc',
             \PhpOffice\PhpWord\Style\Tab::TAB_STOP_DECIMAL => '\tqdec',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_DOT => '\tldot',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_HYPHEN => '\tlhyph',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_UNDERSCORE => '\tlul',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_HEAVY => '\tlth',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_MIDDLEDOT => '\tleq',
         ];
         $content = '';
         if (isset($tabs[$style->getType()])) {
             $content .= $tabs[$style->getType()];
+        }
+        if (isset($tabs[$style->getLeader()])) {
+            $content .= $tabs[$style->getLeader()];
         }
         $content .= '\tx' . round($style->getPosition());
 

--- a/src/PhpWord/Writer/RTF/Style/Tab.php
+++ b/src/PhpWord/Writer/RTF/Style/Tab.php
@@ -42,7 +42,7 @@ class Tab extends AbstractStyle
             \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_HYPHEN => '\tlhyph',
             \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_UNDERSCORE => '\tlul',
             \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_HEAVY => '\tlth',
-            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_MIDDLEDOT => '\tleq',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_MIDDLEDOT => '\tlmdot',
         ];
         $content = '';
         if (isset($tabs[$style->getType()])) {


### PR DESCRIPTION
### Description

Adds TAB_LEADER capability to RTF

### Checklist:

- [ ] Follows the specification found at https://web.archive.org/web/20190708132914/http://www.kleinlercher.at/tools/Windows_Protocols/Word2007RTFSpec9.pdf - pg. 83
