### PR TITLE
Various RTF Enhancements

### DIFF
--- a/src/PhpWord/Writer/RTF/Element/TextBreak.php
+++ b/src/PhpWord/Writer/RTF/Element/TextBreak.php
@@ -36,6 +36,10 @@ class TextBreak extends AbstractElement
         $parentWriter = $this->parentWriter;
         $parentWriter->setLastParagraphStyle();
 
-        return '\pard\par' . PHP_EOL;
+        if ($this->withoutP) {
+            return '\line' . PHP_EOL;
+        } else {
+            return '\pard\par' . PHP_EOL;
+        }
     }
 }

--- a/src/PhpWord/Writer/RTF/Style/Font.php
+++ b/src/PhpWord/Writer/RTF/Style/Font.php
@@ -109,7 +109,7 @@ class Font extends AbstractStyle
         // Paragraph not implemented.
         $content .= $this->getValueIf($style->isRTL(), '\rtlch');
         $content .= $this->getValueIf($style->getShading() !== null, '\chcfpat' . $this->colorIndex); // Doesn't work; coloring not implemented.
-        $content .= $this->getValueIf($style->getColor() !== null, '\lnag' . $this->langIndex); // Doesn't work; language not implemented.
+        $content .= $this->getValueIf($style->getLang() !== null, '\lang' . $this->langIndex); // Doesn't work; language not implemented.
         // Whitespace and fallbackFont are HTML specific
         
         // Other items not in included in array found in PhpOffice\PhpWord\Style\Font\getStyleValues

--- a/src/PhpWord/Writer/RTF/Style/Font.php
+++ b/src/PhpWord/Writer/RTF/Style/Font.php
@@ -115,6 +115,7 @@ class Font extends AbstractStyle
         // Other items not in included in array found in PhpOffice\PhpWord\Style\Font\getStyleValues
         $content .= $this->getValueIf($style->isNoProof(), '\noproof');
         $content .= $this->getValueIf($style->getBgColor() !== null, '\cb' . $this->colorIndex); // Doesn't work; coloring not implemented.
+        
         return $content . ' ';
     }
 

--- a/src/PhpWord/Writer/RTF/Style/Font.php
+++ b/src/PhpWord/Writer/RTF/Style/Font.php
@@ -38,6 +38,11 @@ class Font extends AbstractStyle
     private $colorIndex = 0;
 
     /**
+     * @var int Font lang index
+     */
+    private $langIndex = 0;
+
+    /**
      * Write style.
      *
      * @return string
@@ -50,20 +55,66 @@ class Font extends AbstractStyle
         }
 
         $content = '';
-        $content .= $this->getValueIf($style->isRTL(), '\rtlch');
-        $content .= '\cf' . $this->colorIndex;
+
+        // Font Name
         $content .= '\f' . $this->nameIndex;
 
-        $size = $style->getSize();
-        $content .= $this->getValueIf(is_numeric($size), '\fs' . round($size * 2));
+        // Basic - same order as array found in PhpOffice\PhpWord\Style\Font\getStyleValues
+        $content .= $this->getValueIf($style->getName() !== null, '\f' . $this->nameIndex); // Doesn't work; fonts not implemented.
+        $content .= $this->getValueIf($style->getSize() !== null, '\fs' . round($style->getSize() * 2));
+        $content .= $this->getValueIf($style->getColor() !== null, '\cf' . $this->colorIndex); // Doesn't work; coloring not implemented.
+        // Hint (font content type) not implemented.
 
+        // Underline Keywords
+        $underlines = [
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_DASH => '\uldash',
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_DASHHEAVY => '\ulth',
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_DASHLONG => '\ulldash',
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_DASHLONGHEAVY => '\ulthldash',
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_DOUBLE => '\uldb',
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_DOTDASH => '\uldashd',
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_DOTDASHHEAVY => '\ulthdashd',
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_DOTDOTDASH => '\uldashdd',
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_DOTDOTDASHHEAVY => '\ulthdashdd',
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_DOTTED => '\uld',
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_DOTTEDHEAVY => '\ulthd',
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_HEAVY => '\ulth',
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_SINGLE => '\ul',
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_WAVY => '\ulwave',
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_WAVYDOUBLE => '\ululdbwave',
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_WAVYHEAVY => '\ulhwave',
+            \PhpOffice\PhpWord\Style\Font::UNDERLINE_WORDS => '\ulw',
+        ];
+
+        // Style - same order as array found in PhpOffice\PhpWord\Style\Font\getStyleValues
         $content .= $this->getValueIf($style->isBold(), '\b');
         $content .= $this->getValueIf($style->isItalic(), '\i');
-        $content .= $this->getValueIf($style->getUnderline() != FontStyle::UNDERLINE_NONE, '\ul');
+        if (isset($underlines[$style->getUnderline()])) { $content .= $underlines[$style->getUnderline()]; }
         $content .= $this->getValueIf($style->isStrikethrough(), '\strike');
+        $content .= $this->getValueIf($style->isDoubleStrikethrough(), '\striked1');
         $content .= $this->getValueIf($style->isSuperScript(), '\super');
         $content .= $this->getValueIf($style->isSubScript(), '\sub');
+        $content .= $this->getValueIf($style->isSmallCaps(), '\scaps');
+        $content .= $this->getValueIf($style->isAllCaps(), '\caps');
+        $content .= $this->getValueIf($style->getFgColor() !== null, '\highlight' . $this->colorIndex); // Doesn't work; coloring not implemented.
+        $content .= $this->getValueIf($style->isHidden(), '\v');
 
+        // Spacing - same order as array found in PhpOffice\PhpWord\Style\Font\getStyleValues
+        $content .= $this->getValueIf($style->getScale() !== null, '\charscalex' . $style->getScale());
+        $content .= $this->getValueIf($style->getSpacing() !== null, '\expnd' . $style->getSpacing());
+        $content .= $this->getValueIf($style->getKerning() !== null, '\kerning' . $style->getKerning() * 2);
+        $content .= $this->getValueIf($style->getPosition() !== null, '\up' . $style->getPosition());
+
+        // General - same order as array found in PhpOffice\PhpWord\Style\Font\getStyleValues
+        // Paragraph not implemented.
+        $content .= $this->getValueIf($style->isRTL(), '\rtlch');
+        $content .= $this->getValueIf($style->getShading() !== null, '\chcfpat' . $this->colorIndex); // Doesn't work; coloring not implemented.
+        $content .= $this->getValueIf($style->getColor() !== null, '\lnag' . $this->langIndex); // Doesn't work; language not implemented.
+        // Whitespace and fallbackFont are HTML specific
+        
+        // Other items not in included in array found in PhpOffice\PhpWord\Style\Font\getStyleValues
+        $content .= $this->getValueIf($style->isNoProof(), '\noproof');
+        $content .= $this->getValueIf($style->getBgColor() !== null, '\cb' . $this->colorIndex); // Doesn't work; coloring not implemented.
         return $content . ' ';
     }
 
@@ -85,5 +136,14 @@ class Font extends AbstractStyle
     public function setColorIndex($value = 0): void
     {
         $this->colorIndex = $value;
+    }
+    /**
+     * Set font lang index.
+     *
+     * @param int $value
+     */
+    public function setLangIndex($value = 0): void
+    {
+        $this->langIndex = $value;
     }
 }

--- a/src/PhpWord/Writer/RTF/Style/Section.php
+++ b/src/PhpWord/Writer/RTF/Style/Section.php
@@ -55,6 +55,15 @@ class Section extends AbstractStyle
         $content .= $this->getValueIf($style->getFooterHeight() !== null, '\footery' . round($style->getFooterHeight()));
         $content .= $this->getValueIf($style->getGutter() !== null, '\guttersxn' . round($style->getGutter()));
         $content .= $this->getValueIf($style->getPageNumberingStart() !== null, '\pgnstarts' . $style->getPageNumberingStart() . '\pgnrestart');
+
+        // Vertical Align
+        $verticalAlign = [
+            \PhpOffice\PhpWord\SimpleType\VerticalJc::TOP => '\vertalt',
+            \PhpOffice\PhpWord\SimpleType\VerticalJc::CENTER => '\vertalc',
+            \PhpOffice\PhpWord\SimpleType\VerticalJc::BOTH => '\vertalj',
+            \PhpOffice\PhpWord\SimpleType\VerticalJc::BOTTOM => '\vertalb',
+        ];
+        if (isset($verticalAlign[$style->getVAlign()])) { $content .= $verticalAlign[$style->getVAlign()]; }
         $content .= ' ';
 
         // Borders

--- a/src/PhpWord/Writer/RTF/Style/Tab.php
+++ b/src/PhpWord/Writer/RTF/Style/Tab.php
@@ -38,10 +38,18 @@ class Tab extends AbstractStyle
             \PhpOffice\PhpWord\Style\Tab::TAB_STOP_RIGHT => '\tqr',
             \PhpOffice\PhpWord\Style\Tab::TAB_STOP_CENTER => '\tqc',
             \PhpOffice\PhpWord\Style\Tab::TAB_STOP_DECIMAL => '\tqdec',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_DOT => '\tldot',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_HYPHEN => '\tlhyph',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_UNDERSCORE => '\tlul',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_HEAVY => '\tlth',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_MIDDLEDOT => '\tleq',
         ];
         $content = '';
         if (isset($tabs[$style->getType()])) {
             $content .= $tabs[$style->getType()];
+        }
+        if (isset($tabs[$style->getLeader()])) {
+            $content .= $tabs[$style->getLeader()];
         }
         $content .= '\tx' . round($style->getPosition());
 

--- a/src/PhpWord/Writer/RTF/Style/Tab.php
+++ b/src/PhpWord/Writer/RTF/Style/Tab.php
@@ -42,7 +42,7 @@ class Tab extends AbstractStyle
             \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_HYPHEN => '\tlhyph',
             \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_UNDERSCORE => '\tlul',
             \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_HEAVY => '\tlth',
-            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_MIDDLEDOT => '\tleq',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_MIDDLEDOT => '\tlmdot',
         ];
         $content = '';
         if (isset($tabs[$style->getType()])) {

--- a/src/PhpWord/Writer/RTF/Style/Tab.php
+++ b/src/PhpWord/Writer/RTF/Style/Tab.php
@@ -51,8 +51,11 @@ class Tab extends AbstractStyle
         if (isset($tabs[$style->getLeader()])) {
             $content .= $tabs[$style->getLeader()];
         }
-        $content .= '\tx' . round($style->getPosition());
-
+        if ($style->getType() == \PhpOffice\PhpWord\Style\Tab::TAB_STOP_BAR) {
+            $content .= '\tb' . round($style->getPosition());
+        } else {
+            $content .= '\tx' . round($style->getPosition());
+        }
         return $content;
     }
 }


### PR DESCRIPTION
### Description

Adds RTF features, including many missing font settings, missing tab stop settings, vertical align, and fixes an error with textBreak inside a textRun (line return, but not new paragraph).

### More detailed information
TextBreak - returns \line when not a paragraph return.
Font - adds support for various underlines, smallcaps, allcaps, hidden, scale, spacing, kerning, position, and noproof. Support for color, fgcolor, bgcolor, shading, and lang not implemented, but placeholder code written for future work.
Section - adds support for vertical align.
Tab - adds support for tabLeader, as well as support for tabBar.