### PR TITLE
RTF Writer: Tab - Add Missing Features

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
+- Writer RTF: Support for type 'bar' and leaders in Tab by [@rasamassen](https://github.com/rasamassen) in [#2815](https://github.com/PHPOffice/PHPWord/pull/2815)
 
 ### Miscellaneous
 

--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -7,7 +7,7 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
-- Writer RTF: Support for type 'bar' and leaders in Tab by [@rasamassen](https://github.com/rasamassen) in [#2815](https://github.com/PHPOffice/PHPWord/pull/2815)
+- Writer RTF: Support for type 'bar' and leaders in Tab by [@rasamassen](https://github.com/rasamassen) in [#2815](https://github.com/PHPOffice/PHPWord/pull/2815), partially fixing [#862](https://github.com/PHPOffice/PHPWord/issues/862)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Writer/RTF/Style/Tab.php
+++ b/src/PhpWord/Writer/RTF/Style/Tab.php
@@ -38,12 +38,24 @@ class Tab extends AbstractStyle
             \PhpOffice\PhpWord\Style\Tab::TAB_STOP_RIGHT => '\tqr',
             \PhpOffice\PhpWord\Style\Tab::TAB_STOP_CENTER => '\tqc',
             \PhpOffice\PhpWord\Style\Tab::TAB_STOP_DECIMAL => '\tqdec',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_DOT => '\tldot',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_HYPHEN => '\tlhyph',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_UNDERSCORE => '\tlul',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_HEAVY => '\tlth',
+            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_MIDDLEDOT => '\tlmdot',
         ];
         $content = '';
         if (isset($tabs[$style->getType()])) {
             $content .= $tabs[$style->getType()];
         }
-        $content .= '\tx' . round($style->getPosition());
+        if (isset($tabs[$style->getLeader()])) {
+            $content .= $tabs[$style->getLeader()];
+        }
+        if ($style->getType() == \PhpOffice\PhpWord\Style\Tab::TAB_STOP_BAR) {
+            $content .= '\tb' . round($style->getPosition());
+        } else {
+            $content .= '\tx' . round($style->getPosition());
+        }
 
         return $content;
     }

--- a/src/PhpWord/Writer/RTF/Style/Tab.php
+++ b/src/PhpWord/Writer/RTF/Style/Tab.php
@@ -18,6 +18,8 @@
 
 namespace PhpOffice\PhpWord\Writer\RTF\Style;
 
+use PhpOffice\PhpWord\Style\Tab as TabStyle;
+
 /**
  * Line numbering style writer.
  *
@@ -31,27 +33,27 @@ class Tab extends AbstractStyle
     public function write()
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Tab) {
+        if (!$style instanceof TabStyle) {
             return;
         }
         $tabs = [
-            \PhpOffice\PhpWord\Style\Tab::TAB_STOP_RIGHT => '\tqr',
-            \PhpOffice\PhpWord\Style\Tab::TAB_STOP_CENTER => '\tqc',
-            \PhpOffice\PhpWord\Style\Tab::TAB_STOP_DECIMAL => '\tqdec',
-            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_DOT => '\tldot',
-            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_HYPHEN => '\tlhyph',
-            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_UNDERSCORE => '\tlul',
-            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_HEAVY => '\tlth',
-            \PhpOffice\PhpWord\Style\Tab::TAB_LEADER_MIDDLEDOT => '\tlmdot',
+            TabStyle::TAB_STOP_RIGHT => '\tqr',
+            TabStyle::TAB_STOP_CENTER => '\tqc',
+            TabStyle::TAB_STOP_DECIMAL => '\tqdec',
+            TabStyle::TAB_LEADER_DOT => '\tldot',
+            TabStyle::TAB_LEADER_HYPHEN => '\tlhyph',
+            TabStyle::TAB_LEADER_UNDERSCORE => '\tlul',
+            TabStyle::TAB_LEADER_HEAVY => '\tlth',
+            TabStyle::TAB_LEADER_MIDDLEDOT => '\tlmdot',
         ];
         $content = '';
         if (isset($tabs[$style->getType()])) {
             $content .= $tabs[$style->getType()];
         }
-        if (isset($tabs[$style->getLeader()])) {
+        if (isset($tabs[$style->getLeader()]) && $style->getType() != TabStyle::TAB_STOP_BAR) {
             $content .= $tabs[$style->getLeader()];
         }
-        if ($style->getType() == \PhpOffice\PhpWord\Style\Tab::TAB_STOP_BAR) {
+        if ($style->getType() == TabStyle::TAB_STOP_BAR) {
             $content .= '\tb' . round($style->getPosition());
         } else {
             $content .= '\tx' . round($style->getPosition());

--- a/tests/PhpWordTests/Writer/RTF/Style/TabTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Style/TabTest.php
@@ -60,7 +60,7 @@ class TabTest extends TestCase
         self::assertEquals($expect, $this->removeCr($writer));
 
         $style->setType(TabStyle::TAB_STOP_CENTER);
-        $expect = '\tcq\tx3000';
+        $expect = '\tqc\tx3000';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $style->setType(TabStyle::TAB_STOP_RIGHT);

--- a/tests/PhpWordTests/Writer/RTF/Style/TabTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Style/TabTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWordTests\Writer\RTF\Style;
+
+use PhpOffice\PhpWord\Settings;
+use PhpOffice\PhpWord\Style\Tab as TabStyle;
+use PhpOffice\PhpWord\Writer\RTF;
+use PhpOffice\PhpWord\Writer\RTF\Style\Tab as TabWriter;
+use PHPUnit\Framework\TestCase;
+
+class TabTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Settings::setDefaultRtl(null);
+    }
+
+    /**
+     * @param TabWriter $field
+     */
+    public function removeCr($field): string
+    {
+        return str_replace("\r\n", "\n", $field->write());
+    }
+
+    /**
+     * Test tab stops.
+     * See page 83 of RTF Specification 1.9.1 for Tabs.
+     */
+    public function testTabStop(): void
+    {
+        $parentWriter = new RTF();
+        $style = new TabStyle();
+        $writer = new TabWriter($style);
+        $writer->setParentWriter($parentWriter);
+
+        $style->setPosition(3000);
+        $style->setType($style::TAB_STOP_CLEAR);
+        $expect = '\tx3000';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setType(TabStyle::TAB_STOP_LEFT);
+        $expect = '\tx3000';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setType(TabStyle::TAB_STOP_CENTER);
+        $expect = '\tcq\tx3000';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setType(TabStyle::TAB_STOP_RIGHT);
+        $expect = '\tqr\tx3000';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setType(TabStyle::TAB_STOP_DECIMAL);
+        $expect = '\tqdec\tx3000';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setType(TabStyle::TAB_STOP_BAR);
+        $expect = '\tb3000';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setType(TabStyle::TAB_STOP_NUM); // No equivalent specified in RTF
+        $expect = '\tx3000';
+        self::assertEquals($expect, $this->removeCr($writer));
+    }
+
+    /**
+     * Test tab leaders.
+     * See page 83 of RTF Specification 1.9.1 for Formatting.
+     */
+    public function testTabLeader(): void
+    {
+        $parentWriter = new RTF();
+        $style = new TabStyle();
+        $writer = new TabWriter($style);
+        $writer->setParentWriter($parentWriter);
+
+        $style->setPosition(600);
+        $style->setLeader(TabStyle::TAB_LEADER_NONE);
+        $expect = '\tx600';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setLeader(TabStyle::TAB_LEADER_DOT);
+        $expect = '\tldot\tx600';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setLeader(TabStyle::TAB_LEADER_HYPHEN);
+        $expect = '\tlhyph\tx600';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setLeader(TabStyle::TAB_LEADER_UNDERSCORE);
+        $expect = '\tlul\tx600';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setLeader(TabStyle::TAB_LEADER_HEAVY);
+        $expect = '\tlth\tx600';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setLeader(TabStyle::TAB_LEADER_MIDDLEDOT);
+        $expect = '\tlmdot\tx600';
+        self::assertEquals($expect, $this->removeCr($writer));
+    }
+}

--- a/tests/PhpWordTests/Writer/RTF/Style/TabTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Style/TabTest.php
@@ -82,7 +82,7 @@ class TabTest extends TestCase
 
     /**
      * Test tab leaders.
-     * See page 83 of RTF Specification 1.9.1 for Formatting.
+     * See page 83 of RTF Specification 1.9.1 for Tabs.
      */
     public function testTabLeader(): void
     {

--- a/tests/PhpWordTests/Writer/RTF/StyleTest.php
+++ b/tests/PhpWordTests/Writer/RTF/StyleTest.php
@@ -84,43 +84,6 @@ class StyleTest extends \PHPUnit\Framework\TestCase
         Assert::assertEquals('\fi3\li1\ri2 ', $result);
     }
 
-    public function testRightTab(): void
-    {
-        $tabRight = new \PhpOffice\PhpWord\Style\Tab();
-        $tabRight->setType(\PhpOffice\PhpWord\Style\Tab::TAB_STOP_RIGHT);
-        $tabRight->setPosition(5);
-
-        $tabWriter = new RTF\Style\Tab($tabRight);
-        $tabWriter->setParentWriter(new RTF());
-        $result = $tabWriter->write();
-
-        Assert::assertEquals('\tqr\tx5', $result);
-    }
-
-    public function testCenterTab(): void
-    {
-        $tabRight = new \PhpOffice\PhpWord\Style\Tab();
-        $tabRight->setType(\PhpOffice\PhpWord\Style\Tab::TAB_STOP_CENTER);
-
-        $tabWriter = new RTF\Style\Tab($tabRight);
-        $tabWriter->setParentWriter(new RTF());
-        $result = $tabWriter->write();
-
-        Assert::assertEquals('\tqc\tx0', $result);
-    }
-
-    public function testDecimalTab(): void
-    {
-        $tabRight = new \PhpOffice\PhpWord\Style\Tab();
-        $tabRight->setType(\PhpOffice\PhpWord\Style\Tab::TAB_STOP_DECIMAL);
-
-        $tabWriter = new RTF\Style\Tab($tabRight);
-        $tabWriter->setParentWriter(new RTF());
-        $result = $tabWriter->write();
-
-        Assert::assertEquals('\tqdec\tx0', $result);
-    }
-
     public function testRTL(): void
     {
         $parentWriter = new RTF();


### PR DESCRIPTION
Implement all Tab features.

### Description

Add TAB_STOP_BAR and all TAB_LEADER options to RTF

Partial fixes #862

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
