### PR TITLE
RTF Writer: Textbreak - Fix to work for linebreaks

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
+- Writer RTF: Fix paragraph return when it should be line return in TextBreak by [@rasamassen](https://github.com/rasamassen) in [#2816](https://github.com/PHPOffice/PHPWord/pull/2816)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Writer/RTF/Element/TextBreak.php
+++ b/src/PhpWord/Writer/RTF/Element/TextBreak.php
@@ -38,8 +38,8 @@ class TextBreak extends AbstractElement
 
         if ($this->withoutP) {
             return '\line' . PHP_EOL;
-        } else {
-            return '\pard\par' . PHP_EOL;
         }
+        
+        return '\pard\par' . PHP_EOL;
     }
 }

--- a/src/PhpWord/Writer/RTF/Element/TextBreak.php
+++ b/src/PhpWord/Writer/RTF/Element/TextBreak.php
@@ -39,7 +39,7 @@ class TextBreak extends AbstractElement
         if ($this->withoutP) {
             return '\line' . PHP_EOL;
         }
-        
+
         return '\pard\par' . PHP_EOL;
     }
 }

--- a/src/PhpWord/Writer/RTF/Element/TextBreak.php
+++ b/src/PhpWord/Writer/RTF/Element/TextBreak.php
@@ -36,6 +36,10 @@ class TextBreak extends AbstractElement
         $parentWriter = $this->parentWriter;
         $parentWriter->setLastParagraphStyle();
 
-        return '\pard\par' . PHP_EOL;
+        if ($this->withoutP) {
+            return '\line' . PHP_EOL;
+        } else {
+            return '\pard\par' . PHP_EOL;
+        }
     }
 }

--- a/tests/PhpWordTests/Writer/RTF/Element/TextBreakTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Element/TextBreakTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWordTests\Writer\RTF\Element;
+
+use PhpOffice\PhpWord\Element\TextBreak as TextBreakElement;
+use PhpOffice\PhpWord\Settings;
+use PhpOffice\PhpWord\Writer\RTF;
+use PhpOffice\PhpWord\Writer\RTF\Element\TextBreak as TextBreakWriter;
+use PHPUnit\Framework\TestCase;
+
+class TextBreakTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Settings::setDefaultRtl(null);
+    }
+    
+    public function removeCr($field)
+    {
+        return str_replace("\r\n", "\n", $field->write());
+    }
+    
+    public function testTextBreakParagraph(): void
+    {
+        $parentWriter = new RTF();
+        $element = new TextBreakElement();
+        $writer = new TextBreakWriter($parentWriter, $element);
+        $expect = "\\pard\\par\n";
+        self::assertEquals($expect, $this->removeCr($writer));
+    }
+
+}

--- a/tests/PhpWordTests/Writer/RTF/Element/TextBreakTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Element/TextBreakTest.php
@@ -41,6 +41,7 @@ class TextBreakTest extends TestCase
 
     /**
      * Test a normal textBreak.
+     * See page 142-143 of RTF Specification 1.9.1.
      */
     public function testTextBreakParagraph(): void
     {
@@ -53,6 +54,7 @@ class TextBreakTest extends TestCase
 
     /**
      * Test a textBreak as a line break.
+     * See page 142-143 of RTF Specification 1.9.1.
      */
     public function testTextBreakLine(): void
     {

--- a/tests/PhpWordTests/Writer/RTF/Element/TextBreakTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Element/TextBreakTest.php
@@ -40,7 +40,7 @@ class TextBreakTest extends TestCase
     }
 
     /**
-     * Test a normal textBreak
+     * Test a normal textBreak.
      */
     public function testTextBreakParagraph(): void
     {
@@ -52,7 +52,7 @@ class TextBreakTest extends TestCase
     }
 
     /**
-     * Test a textBreak with two paragraph breaks
+     * Test a textBreak with two paragraph breaks.
      */
     public function testTextBreakTwoParagraphs(): void
     {
@@ -64,7 +64,7 @@ class TextBreakTest extends TestCase
     }
 
     /**
-     * Test a textBreak as a line break
+     * Test a textBreak as a line break.
      */
     public function testTextBreakLine(): void
     {

--- a/tests/PhpWordTests/Writer/RTF/Element/TextBreakTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Element/TextBreakTest.php
@@ -52,18 +52,6 @@ class TextBreakTest extends TestCase
     }
 
     /**
-     * Test a textBreak with two paragraph breaks.
-     */
-    public function testTextBreakTwoParagraphs(): void
-    {
-        $parentWriter = new RTF();
-        $element = new TextBreakElement(2);
-        $writer = new TextBreakWriter($parentWriter, $element);
-        $expect = "\\pard\\par\n\\pard\\par\n";
-        self::assertEquals($expect, $this->removeCr($writer));
-    }
-
-    /**
      * Test a textBreak as a line break.
      */
     public function testTextBreakLine(): void

--- a/tests/PhpWordTests/Writer/RTF/Element/TextBreakTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Element/TextBreakTest.php
@@ -30,12 +30,15 @@ class TextBreakTest extends TestCase
     {
         Settings::setDefaultRtl(null);
     }
-    
-    public function removeCr($field)
+
+    /**
+     * @param TextBreakWriter $field
+     */    
+    public function removeCr($field): string
     {
         return str_replace("\r\n", "\n", $field->write());
     }
-    
+
     public function testTextBreakParagraph(): void
     {
         $parentWriter = new RTF();
@@ -44,5 +47,4 @@ class TextBreakTest extends TestCase
         $expect = "\\pard\\par\n";
         self::assertEquals($expect, $this->removeCr($writer));
     }
-
 }

--- a/tests/PhpWordTests/Writer/RTF/Element/TextBreakTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Element/TextBreakTest.php
@@ -33,18 +33,45 @@ class TextBreakTest extends TestCase
 
     /**
      * @param TextBreakWriter $field
-     */    
+     */
     public function removeCr($field): string
     {
         return str_replace("\r\n", "\n", $field->write());
     }
 
+    /**
+     * Test a normal textBreak
+     */
     public function testTextBreakParagraph(): void
     {
         $parentWriter = new RTF();
         $element = new TextBreakElement();
         $writer = new TextBreakWriter($parentWriter, $element);
         $expect = "\\pard\\par\n";
+        self::assertEquals($expect, $this->removeCr($writer));
+    }
+
+    /**
+     * Test a textBreak with two paragraph breaks
+     */
+    public function testTextBreakTwoParagraphs(): void
+    {
+        $parentWriter = new RTF();
+        $element = new TextBreakElement(2);
+        $writer = new TextBreakWriter($parentWriter, $element);
+        $expect = "\\pard\\par\n\\pard\\par\n";
+        self::assertEquals($expect, $this->removeCr($writer));
+    }
+
+    /**
+     * Test a textBreak as a line break
+     */
+    public function testTextBreakLine(): void
+    {
+        $parentWriter = new RTF();
+        $element = new TextBreakElement();
+        $writer = new TextBreakWriter($parentWriter, $element, true);
+        $expect = "\\line\n";
         self::assertEquals($expect, $this->removeCr($writer));
     }
 }


### PR DESCRIPTION
Returns line return instead of paragraph return on textrun, footnote, and endnote.

### Description

TextBreak was always creating a new paragraph, even when it should have just been making a line break.

Fixes # (issue)

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
