### PR TITLE
RTF Writer: Section - Add verticalAlign

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
+- Writer RTF: Support for verticalAlign in Section by [@rasamassen](https://github.com/rasamassen) in [#2817](https://github.com/PHPOffice/PHPWord/pull/2817)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Writer/RTF/Style/Section.php
+++ b/src/PhpWord/Writer/RTF/Style/Section.php
@@ -55,6 +55,17 @@ class Section extends AbstractStyle
         $content .= $this->getValueIf($style->getFooterHeight() !== null, '\footery' . round($style->getFooterHeight()));
         $content .= $this->getValueIf($style->getGutter() !== null, '\guttersxn' . round($style->getGutter()));
         $content .= $this->getValueIf($style->getPageNumberingStart() !== null, '\pgnstarts' . $style->getPageNumberingStart() . '\pgnrestart');
+ 
+        // Vertical Align
+        $verticalAlign = [
+            \PhpOffice\PhpWord\SimpleType\VerticalJc::TOP => '\vertalt',
+            \PhpOffice\PhpWord\SimpleType\VerticalJc::CENTER => '\vertalc',
+            \PhpOffice\PhpWord\SimpleType\VerticalJc::BOTH => '\vertalj',
+            \PhpOffice\PhpWord\SimpleType\VerticalJc::BOTTOM => '\vertalb',
+        ];
+        if (isset($verticalAlign[$style->getVAlign()])) {
+            $content .= $verticalAlign[$style->getVAlign()];
+        }
         $content .= ' ';
 
         // Borders

--- a/src/PhpWord/Writer/RTF/Style/Section.php
+++ b/src/PhpWord/Writer/RTF/Style/Section.php
@@ -55,7 +55,7 @@ class Section extends AbstractStyle
         $content .= $this->getValueIf($style->getFooterHeight() !== null, '\footery' . round($style->getFooterHeight()));
         $content .= $this->getValueIf($style->getGutter() !== null, '\guttersxn' . round($style->getGutter()));
         $content .= $this->getValueIf($style->getPageNumberingStart() !== null, '\pgnstarts' . $style->getPageNumberingStart() . '\pgnrestart');
- 
+
         // Vertical Align
         $verticalAlign = [
             \PhpOffice\PhpWord\SimpleType\VerticalJc::TOP => '\vertalt',


### PR DESCRIPTION
Adds missing verticalAlign settings.

### Description

Vertical align wasn't implemented.

Fixes # (issue)

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
