### PR TITLE
RTF Writer: Fix Header.php registerFont() not registering fonts/colors in subElements (such as textRuns)

### DIFF
--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -201,14 +201,14 @@ class Header extends AbstractPart
             $elements = $section->getElements();
             $this->registerBorderColor($section->getStyle());
             foreach ($elements as $element) {
-                if (method_exists($element, 'getFontStyle')) {
-                    $style = (object)$element->getFontStyle();
+                if (is_object($element) && method_exists($element, 'getFontStyle')) {
+                    $style = $element->getFontStyle();
                     $this->registerFontItems($style);
-                } elseif (method_exists($element, 'getElements')) {
+                } elseif (is_object($element) && method_exists($element, 'getElements')) {
                     $subElements = $element->getElements();
                     foreach ($subElements as $subElement) {
-                        if (method_exists($subElement, 'getFontStyle')) {
-                            $style = (object)$subElement->getFontStyle();
+                        if (is_object($subElement) && method_exists($subElement, 'getFontStyle')) {
+                            $style = $subElement->getFontStyle();
                             $this->registerFontItems($style);
                         }
                     }

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -204,6 +204,14 @@ class Header extends AbstractPart
                 if (method_exists($element, 'getFontStyle')) {
                     $style = $element->getFontStyle();
                     $this->registerFontItems($style);
+                } elseif (method_exists($element, 'getElements')) { 
+                    $textRuns = $element->getElements();
+                    foreach ($textRuns as $textRun) {
+                        if (method_exists($textRun, 'getFontStyle')) {
+                            $style = $textRun->getFontStyle();
+                            $this->registerFontItems($style);
+                        }
+                    }
                 }
             }
         }

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -204,7 +204,7 @@ class Header extends AbstractPart
                 if (method_exists($element, 'getFontStyle')) {
                     $style = $element->getFontStyle();
                     $this->registerFontItems($style);
-                } elseif (method_exists($element, 'getElements')) { 
+                } elseif (method_exists($element, 'getElements')) {
                     $textRuns = $element->getElements();
                     foreach ($textRuns as $textRun) {
                         if (method_exists($textRun, 'getFontStyle')) {

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -202,13 +202,13 @@ class Header extends AbstractPart
             $this->registerBorderColor($section->getStyle());
             foreach ($elements as $element) {
                 if (method_exists($element, 'getFontStyle')) {
-                    $style = $element->getFontStyle();
+                    $style = (object)$element->getFontStyle();
                     $this->registerFontItems($style);
                 } elseif (method_exists($element, 'getElements')) {
-                    $textRuns = $element->getElements();
-                    foreach ($textRuns as $textRun) {
-                        if (method_exists($textRun, 'getFontStyle')) {
-                            $style = $textRun->getFontStyle();
+                    $subElements = $element->getElements();
+                    foreach ($subElements as $subElement) {
+                        if (method_exists($subElement, 'getFontStyle')) {
+                            $style = (object)$subElement->getFontStyle();
                             $this->registerFontItems($style);
                         }
                     }


### PR DESCRIPTION
registerFont() registered fonts and colors from sections, but not from subparts of sections, such as textruns.

### Description

Now the header registers every font and color in a textRun. This is important if the fonts and colors are actually going to be used.

Fixes # (issue)

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
