### PR TITLE
RTF Writer: List item - Implement

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
+- Writer RTF: Support listItem, including listTable by [@rasamassen](https://github.com/rasamassen) in [#2821](https://github.com/PHPOffice/PHPWord/pull/2821), fixing [#1106](https://github.com/PHPOffice/PHPWord/issues/1106)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Escaper/Rtf.php
+++ b/src/PhpWord/Escaper/Rtf.php
@@ -43,7 +43,7 @@ class Rtf extends AbstractEscaper
     protected function escapeMultibyteCharacter($code)
     {
         if ($code > 32767) {
-            return '\\uc0\\u' . $code - 65536 . ' ';
+            return '\\uc0\\u' . ((int) $code - 65536) . ' ';
         }
 
         return '\\uc0\\u' . $code . ' ';

--- a/src/PhpWord/Escaper/Rtf.php
+++ b/src/PhpWord/Escaper/Rtf.php
@@ -42,7 +42,11 @@ class Rtf extends AbstractEscaper
 
     protected function escapeMultibyteCharacter($code)
     {
-        return '\\uc0{\\u' . $code . '}';
+        if ($code > 32767) {
+            return '\\uc0\\u' . $code - 65536 . ' ';
+        }
+
+        return '\\uc0\\u' . $code . ' ';
     }
 
     /**

--- a/src/PhpWord/Style/ListItem.php
+++ b/src/PhpWord/Style/ListItem.php
@@ -116,6 +116,21 @@ class ListItem extends AbstractStyle
     }
 
     /**
+     * Get numbering style.
+     *
+     * @return ?NumberingStyle
+     */
+    public function getNumberingStyle()
+    {
+        $numStyleObject = Style::getStyle($this->numStyle);
+        if ($numStyleObject instanceof Numbering) {
+            return $numStyleObject;
+        }
+
+        return null;
+    }
+
+    /**
      * Set numbering style name.
      *
      * @param string $value

--- a/src/PhpWord/Style/ListItem.php
+++ b/src/PhpWord/Style/ListItem.php
@@ -19,6 +19,7 @@
 namespace PhpOffice\PhpWord\Style;
 
 use PhpOffice\PhpWord\Style;
+use PhpOffice\PhpWord\Style\Numbering as NumberingStyle;
 
 /**
  * List item style.

--- a/src/PhpWord/Style/ListItem.php
+++ b/src/PhpWord/Style/ListItem.php
@@ -124,7 +124,7 @@ class ListItem extends AbstractStyle
     public function getNumberingStyle()
     {
         $numStyleObject = Style::getStyle($this->numStyle);
-        if ($numStyleObject instanceof Numbering) {
+        if ($numStyleObject instanceof NumberingStyle) {
             return $numStyleObject;
         }
 
@@ -142,7 +142,7 @@ class ListItem extends AbstractStyle
     {
         $this->numStyle = $value;
         $numStyleObject = Style::getStyle($this->numStyle);
-        if ($numStyleObject instanceof Numbering) {
+        if ($numStyleObject instanceof NumberingStyle) {
             $this->numId = $numStyleObject->getIndex();
             $numStyleObject->setNumId($this->numId);
         }

--- a/src/PhpWord/Writer/RTF.php
+++ b/src/PhpWord/Writer/RTF.php
@@ -102,6 +102,16 @@ class RTF extends AbstractWriter implements WriterInterface
     }
 
     /**
+     * Get list table.
+     *
+     * @return array
+     */
+    public function getListTable()
+    {
+        return $this->getWriterPart('Header')->getListTable();
+    }
+
+    /**
      * Get last paragraph style.
      *
      * @return mixed

--- a/src/PhpWord/Writer/RTF/Element/ListItem.php
+++ b/src/PhpWord/Writer/RTF/Element/ListItem.php
@@ -25,6 +25,11 @@ namespace PhpOffice\PhpWord\Writer\RTF\Element;
  */
 class ListItem extends Text
 {
+    /**
+     * Write list item element.
+     */
+    public function write()
+    {
         /** @var \PhpOffice\PhpWord\Element\Text $element Type hint */
         $element = $this->element;
         if (!$element instanceof \PhpOffice\PhpWord\Element\ListItem) {
@@ -61,4 +66,5 @@ class ListItem extends Text
         $content .= $this->writeClosing();
 
         return $content;
+    }
 }

--- a/src/PhpWord/Writer/RTF/Element/ListItem.php
+++ b/src/PhpWord/Writer/RTF/Element/ListItem.php
@@ -37,7 +37,7 @@ class ListItem extends Text
         }
 
         $this->getStyles();
-        
+
         $depth = (int) $element->getDepth();
         $style = $element->getStyle();
         $numStyle = $style->getNumberingStyle();

--- a/src/PhpWord/Writer/RTF/Element/ListItem.php
+++ b/src/PhpWord/Writer/RTF/Element/ListItem.php
@@ -25,4 +25,40 @@ namespace PhpOffice\PhpWord\Writer\RTF\Element;
  */
 class ListItem extends Text
 {
+        /** @var \PhpOffice\PhpWord\Element\Text $element Type hint */
+        $element = $this->element;
+        if (!$element instanceof \PhpOffice\PhpWord\Element\ListItem) {
+            return;
+        }
+
+        $this->getStyles();
+        
+        $depth = (int) $element->getDepth();
+        $style = $element->getStyle();
+        $numStyle = $style->getNumberingStyle();
+        $levels = $numStyle->getLevels();
+        $text = $element->getTextObject();
+
+        // Bullet List
+        $content = '';
+        $content .= $this->writeOpening();
+        $content .= '\ilvl' . $element->getDepth();
+        $content .= '\ls' . $style->getNumId();
+        $content .= '\tx' . $levels[$depth]->getTabPos();
+        $hanging = $levels[$depth]->getLeft() + $levels[$depth]->getHanging();
+        $left = 0 - $levels[$depth]->getHanging();
+        $content .= '\fi' . $left;
+        $content .= '\li' . $hanging;
+        $content .= '\lin' . $hanging;
+        $content .= $this->writeFontStyle(); // Doesn't work. Don't know why. Probalby something to do with \PphOffice\PhpWord\Element\ListItem storing styles in a textObject type \PphOffice\PhpWord\Element\Text rather than within the Element itself
+        $content .= PHP_EOL;
+        /* $content .= '{\listtext\f2 \\\'b7\tab }'; // Not sure if needed for listItemRun
+        $content .= PHP_EOL; */
+        $content .= '{';
+        $content .= $this->writeText($element->getText());
+        $content .= '}';
+        $content .= PHP_EOL;
+        $content .= $this->writeClosing();
+
+        return $content;
 }

--- a/src/PhpWord/Writer/RTF/Element/ListItem.php
+++ b/src/PhpWord/Writer/RTF/Element/ListItem.php
@@ -33,7 +33,7 @@ class ListItem extends Text
         /** @var \PhpOffice\PhpWord\Element\Text $element Type hint */
         $element = $this->element;
         if (!$element instanceof \PhpOffice\PhpWord\Element\ListItem) {
-            return;
+            return '';
         }
 
         $this->getStyles();

--- a/src/PhpWord/Writer/RTF/Element/ListItem.php
+++ b/src/PhpWord/Writer/RTF/Element/ListItem.php
@@ -40,8 +40,6 @@ class ListItem extends Text
 
         $depth = (int) $element->getDepth();
         $style = $element->getStyle();
-        $numStyle = $style->getNumberingStyle();
-        $levels = $numStyle->getLevels();
         $text = $element->getTextObject();
 
         // Bullet List

--- a/src/PhpWord/Writer/RTF/Element/ListItem.php
+++ b/src/PhpWord/Writer/RTF/Element/ListItem.php
@@ -47,6 +47,9 @@ class ListItem extends Text
         $content .= $this->writeOpening();
         if ($style instanceof \PhpOffice\PhpWord\Style\ListItem) {
             $numStyle = $style->getNumberingStyle();
+            if ($numStyle->getType() == 'singleLevel') {
+                $depth = 0;
+            }
             $levels = $numStyle->getLevels();
             $content .= '\ilvl' . $element->getDepth();
             $content .= '\ls' . $style->getNumId();

--- a/src/PhpWord/Writer/RTF/Element/ListItem.php
+++ b/src/PhpWord/Writer/RTF/Element/ListItem.php
@@ -54,11 +54,9 @@ class ListItem extends Text
             $content .= '\ilvl' . $element->getDepth();
             $content .= '\ls' . $style->getNumId();
             $content .= '\tx' . $levels[$depth]->getTabPos();
-            $hanging = $levels[$depth]->getLeft() + $levels[$depth]->getHanging();
-            $left = 0 - $levels[$depth]->getHanging();
-            $content .= '\fi' . $left;
-            $content .= '\li' . $hanging;
-            $content .= '\lin' . $hanging;
+            $content .= '\fi' . $levels[$depth]->getHanging() * -1;
+            $content .= '\li' . $levels[$depth]->getLeft();
+            $content .= '\lin' . $levels[$depth]->getLeft();
         }
         $content .= $this->writeFontStyle(); // Doesn't work. Don't know why. Probalby something to do with \PphOffice\PhpWord\Element\ListItem storing styles in a textObject type \PphOffice\PhpWord\Element\Text rather than within the Element itself
         $content .= PHP_EOL;

--- a/src/PhpWord/Writer/RTF/Element/ListItem.php
+++ b/src/PhpWord/Writer/RTF/Element/ListItem.php
@@ -47,14 +47,18 @@ class ListItem extends Text
         // Bullet List
         $content = '';
         $content .= $this->writeOpening();
-        $content .= '\ilvl' . $element->getDepth();
-        $content .= '\ls' . $style->getNumId();
-        $content .= '\tx' . $levels[$depth]->getTabPos();
-        $hanging = $levels[$depth]->getLeft() + $levels[$depth]->getHanging();
-        $left = 0 - $levels[$depth]->getHanging();
-        $content .= '\fi' . $left;
-        $content .= '\li' . $hanging;
-        $content .= '\lin' . $hanging;
+        if ($style instanceof \PhpOffice\PhpWord\Style\ListItem) {
+            $numStyle = $style->getNumberingStyle();
+            $levels = $numStyle->getLevels();
+            $content .= '\ilvl' . $element->getDepth();
+            $content .= '\ls' . $style->getNumId();
+            $content .= '\tx' . $levels[$depth]->getTabPos();
+            $hanging = $levels[$depth]->getLeft() + $levels[$depth]->getHanging();
+            $left = 0 - $levels[$depth]->getHanging();
+            $content .= '\fi' . $left;
+            $content .= '\li' . $hanging;
+            $content .= '\lin' . $hanging;
+        }
         $content .= $this->writeFontStyle(); // Doesn't work. Don't know why. Probalby something to do with \PphOffice\PhpWord\Element\ListItem storing styles in a textObject type \PphOffice\PhpWord\Element\Text rather than within the Element itself
         $content .= PHP_EOL;
         /* $content .= '{\listtext\f2 \\\'b7\tab }'; // Not sure if needed for listItemRun

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -23,6 +23,7 @@ use PhpOffice\PhpWord\Shared\Converter;
 use PhpOffice\PhpWord\Style;
 use PhpOffice\PhpWord\Style\Font;
 use PhpOffice\PhpWord\Style\Table;
+use PhpOffice\PhpWord\Style\Numbering;
 
 /**
  * RTF header part writer.
@@ -54,6 +55,13 @@ class Header extends AbstractPart
     private $colorTable = [];
 
     /**
+     * List table.
+     *
+     * @var array
+     */
+    private $listTable = [];
+
+    /**
      * Get font table.
      *
      * @return array
@@ -74,13 +82,23 @@ class Header extends AbstractPart
     }
 
     /**
+     * Get list table.
+     *
+     * @return array
+     */
+    public function getListTable()
+    {
+        return $this->listTable;
+    }
+
+    /**
      * Write part.
      *
      * @return string
      */
     public function write()
     {
-        $this->registerFont();
+        $this->registerHeader();
 
         $content = '';
 
@@ -88,6 +106,7 @@ class Header extends AbstractPart
         $content .= $this->writeDefaults();
         $content .= $this->writeFontTable();
         $content .= $this->writeColorTable();
+        $content .= $this->writeListTable();
         $content .= $this->writeGenerator();
         $content .= PHP_EOL;
 
@@ -167,6 +186,18 @@ class Header extends AbstractPart
     }
 
     /**
+     * Write list table.
+     *
+     * @return string
+     */
+    private function writeListTable()
+    {
+        $content = '';
+
+        return $content;
+    }
+
+    /**
      * Write.
      *
      * @return string
@@ -182,9 +213,9 @@ class Header extends AbstractPart
     }
 
     /**
-     * Register all fonts and colors in both named and inline styles to appropriate header table.
+     * Register all fonts, colors, and lists in both named and inline styles to appropriate header table.
      */
-    private function registerFont(): void
+    private function registerHeader(): void
     {
         $phpWord = $this->getParentWriter()->getPhpWord();
         $this->fontTable[] = Settings::getDefaultFontName();
@@ -192,7 +223,7 @@ class Header extends AbstractPart
         // Search named styles
         $styles = Style::getStyles();
         foreach ($styles as $style) {
-            $this->registerFontItems($style);
+            $this->registerHeaderItems($style);
         }
 
         // Search inline styles
@@ -203,7 +234,7 @@ class Header extends AbstractPart
             foreach ($elements as $element) {
                 if (method_exists($element, 'getFontStyle')) {
                     $style = $element->getFontStyle();
-                    $this->registerFontItems($style);
+                    $this->registerHeaderItems($style);
                 }
             }
         }
@@ -225,11 +256,11 @@ class Header extends AbstractPart
     }
 
     /**
-     * Register fonts and colors.
+     * Register fonts, colors, and lists.
      *
      * @param Style\AbstractStyle $style
      */
-    private function registerFontItems($style): void
+    private function registerHeaderItems($style): void
     {
         $defaultFont = Settings::getDefaultFontName();
         $defaultColor = Settings::DEFAULT_FONT_COLOR;
@@ -247,6 +278,9 @@ class Header extends AbstractPart
             $this->registerTableItem($this->colorTable, $style->getBorderLeftColor(), $defaultColor);
             $this->registerTableItem($this->colorTable, $style->getBorderBottomColor(), $defaultColor);
         }
+        if ($style instanceof Numbering) {
+            $this->registerList($this->listTable, $style);
+        }
     }
 
     /**
@@ -261,5 +295,16 @@ class Header extends AbstractPart
         if (in_array($value, $table) === false && $value !== null && $value != $default) {
             $table[] = $value;
         }
+    }
+
+    /**
+     * Register lists and fonts within lists.
+     *
+     * @param array &$table
+     * @param Style\Numbering $style
+     */
+    private function registerList(&$table, $style): void
+    {
+        $table[] = [];
     }
 }

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -22,8 +22,8 @@ use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\Shared\Converter;
 use PhpOffice\PhpWord\Style;
 use PhpOffice\PhpWord\Style\Font;
-use PhpOffice\PhpWord\Style\Table;
 use PhpOffice\PhpWord\Style\Numbering;
+use PhpOffice\PhpWord\Style\Table;
 
 /**
  * RTF header part writer.

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -460,7 +460,7 @@ class Header extends AbstractPart
      *
      * @param array &$table
      * @param Numbering $style
-     * @param string $default
+     * @param string $defaultFont
      */
     private function registerList(&$table, $style, $defaultFont): void
     {
@@ -503,8 +503,8 @@ class Header extends AbstractPart
 
     private function lowerDigitsByOne($string)
     {
-        return preg_replace_callback('/\d/', function($matches) {
-            $digit = (int)$matches[0];
+        return preg_replace_callback('/\d/', function ($matches) {
+            $digit = (int) $matches[0];
             // Ensure the digit does not go below 0
             return ($digit > 0) ? ($digit - 1) : $digit;
         }, $string);

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -306,9 +306,9 @@ class Header extends AbstractPart
                 $offset = 0;
                 while (($pos = strpos($levelNumbers, 'X', $offset)) !== false) {
                     $positions[] = $pos;
-                    $offset = $pos + 1; 
+                    $offset = $pos + 1;
                 }
-                $strLength = sprintf("%02d", strlen($levelNumbers));
+                $strLength = sprintf('%02d', strlen($levelNumbers));
 
                 $content .= '{';
                 $content .= '\leveltext \\\'' . $strLength . $level;
@@ -316,7 +316,7 @@ class Header extends AbstractPart
                 $content .= '{';
                 $content .= '\levelnumbers ';
                 foreach ($positions as $position) {
-                    $position++;
+                    ++$position;
                     $content .= '\\\'0' . $position;
                 }
                 $content .= ';}';
@@ -343,7 +343,7 @@ class Header extends AbstractPart
         $content .= '{';
         $content .= '\*\listoverridetable' . PHP_EOL;
         foreach ($this->listTable as $list) {
-           $content .= '{';
+            $content .= '{';
             $content .= '\listoverride\listid' . $list[0];
             $content .= '\listoverridecount0\ls' . $list[0];
             $content .= '}';
@@ -437,7 +437,7 @@ class Header extends AbstractPart
             $this->registerTableItem($this->colorTable, $style->getBorderBottomColor(), $defaultColor);
         }
         if ($style instanceof Numbering) {
-            $this->registerList($this->listTable, $style);
+            $this->registerList($this->listTable, $style, $defaultFont);
         }
     }
 
@@ -459,9 +459,10 @@ class Header extends AbstractPart
      * Register lists and fonts within lists.
      *
      * @param array &$table
-     * @param Style\Numbering $style
+     * @param Numbering $style
+     * @param string $default
      */
-    private function registerList(&$table, $style): void
+    private function registerList(&$table, $style, $defaultFont): void
     {
         $listItems = [];
 
@@ -492,7 +493,7 @@ class Header extends AbstractPart
         $list = [$style->getNumId(), $style->getType(), $listItems];
         $table[] = $list;
     }
-    
+
     /**
      * NumberingLevel->getText() returns levels a step higher than expected in RTF \leveltext, (1-9) instead of (0-8).
      * Thus all the digits need to be reduced by 1.
@@ -500,7 +501,8 @@ class Header extends AbstractPart
      * @param string $string
      */
 
-    private function lowerDigitsByOne($string) {
+    private function lowerDigitsByOne($string)
+    {
         return preg_replace_callback('/\d/', function($matches) {
             $digit = (int)$matches[0];
             // Ensure the digit does not go below 0

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -194,6 +194,164 @@ class Header extends AbstractPart
     {
         $content = '';
 
+        $listType = [
+            'singleLevel' => '\listsimple1',
+            'multilevel' => '\listsimple0',
+            'hybridMultilevel' => '\listhybrid',
+        ];
+
+        // see page 31-34 of RTF 1.9.1 spec - unsure which code to use for commented out items
+        $numberType = [
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL => '0',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::UPPER_ROMAN => '1',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::LOWER_ROMAN => '2',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::UPPER_LETTER => '3',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::LOWER_LETTER => '4',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::ORDINAL => '5',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::CARDINAL_TEXT => '6',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::ORDINAL_TEXT => '7',
+            /* \PhpOffice\PhpWord\SimpleType\NumberFormat::HEX => 'hex',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::CHICAGO => 'chicago',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::IDEOGRAPH_DIGITAL => 'ideographDigital',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::JAPANESE_COUNTING => 'japaneseCounting', */
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::AIUEO => '12',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::IROHA => '13',
+            /* \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL_FULL_WIDTH => 'decimalFullWidth',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL_HALF_WIDTH => 'decimalHalfWidth',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::JAPANESE_LEGAL => 'japaneseLegal',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::JAPANESE_DIGITAL_TEN_THOUSAND => 'japaneseDigitalTenThousand',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL_ENCLOSED_CIRCLE => 'decimalEnclosedCircle',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL_FULL_WIDTH2 => 'decimalFullWidth2', */
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::AIUEO_FULL_WIDTH => '20',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::IROHA_FULL_WIDTH => '21',
+            /* \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL_ZERO => 'decimalZero',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::BULLET => 'bullet',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::GANADA => 'ganada',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::CHOSUNG => 'chosung',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL_ENCLOSED_FULL_STOP => 'decimalEnclosedFullstop',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL_ENCLOSED_PAREN => 'decimalEnclosedParen',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL_ENCLOSED_CIRCLE_CHINESE => 'decimalEnclosedCircleChinese',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::IDEOGRAPHENCLOSEDCIRCLE => 'ideographEnclosedCircle',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::IDEOGRAPH_TRADITIONAL => 'ideographTraditional',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::IDEOGRAPH_ZODIAC => 'ideographZodiac',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::IDEOGRAPH_ZODIAC_TRADITIONAL => 'ideographZodiacTraditional',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::TAIWANESE_COUNTING => 'taiwaneseCounting',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::IDEOGRAPH_LEGAL_TRADITIONAL => 'ideographLegalTraditional',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::TAIWANESE_COUNTING_THOUSAND => 'taiwaneseCountingThousand',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::TAIWANESE_DIGITAL => 'taiwaneseDigital',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::CHINESE_COUNTING => 'chineseCounting',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::CHINESE_LEGAL_SIMPLIFIED => 'chineseLegalSimplified',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::CHINESE_COUNTING_THOUSAND => 'chineseCountingThousand',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::KOREAN_DIGITAL => 'koreanDigital',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::KOREAN_COUNTING => 'koreanCounting',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::KOREAN_LEGAL => 'koreanLegal',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::KOREAN_DIGITAL2 => 'koreanDigital2', */
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::VIETNAMESE_COUNTING => '56',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::RUSSIAN_LOWER => '58',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::RUSSIAN_UPPER => '59',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::NONE => '255',
+            /* \PhpOffice\PhpWord\SimpleType\NumberFormat::NUMBER_IN_DASH => 'numberInDash',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::HEBREW1 => 'hebrew1',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::HEBREW2 => 'hebrew2',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::ARABIC_ALPHA => 'arabicAlpha', */
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::ARABIC_ABJAD => '48',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::HINDI_VOWELS => '49',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::HINDI_CONSONANTS => '50',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::HINDI_NUMBERS => '51',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::HINDI_COUNTING => '52',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::THAI_LETTERS => '53',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::THAI_NUMBERS => '54',
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::THAI_COUNTING => '55',
+        ];
+
+        // listtable
+        $content .= '{';
+        $content .= '\*\listtable' . PHP_EOL;
+
+        foreach ($this->listTable as $list) {
+            // $list = RTF tag
+            // [0] = \listtemplateid && \listid
+            // [1] = \listsimple OR \listhybrid
+            // [2] = array for \listlevel
+            $content .= '{';
+            $content .= '\list\listtemplateid' . $list[0];
+            if (isset($listType[$list[1]])) {
+                $content .= $listType[$list[1]];
+            }
+            $content .= PHP_EOL;
+            foreach ($list[2] as $listItem) {
+                // $listItem = RTF tag (may require manipulation)
+                // [0] = \listlevel
+                // [1] = \levelstartat
+                // [2] = \levellnfc
+                // [3] = \leveljc
+                // [4] = \leveltext && \levelnumbers
+                // [5] = \tx
+                // [6] = \li && \lin
+                // [7] = \fi
+                $content .= '{';
+                $content .= '\listlevel';
+                if (isset($numberType[$listItem[2]])) {
+                    $content .= '\levelnfc' . $numberType[$listItem[2]];
+                    $content .= '\levelnfcn' . $numberType[$listItem[2]];
+                }
+                $content .= '\leveljc' . $listItem[3];
+                $content .= '\leveljcn' . $listItem[3];
+                $content .= '\levelstartat' . $listItem[1];
+
+                // Level Text and Numbers
+                $level = $this->lowerDigitsByOne(str_replace('%', '\\\'0', $listItem[4]));
+                $levelNumbers = preg_replace('/\d/', 'X', str_replace('%', '', $listItem[4]));
+                $positions = [];
+                $offset = 0;
+                while (($pos = strpos($levelNumbers, 'X', $offset)) !== false) {
+                    $positions[] = $pos;
+                    $offset = $pos + 1; 
+                }
+                $strLength = sprintf("%02d", strlen($levelNumbers));
+
+                $content .= '{';
+                $content .= '\leveltext \\\'' . $strLength . $level;
+                $content .= ' ;}';
+                $content .= '{';
+                $content .= '\levelnumbers ';
+                foreach ($positions as $position) {
+                    $position++;
+                    $content .= '\\\'0' . $position;
+                }
+                $content .= ';}';
+
+                // Tabs, Hanging, and First Line
+                $content .= '\levelfollow' . '0';
+                $content .= '\jclisttab';
+                $content .= '\tx' . $listItem[5];
+                $hanging = $listItem[6] + $listItem[7];
+                $left = 0 - $listItem[7];
+                $content .= '\fi' . $left;
+                $content .= '\li' . $hanging;
+                $content .= '\lin' . $hanging;
+                $content .= '}';
+                $content .= PHP_EOL;
+            }
+            $content .= '\listid' . $list[0] . '}';
+            $content .= PHP_EOL;
+        }
+        $content .= '}';
+        $content .= PHP_EOL . PHP_EOL;
+
+        // listoverridetable
+        $content .= '{';
+        $content .= '\*\listoverridetable' . PHP_EOL;
+        foreach ($this->listTable as $list) {
+           $content .= '{';
+            $content .= '\listoverride\listid' . $list[0];
+            $content .= '\listoverridecount0\ls' . $list[0];
+            $content .= '}';
+            $content .= PHP_EOL;
+        }
+        $content .= '}';
+        $content .= PHP_EOL . PHP_EOL;
+
         return $content;
     }
 
@@ -305,6 +463,48 @@ class Header extends AbstractPart
      */
     private function registerList(&$table, $style): void
     {
-        $table[] = [];
+        $listItems = [];
+
+        $levels = $style->getLevels();
+        foreach ($levels as $level) {
+            echo 'Level:' . $level->getLevel() . ' Start:' . $level->getStart() . ' Format:' . $level->getFormat() . ' Restart:' . $level->getRestart() . ' PStyle:' . $level->getPStyle() . ' Suffix:' . $level->getSuffix() . ' Text:' . $level->getText() . ' Alignment:' . $level->getAlignment() . ' Left:' . $level->getLeft() . ' Hanging:' . $level->getHanging() . ' TabPos:' . $level->getTabPos() . ' Font:' . $level->getFont() . ' Hint:' . $level->getHint() . '<br>';
+            $this->registerTableItem($this->fontTable, $level->getFont(), $defaultFont);
+
+            /**
+             * $listItem = RTF tag (may require manipulation for correct output)
+             * [$level->getLevel()] = \listlevel
+             * [$level->getStart()] = \levelstartat
+             * [$level->getFormat()] = \levellnfc
+             * [$level->getAlignment()] = \leveljc
+             * [$level->getText()] = \leveltext && \levelnumbers
+             * [$level->getTabPos()] = \tx
+             * [$level->getLeft()] = \li && \lin
+             * [$level->getHanging()] = \fi */
+            $listItem = [$level->getLevel(), $level->getStart(), $level->getFormat(), $level->getAlignment(), $level->getText(), $level->getTabPos(), $level->getLeft(), $level->getHanging()];
+            array_push($listItems, $listItem);
+        }
+
+        /**
+         * $list = RTF tag in listtable
+         * [$style->getNumId()] = \listtemplateid && \listid
+         * [$style->getType()] = \listsimple OR \listhybrid
+         * [$listItems] = array for \listlevel */
+        $list = [$style->getNumId(), $style->getType(), $listItems];
+        $table[] = $list;
+    }
+    
+    /**
+     * NumberingLevel->getText() returns levels a step higher than expected in RTF \leveltext, (1-9) instead of (0-8).
+     * Thus all the digits need to be reduced by 1.
+     *
+     * @param string $string
+     */
+
+    private function lowerDigitsByOne($string) {
+        return preg_replace_callback('/\d/', function($matches) {
+            $digit = (int)$matches[0];
+            // Ensure the digit does not go below 0
+            return ($digit > 0) ? ($digit - 1) : $digit;
+        }, $string);
     }
 }

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -500,11 +500,11 @@ class Header extends AbstractPart
      *
      * @param string $string
      */
-
     private function lowerDigitsByOne($string)
     {
         return preg_replace_callback('/\d/', function ($matches) {
             $digit = (int) $matches[0];
+
             // Ensure the digit does not go below 0
             return ($digit > 0) ? ($digit - 1) : $digit;
         }, $string);

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -200,7 +200,6 @@ class Header extends AbstractPart
             'hybridMultilevel' => '\listhybrid',
         ];
 
-        // see page 31-34 of RTF 1.9.1 spec - unsure which code to use for commented out items
         $numberType = [
             \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL => '0',
             \PhpOffice\PhpWord\SimpleType\NumberFormat::UPPER_ROMAN => '1',
@@ -224,7 +223,7 @@ class Header extends AbstractPart
             \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL_FULL_WIDTH2 => 'decimalFullWidth2', */
             \PhpOffice\PhpWord\SimpleType\NumberFormat::AIUEO_FULL_WIDTH => '20',
             \PhpOffice\PhpWord\SimpleType\NumberFormat::IROHA_FULL_WIDTH => '21',
-            /* \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL_ZERO => 'decimalZero', */
+            // \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL_ZERO => 'decimalZero',
             \PhpOffice\PhpWord\SimpleType\NumberFormat::BULLET => '23',
             /* \PhpOffice\PhpWord\SimpleType\NumberFormat::GANADA => 'ganada',
             \PhpOffice\PhpWord\SimpleType\NumberFormat::CHOSUNG => 'chosung',
@@ -270,7 +269,6 @@ class Header extends AbstractPart
             'right' => '2',
         ];
 
-        // listtable
         $content .= '{';
         $content .= '\*\listtable' . PHP_EOL;
 
@@ -282,7 +280,6 @@ class Header extends AbstractPart
             }
             $content .= PHP_EOL;
             foreach ($list['listItems'] as $listItem) {
-
                 $content .= '{';
                 $content .= '\listlevel';
                 if (isset($numberType[$listItem['format']])) {
@@ -294,7 +291,9 @@ class Header extends AbstractPart
                     $content .= '\leveljcn' . $listAlignment[$listItem['alignment']];
                 }
                 $content .= '\levelstartat' . $listItem['start'];
-                if (isset($listItem['restart'])) { $content .= '\levelnorestart' . $listItem['restart']; }
+                if (isset($listItem['restart'])) {
+                    $content .= '\levelnorestart' . $listItem['restart'];
+                }
 
                 // Level Text and Numbers
                 $positions = [];
@@ -306,9 +305,9 @@ class Header extends AbstractPart
                     $offset = 0;
                     while (($pos = strpos($levelNumbers, 'X', $offset)) !== false) {
                         $positions[] = $pos;
-                        $offset = $pos + 1; 
+                        $offset = $pos + 1;
                     }
-                    $strLength = (string) sprintf("%02d", strlen($levelNumbers));
+                    $strLength = (string) sprintf('%02d', strlen($levelNumbers));
                 } else {
                     $level = '\\\'' . (string) strtoupper(dechex(ord(iconv('UTF-8', 'UCS-2', $listItem['text']))));
                     $strLength = '01';
@@ -320,20 +319,16 @@ class Header extends AbstractPart
                 $content .= '{';
                 $content .= '\levelnumbers ';
                 foreach ($positions as $position) {
-                    $position++;
+                    ++$position;
                     $content .= '\\\'0' . $position;
                 }
                 $content .= ';}';
 
-                print_r($listItem);
-                echo '<br>';
-                
                 // Font settings for Level Numbers
                 if (isset($listItem['font']) && !empty($listItem['font'])) {
                     $fontKey = array_search($listItem['font'], $this->fontTable);
-                    if ($fontKey !== FALSE) {
+                    if ($fontKey !== false) {
                         $content .= '\f' . $fontKey;
-
                     }
                 }
 
@@ -357,7 +352,7 @@ class Header extends AbstractPart
         $content .= '{';
         $content .= '\*\listoverridetable' . PHP_EOL;
         foreach ($this->listTable as $list) {
-           $content .= '{';
+            $content .= '{';
             $content .= '\listoverride\listid' . $list['numId'];
             $content .= '\listoverridecount0\ls' . $list['numId'];
             $content .= '}';
@@ -470,12 +465,27 @@ class Header extends AbstractPart
     }
 
     /**
+     * Register individual font and color.
+     *
+     * @param array &$table
+     * @param string $value
+     * @param string $default
+     */
+    private function registerTableItem(&$table, $value, $default = null): void
+    {
+        if (in_array($value, $table) === false && $value !== null && $value != $default) {
+            $table[] = $value;
+        }
+    }
+
+    /**
      * Register lists and fonts within lists.
      *
      * @param array &$table
-     * @param Style\Numbering $style
+     * @param Numbering $style
+     * @param string $defaultFont
      */
-    private function registerList(&$table, $style): void
+    private function registerList(&$table, $style, $defaultFont = null): void
     {
         $listItems = [];
 
@@ -515,11 +525,11 @@ class Header extends AbstractPart
      *
      * @param string $string
      */
-
     private function lowerDigitsByOne($string): string
     {
-        return preg_replace_callback('/\d/', function($matches) {
+        return preg_replace_callback('/\d/', function ($matches) {
             $digit = (int) $matches[0];
+
             return ($digit > 0) ? (string) ($digit - 1) : (string) $digit;
         }, $string);
     }

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -224,9 +224,9 @@ class Header extends AbstractPart
             \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL_FULL_WIDTH2 => 'decimalFullWidth2', */
             \PhpOffice\PhpWord\SimpleType\NumberFormat::AIUEO_FULL_WIDTH => '20',
             \PhpOffice\PhpWord\SimpleType\NumberFormat::IROHA_FULL_WIDTH => '21',
-            /* \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL_ZERO => 'decimalZero',
-            \PhpOffice\PhpWord\SimpleType\NumberFormat::BULLET => 'bullet',
-            \PhpOffice\PhpWord\SimpleType\NumberFormat::GANADA => 'ganada',
+            /* \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL_ZERO => 'decimalZero', */
+            \PhpOffice\PhpWord\SimpleType\NumberFormat::BULLET => '23',
+            /* \PhpOffice\PhpWord\SimpleType\NumberFormat::GANADA => 'ganada',
             \PhpOffice\PhpWord\SimpleType\NumberFormat::CHOSUNG => 'chosung',
             \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL_ENCLOSED_FULL_STOP => 'decimalEnclosedFullstop',
             \PhpOffice\PhpWord\SimpleType\NumberFormat::DECIMAL_ENCLOSED_PAREN => 'decimalEnclosedParen',
@@ -264,56 +264,53 @@ class Header extends AbstractPart
             \PhpOffice\PhpWord\SimpleType\NumberFormat::THAI_COUNTING => '55',
         ];
 
+        $listAlignment = [
+            'left' => '0',
+            'center' => '1',
+            'right' => '2',
+        ];
+
         // listtable
         $content .= '{';
         $content .= '\*\listtable' . PHP_EOL;
 
         foreach ($this->listTable as $list) {
-            // $list = RTF tag
-            // [0] = \listtemplateid && \listid
-            // [1] = \listsimple OR \listhybrid
-            // [2] = array for \listlevel
             $content .= '{';
-            $content .= '\list\listtemplateid' . $list[0];
-            if (isset($listType[$list[1]])) {
-                $content .= $listType[$list[1]];
+            $content .= '\list\listtemplateid' . $list['numId'];
+            if (isset($listType[$list['type']])) {
+                $content .= $listType[$list['type']];
             }
             $content .= PHP_EOL;
-            foreach ($list[2] as $listItem) {
-                // $listItem = RTF tag (may require manipulation)
-                // [0] = \listlevel
-                // [1] = \levelstartat
-                // [2] = \levellnfc
-                // [3] = \leveljc
-                // [4] = \leveltext && \levelnumbers
-                // [5] = \tx
-                // [6] = \li && \lin
-                // [7] = \fi
+            foreach ($list['listItems'] as $listItem) {
+
                 $content .= '{';
                 $content .= '\listlevel';
-                if (isset($numberType[$listItem[2]])) {
-                    $content .= '\levelnfc' . $numberType[$listItem[2]];
-                    $content .= '\levelnfcn' . $numberType[$listItem[2]];
+                if (isset($numberType[$listItem['format']])) {
+                    $content .= '\levelnfc' . $numberType[$listItem['format']];
+                    $content .= '\levelnfcn' . $numberType[$listItem['format']];
                 }
-                $content .= '\leveljc' . $listItem[3];
-                $content .= '\leveljcn' . $listItem[3];
-                $content .= '\levelstartat' . $listItem[1];
+                if (isset($listAlignment[$listItem['alignment']])) {
+                    $content .= '\leveljc' . $listAlignment[$listItem['alignment']];
+                    $content .= '\leveljcn' . $listAlignment[$listItem['alignment']];
+                }
+                $content .= '\levelstartat' . $listItem['start'];
+                if (isset($listItem['restart'])) { $content .= '\levelnorestart' . $listItem['restart']; }
 
                 // Level Text and Numbers
                 $positions = [];
                 $level = '';
                 $strLength = '';
-                if (strpos($listItem[4], '%') !== false) {
-                    $level = $this->lowerDigitsByOne(str_replace('%', '\\\'0', $listItem[4]));
-                    $levelNumbers = preg_replace('/\d/', 'X', str_replace('%', '', $listItem[4]));
+                if (strpos($listItem['text'], '%') !== false) {
+                    $level = $this->lowerDigitsByOne(str_replace('%', '\\\'0', $listItem['text']));
+                    $levelNumbers = (string) preg_replace('/\d/', 'X', str_replace('%', '', $listItem['text']));
                     $offset = 0;
                     while (($pos = strpos($levelNumbers, 'X', $offset)) !== false) {
                         $positions[] = $pos;
                         $offset = $pos + 1; 
                     }
-                    $strLength = sprintf("%02d", strlen($levelNumbers));
+                    $strLength = (string) sprintf("%02d", strlen($levelNumbers));
                 } else {
-                    $level = '\\\'' . strtoupper(dechex(ord(iconv('UTF-8', 'UCS-2', $listItem[4]))));
+                    $level = '\\\'' . (string) strtoupper(dechex(ord(iconv('UTF-8', 'UCS-2', $listItem['text']))));
                     $strLength = '01';
                 }
 
@@ -323,36 +320,46 @@ class Header extends AbstractPart
                 $content .= '{';
                 $content .= '\levelnumbers ';
                 foreach ($positions as $position) {
-                    ++$position;
+                    $position++;
                     $content .= '\\\'0' . $position;
                 }
                 $content .= ';}';
 
+                print_r($listItem);
+                echo '<br>';
+                
+                // Font settings for Level Numbers
+                if (isset($listItem['font']) && !empty($listItem['font'])) {
+                    $fontKey = array_search($listItem['font'], $this->fontTable);
+                    if ($fontKey !== FALSE) {
+                        $content .= '\f' . $fontKey;
+
+                    }
+                }
+
                 // Tabs, Hanging, and First Line
                 $content .= '\levelfollow' . '0';
                 $content .= '\jclisttab';
-                $content .= '\tx' . $listItem[5];
-                $hanging = $listItem[6] + $listItem[7];
-                $left = 0 - $listItem[7];
-                $content .= '\fi' . $left;
-                $content .= '\li' . $hanging;
-                $content .= '\lin' . $hanging;
+                $content .= '\tx' . $listItem['tabPos'];
+                $hanging = 0 - $listItem['hanging'];
+                $content .= '\fi' . $hanging;
+                $content .= '\li' . $listItem['left'];
+                $content .= '\lin' . $listItem['left'];
                 $content .= '}';
                 $content .= PHP_EOL;
             }
-            $content .= '\listid' . $list[0] . '}';
+            $content .= '\listid' . $list['numId'] . '}';
             $content .= PHP_EOL;
         }
         $content .= '}';
         $content .= PHP_EOL . PHP_EOL;
 
-        // listoverridetable
         $content .= '{';
         $content .= '\*\listoverridetable' . PHP_EOL;
         foreach ($this->listTable as $list) {
-            $content .= '{';
-            $content .= '\listoverride\listid' . $list[0];
-            $content .= '\listoverridecount0\ls' . $list[0];
+           $content .= '{';
+            $content .= '\listoverride\listid' . $list['numId'];
+            $content .= '\listoverridecount0\ls' . $list['numId'];
             $content .= '}';
             $content .= PHP_EOL;
         }
@@ -466,38 +473,39 @@ class Header extends AbstractPart
      * Register lists and fonts within lists.
      *
      * @param array &$table
-     * @param Numbering $style
-     * @param string $defaultFont
+     * @param Style\Numbering $style
      */
-    private function registerList(&$table, $style, $defaultFont): void
+    private function registerList(&$table, $style): void
     {
         $listItems = [];
 
         $levels = $style->getLevels();
         foreach ($levels as $level) {
-            echo 'Level:' . $level->getLevel() . ' Start:' . $level->getStart() . ' Format:' . $level->getFormat() . ' Restart:' . $level->getRestart() . ' PStyle:' . $level->getPStyle() . ' Suffix:' . $level->getSuffix() . ' Text:' . $level->getText() . ' Alignment:' . $level->getAlignment() . ' Left:' . $level->getLeft() . ' Hanging:' . $level->getHanging() . ' TabPos:' . $level->getTabPos() . ' Font:' . $level->getFont() . ' Hint:' . $level->getHint() . '<br>';
             $this->registerTableItem($this->fontTable, $level->getFont(), $defaultFont);
 
-            /**
-             * $listItem = RTF tag (may require manipulation for correct output)
-             * [$level->getLevel()] = \listlevel
-             * [$level->getStart()] = \levelstartat
-             * [$level->getFormat()] = \levellnfc
-             * [$level->getAlignment()] = \leveljc
-             * [$level->getText()] = \leveltext && \levelnumbers
-             * [$level->getTabPos()] = \tx
-             * [$level->getLeft()] = \li && \lin
-             * [$level->getHanging()] = \fi */
-            $listItem = [$level->getLevel(), $level->getStart(), $level->getFormat(), $level->getAlignment(), $level->getText(), $level->getTabPos(), $level->getLeft(), $level->getHanging()];
+            $listItem = [
+                'level' => $level->getLevel(),
+                'start' => $level->getStart(),
+                'restart' => $level->getRestart(),
+                'format' => $level->getFormat(),
+                'pStyle' => $level->getPStyle(),
+                'suffix' => $level->getSuffix(),
+                'text' => $level->getText(),
+                'alignment' => $level->getAlignment(),
+                'left' => $level->getLeft(),
+                'hanging' => $level->getHanging(),
+                'tabPos' => $level->getTabPos(),
+                'font' => $level->getFont(),
+                'hint' => $level->getHint(),
+            ];
             array_push($listItems, $listItem);
         }
 
-        /**
-         * $list = RTF tag in listtable
-         * [$style->getNumId()] = \listtemplateid && \listid
-         * [$style->getType()] = \listsimple OR \listhybrid
-         * [$listItems] = array for \listlevel */
-        $list = [$style->getNumId(), $style->getType(), $listItems];
+        $list = [
+            'numId' => $style->getNumId(),
+            'type' => $style->getType(),
+            'listItems' => $listItems,
+        ];
         $table[] = $list;
     }
 
@@ -507,13 +515,12 @@ class Header extends AbstractPart
      *
      * @param string $string
      */
+
     private function lowerDigitsByOne($string): string
     {
-        return preg_replace_callback('/\d/', function ($matches) {
+        return preg_replace_callback('/\d/', function($matches) {
             $digit = (int) $matches[0];
-
-            // Ensure the digit does not go below 0
-            return ($digit > 0) ? ($digit - 1) : $digit;
+            return ($digit > 0) ? (string) ($digit - 1) : (string) $digit;
         }, $string);
     }
 }

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -465,20 +465,6 @@ class Header extends AbstractPart
     }
 
     /**
-     * Register individual font and color.
-     *
-     * @param array &$table
-     * @param string $value
-     * @param string $default
-     */
-    private function registerTableItem(&$table, $value, $default = null): void
-    {
-        if (in_array($value, $table) === false && $value !== null && $value != $default) {
-            $table[] = $value;
-        }
-    }
-
-    /**
      * Register lists and fonts within lists.
      *
      * @param array &$table

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -310,7 +310,7 @@ class Header extends AbstractPart
                     }
                     $strLength = (string) sprintf('%02d', strlen($levelNumbers));
                 } else {
-                    $level = '\\\'' . (string) strtoupper(dechex(ord(iconv('UTF-8', 'UCS-2', $listText))));
+                    $level = '\\\'' . (string) strtoupper(dechex(ord((string) iconv('UTF-8', 'UCS-2', $listText))));
                     $strLength = '01';
                 }
 

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -300,15 +300,22 @@ class Header extends AbstractPart
                 $content .= '\levelstartat' . $listItem[1];
 
                 // Level Text and Numbers
-                $level = $this->lowerDigitsByOne(str_replace('%', '\\\'0', $listItem[4]));
-                $levelNumbers = preg_replace('/\d/', 'X', str_replace('%', '', $listItem[4]));
                 $positions = [];
-                $offset = 0;
-                while (($pos = strpos($levelNumbers, 'X', $offset)) !== false) {
-                    $positions[] = $pos;
-                    $offset = $pos + 1;
+                $level = '';
+                $strLength = '';
+                if (strpos($listItem[4], '%') !== false) {
+                    $level = $this->lowerDigitsByOne(str_replace('%', '\\\'0', $listItem[4]));
+                    $levelNumbers = preg_replace('/\d/', 'X', str_replace('%', '', $listItem[4]));
+                    $offset = 0;
+                    while (($pos = strpos($levelNumbers, 'X', $offset)) !== false) {
+                        $positions[] = $pos;
+                        $offset = $pos + 1; 
+                    }
+                    $strLength = sprintf("%02d", strlen($levelNumbers));
+                } else {
+                    $level = '\\\'' . strtoupper(dechex(ord(iconv('UTF-8', 'UCS-2', $listItem[4]))));
+                    $strLength = '01';
                 }
-                $strLength = sprintf('%02d', strlen($levelNumbers));
 
                 $content .= '{';
                 $content .= '\leveltext \\\'' . $strLength . $level;
@@ -500,7 +507,7 @@ class Header extends AbstractPart
      *
      * @param string $string
      */
-    private function lowerDigitsByOne($string)
+    private function lowerDigitsByOne($string): string
     {
         return preg_replace_callback('/\d/', function ($matches) {
             $digit = (int) $matches[0];

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -299,9 +299,10 @@ class Header extends AbstractPart
                 $positions = [];
                 $level = '';
                 $strLength = '';
-                if (strpos($listItem['text'], '%') !== false) {
-                    $level = $this->lowerDigitsByOne(str_replace('%', '\\\'0', $listItem['text']));
-                    $levelNumbers = (string) preg_replace('/\d/', 'X', str_replace('%', '', $listItem['text']));
+                $listText = (string) $listItem['text'];
+                if (strpos($listText, '%') !== false) {
+                    $level = $this->lowerDigitsByOne(str_replace('%', '\\\'0', $listText));
+                    $levelNumbers = preg_replace('/\d/', 'X', str_replace('%', '', $listText));
                     $offset = 0;
                     while (($pos = strpos($levelNumbers, 'X', $offset)) !== false) {
                         $positions[] = $pos;
@@ -309,7 +310,7 @@ class Header extends AbstractPart
                     }
                     $strLength = (string) sprintf('%02d', strlen($levelNumbers));
                 } else {
-                    $level = '\\\'' . (string) strtoupper(dechex(ord(iconv('UTF-8', 'UCS-2', $listItem['text']))));
+                    $level = '\\\'' . (string) strtoupper(dechex(ord(iconv('UTF-8', 'UCS-2', $listText))));
                     $strLength = '01';
                 }
 

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -337,7 +337,7 @@ class Header extends AbstractPart
                 $content .= '\levelfollow' . '0';
                 $content .= '\jclisttab';
                 $content .= '\tx' . $listItem['tabPos'];
-                $content .= '\fi' . $listItem['hanging'] *-1;
+                $content .= '\fi' . $listItem['hanging'] * -1;
                 $content .= '\li' . $listItem['left'];
                 $content .= '\lin' . $listItem['left'];
                 $content .= '}';

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -337,8 +337,7 @@ class Header extends AbstractPart
                 $content .= '\levelfollow' . '0';
                 $content .= '\jclisttab';
                 $content .= '\tx' . $listItem['tabPos'];
-                $hanging = 0 - $listItem['hanging'];
-                $content .= '\fi' . $hanging;
+                $content .= '\fi' . $listItem['hanging'] *-1;
                 $content .= '\li' . $listItem['left'];
                 $content .= '\lin' . $listItem['left'];
                 $content .= '}';

--- a/src/PhpWord/Writer/RTF/Part/Header.php
+++ b/src/PhpWord/Writer/RTF/Part/Header.php
@@ -310,13 +310,13 @@ class Header extends AbstractPart
                     }
                     $strLength = (string) sprintf('%02d', strlen($levelNumbers));
                 } else {
-                    $level = '\\\'' . (string) strtoupper(dechex(ord((string) iconv('UTF-8', 'UCS-2', $listText))));
-                    $strLength = '01';
+                    $level = $this->escaper->escape($listText);
+                    $strLength = (string) sprintf('%02d', mb_strlen($listText));
                 }
 
                 $content .= '{';
                 $content .= '\leveltext \\\'' . $strLength . $level;
-                $content .= ' ;}';
+                $content .= ';}';
                 $content .= '{';
                 $content .= '\levelnumbers ';
                 foreach ($positions as $position) {

--- a/tests/PhpWordTests/Escaper/RtfEscaper2Test.php
+++ b/tests/PhpWordTests/Escaper/RtfEscaper2Test.php
@@ -58,7 +58,7 @@ class RtfEscaper2Test extends \PHPUnit\Framework\TestCase
     public function testAccent(): void
     {
         $str = 'Voilà - string with accented char';
-        $expect = $this->expect('Voil\\uc0{\\u224} - string with accented char');
+        $expect = $this->expect('Voil\\uc0\\u224  - string with accented char');
         self::assertEquals($expect, $this->escapestring($str));
     }
 
@@ -68,7 +68,7 @@ class RtfEscaper2Test extends \PHPUnit\Framework\TestCase
     public function testHebrew(): void
     {
         $str = 'Hebrew - שלום';
-        $expect = $this->expect('Hebrew - \\uc0{\\u1513}\\uc0{\\u1500}\\uc0{\\u1493}\\uc0{\\u1501}');
+        $expect = $this->expect('Hebrew - \\uc0\\u1513 \\uc0\\u1500 \\uc0\\u1493 \\uc0\\u1501 }');
         self::assertEquals($expect, $this->escapestring($str));
     }
 

--- a/tests/PhpWordTests/Escaper/RtfEscaper2Test.php
+++ b/tests/PhpWordTests/Escaper/RtfEscaper2Test.php
@@ -68,7 +68,7 @@ class RtfEscaper2Test extends \PHPUnit\Framework\TestCase
     public function testHebrew(): void
     {
         $str = 'Hebrew - שלום';
-        $expect = $this->expect('Hebrew - \\uc0\\u1513 \\uc0\\u1500 \\uc0\\u1493 \\uc0\\u1501 }');
+        $expect = $this->expect('Hebrew - \\uc0\\u1513 \\uc0\\u1500 \\uc0\\u1493 \\uc0\\u1501 ');
         self::assertEquals($expect, $this->escapestring($str));
     }
 

--- a/tests/PhpWordTests/Escaper/RtfEscaper3Test.php
+++ b/tests/PhpWordTests/Escaper/RtfEscaper3Test.php
@@ -68,7 +68,7 @@ class RtfEscaper3Test extends \PHPUnit\Framework\TestCase
     {
         Settings::setDefaultRtl(false);
         $str = 'Voilà - string with accented char';
-        $expect = $this->expect('Voil\\uc0{\\u224} - string with accented char');
+        $expect = $this->expect('Voil\\uc0\\u224  - string with accented char');
         self::assertEquals($expect, $this->escapestring($str));
     }
 
@@ -79,7 +79,7 @@ class RtfEscaper3Test extends \PHPUnit\Framework\TestCase
     {
         Settings::setDefaultRtl(true);
         $str = 'Hebrew - שלום';
-        $expect = $this->expect('Hebrew - \\uc0{\\u1513}\\uc0{\\u1500}\\uc0{\\u1493}\\uc0{\\u1501}', true);
+        $expect = $this->expect('Hebrew - \\uc0\\u1513 \\uc0\\u1500 \\uc0\\u1493 \\uc0\\u1501 ', true);
         self::assertEquals($expect, $this->escapestring($str));
     }
 

--- a/tests/PhpWordTests/Writer/RTF/StyleTest.php
+++ b/tests/PhpWordTests/Writer/RTF/StyleTest.php
@@ -136,7 +136,7 @@ class StyleTest extends \PHPUnit\Framework\TestCase
         $parentWriter = new RTF();
         $element = new \PhpOffice\PhpWord\Element\Text('אב גד');
         $text = new RTF\Element\Text($parentWriter, $element);
-        $expect = "\\pard\\nowidctlpar \\qr{\\rtlch\\cf0\\f0 \\uc0\\u1488 \\uc0\\u1489  \\uc0\\u1490 \\uc0\\u1491 }}\\par\n";
+        $expect = "\\pard\\nowidctlpar \\qr{\\rtlch\\cf0\\f0 \\uc0\\u1488 \\uc0\\u1489  \\uc0\\u1490 \\uc0\\u1491 }\\par\n";
         self::assertEquals($expect, $this->removeCr($text));
     }
 

--- a/tests/PhpWordTests/Writer/RTF/StyleTest.php
+++ b/tests/PhpWordTests/Writer/RTF/StyleTest.php
@@ -126,7 +126,7 @@ class StyleTest extends \PHPUnit\Framework\TestCase
         $parentWriter = new RTF();
         $element = new \PhpOffice\PhpWord\Element\Text('אב גד', ['RTL' => true]);
         $text = new RTF\Element\Text($parentWriter, $element);
-        $expect = "\\pard\\nowidctlpar {\\rtlch\\cf0\\f0 \\uc0{\\u1488}\\uc0{\\u1489} \\uc0{\\u1490}\\uc0{\\u1491}}\\par\n";
+        $expect = "\\pard\\nowidctlpar {\\rtlch\\cf0\\f0 \\uc0\\u1488 \\uc0\\u1489  \\uc0\\u1490 \\uc0\\u1491 }\\par\n";
         self::assertEquals($expect, $this->removeCr($text));
     }
 
@@ -136,7 +136,7 @@ class StyleTest extends \PHPUnit\Framework\TestCase
         $parentWriter = new RTF();
         $element = new \PhpOffice\PhpWord\Element\Text('אב גד');
         $text = new RTF\Element\Text($parentWriter, $element);
-        $expect = "\\pard\\nowidctlpar \\qr{\\rtlch\\cf0\\f0 \\uc0{\\u1488}\\uc0{\\u1489} \\uc0{\\u1490}\\uc0{\\u1491}}\\par\n";
+        $expect = "\\pard\\nowidctlpar \\qr{\\rtlch\\cf0\\f0 \\uc0\\u1488 \\uc0\\u1489  \\uc0\\u1490 \\uc0\\u1491 }}\\par\n";
         self::assertEquals($expect, $this->removeCr($text));
     }
 


### PR DESCRIPTION
### Description

This is a first go at making ListItem work in RTF Writer. It's a start, but needs revisions.

Creates ListTable and ListOverrideTable in Header. Creates ListItem in Document.

Fixes #1106.

What's not working:
- not all NumberFormats are supports (if anyone knows how to translate NumberFormat into RTF page 31-34 of 1.9.1 spec, help appreciated).
- fontStyle and paragraphStyle isn't working, both for the leveltext and the listitem (still figuring this out).

### Limitations:
- PhpOffice\PhpWord\Style\NumberingLevel currently only sets a font name and doesn't store a whole font style (color, size, highlight, etc). Numbering can be fully styled, but the ability isn't currently available in the Library. Not sure how much work it would take to rewrite that.

### Checklist:

- [x] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
