### PR TITLE
RTF Writer: ListItemRun - Create

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
+- Writer RTF: Create element ListItemRun by [@rasamassen](https://github.com/rasamassen) in [#2823](https://github.com/PHPOffice/PHPWord/pull/2823)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Writer/RTF/Element/Container.php
+++ b/src/PhpWord/Writer/RTF/Element/Container.php
@@ -46,7 +46,7 @@ class Container extends AbstractElement
             return '';
         }
         $containerClass = substr(get_class($container), strrpos(get_class($container), '\\') + 1);
-        $withoutP = in_array($containerClass, ['TextRun', 'Footnote', 'Endnote']) ? true : false;
+        $withoutP = in_array($containerClass, ['TextRun', 'Footnote', 'Endnote', 'ListItemRun', 'Field']) ? true : false;
         $content = '';
 
         $elements = $container->getElements();

--- a/src/PhpWord/Writer/RTF/Element/ListItemRun
+++ b/src/PhpWord/Writer/RTF/Element/ListItemRun
@@ -32,15 +32,34 @@ class ListItemRun extends TextRun
      */
     public function write()
     {
-        if (!$this->element instanceof \PhpOffice\PhpWord\Element\ListItemRun) {
+        $element = $this->element;
+        if (!$element instanceof \PhpOffice\PhpWord\Element\ListItemRun) {
             return '';
         }
 
-        $writer = new Container($this->parentWriter, $this->element);
+        $writer = new Container($this->parentWriter, $element);
         $this->getStyles();
+
+        $depth = (int) $element->getDepth();
+        $style = $element->getStyle();
+
+        echo $depth . '<br>';
+        print_r($style);
 
         $content = '';
         $content .= $this->writeOpening();
+        if ($style instanceof \PhpOffice\PhpWord\Style\ListItem) {
+            $numStyle = $style->getNumberingStyle();
+            $levels = $numStyle->getLevels();
+            $content .= '\ilvl' . $element->getDepth();
+            $content .= '\ls' . $style->getNumId();
+            $content .= '\tx' . $levels[$depth]->getTabPos();
+            $hanging = $levels[$depth]->getLeft() + $levels[$depth]->getHanging();
+            $left = 0 - $levels[$depth]->getHanging();
+            $content .= '\fi' . $left;
+            $content .= '\li' . $hanging;
+            $content .= '\lin' . $hanging;
+        }
         $content .= '{';
         $content .= $writer->write();
         $content .= '}';

--- a/src/PhpWord/Writer/RTF/Element/ListItemRun
+++ b/src/PhpWord/Writer/RTF/Element/ListItemRun
@@ -43,9 +43,6 @@ class ListItemRun extends TextRun
         $depth = (int) $element->getDepth();
         $style = $element->getStyle();
 
-        echo $depth . '<br>';
-        print_r($style);
-
         $content = '';
         $content .= $this->writeOpening();
         if ($style instanceof \PhpOffice\PhpWord\Style\ListItem) {

--- a/src/PhpWord/Writer/RTF/Element/ListItemRun
+++ b/src/PhpWord/Writer/RTF/Element/ListItemRun
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\RTF\Element;
+
+/**
+ * ListItem element HTML writer.
+ *
+ * @since 0.10.0
+ */
+class ListItemRun extends TextRun
+{
+    /**
+     * Write list item.
+     *
+     * @return string
+     */
+    public function write()
+    {
+        if (!$this->element instanceof \PhpOffice\PhpWord\Element\ListItemRun) {
+            return '';
+        }
+
+        $writer = new Container($this->parentWriter, $this->element);
+        $this->getStyles();
+
+        $content = '';
+        $content .= $this->writeOpening();
+        $content .= '{';
+        $content .= $writer->write();
+        $content .= '}';
+        $content .= $this->writeClosing();
+
+        return $content;
+    }
+}


### PR DESCRIPTION
### Description

ListItemRun now works!

Depends on [#2821](https://github.com/PHPOffice/PHPWord/pull/2821)

### Limitations

- In the Library, there's currently no way to pass a fontStyle for the whole ListItemRun, nor for TextRun. Without being able to pass a fontStyle to the whole Run and then specify specific changes within the run, it makes it much harder to make small changes. Let's say I want a list that's all size => 22, color => purple, bold => true, but there's one little item I want to underline. I'd have to either pass all the variables on every line of the run or I'd have to setup two different fontStyles. It would be simpler to setup one fontStyle and then pass the small change as a custom fontStyle where DIFF would override the default for the run (but if no change, default still applies).

### Checklist:

- [x] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
