### PR TITLE
Fix: prevent null being passed to htmlspecialchars() in AbstractPart.php

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
+- Prevent `htmlspecialchars()` deprecation warnings by defaulting `null` values to empty strings in `AbstractPart` by [@dafydd-rhys](https://github.com/dafydd-rhys) fixing [#2829](https://github.com/PHPOffice/PHPWord/issues/2829) in [#2828](https://github.com/PHPOffice/PHPWord/pull/2828)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -302,7 +302,7 @@ abstract class AbstractPart
             $nodes = $xmlReader->getElements('w:r|w:hyperlink', $domNode);
             $hasRubyElement = $xmlReader->elementExists('w:r/w:ruby', $domNode);
             if ($nodes->length === 1 && !$hasRubyElement) {
-                $textContent = htmlspecialchars($xmlReader->getValue('w:t', $nodes->item(0)), ENT_QUOTES, 'UTF-8');
+                $textContent = htmlspecialchars($xmlReader->getValue('w:t', $nodes->item(0)) ?? '', ENT_QUOTES, 'UTF-8');
             } else {
                 $textContent = new TextRun($paragraphStyle);
                 foreach ($nodes as $node) {
@@ -559,14 +559,14 @@ abstract class AbstractPart
                 if ($fallbackElements->length) {
                     $fallback = $fallbackElements->item(0);
                     // TextRun
-                    $textContent = htmlspecialchars($fallback->nodeValue, ENT_QUOTES, 'UTF-8');
+                    $textContent = htmlspecialchars($fallback->nodeValue ?? '', ENT_QUOTES, 'UTF-8');
 
                     $parent->addText($textContent, $fontStyle, $paragraphStyle);
                 }
             }
         } elseif ($node->nodeName == 'w:t' || $node->nodeName == 'w:delText') {
             // TextRun
-            $textContent = htmlspecialchars($xmlReader->getValue('.', $node), ENT_QUOTES, 'UTF-8');
+            $textContent = htmlspecialchars($xmlReader->getValue('.', $node) ?? '', ENT_QUOTES, 'UTF-8');
 
             if ($runParent->nodeName == 'w:hyperlink') {
                 $rId = $xmlReader->getAttribute('r:id', $runParent);


### PR DESCRIPTION
### Description

This PR fixes deprecation warnings in PHP 8.1+ caused by `htmlspecialchars()` receiving `null`.  
The affected code paths occur when XML nodes or text content may be missing.  

Fix applied by using the null coalescing operator (`?? ''`) to ensure a string is always passed.

"DEPRECATE: vendor/phpoffice/phpword/src/PhpWord/Reader/Word2007/AbstractPart.php line 300 user unknown -- htmlspecialchars(): Passing null to parameter [0000001](https://mantis.hoowla.com/view.php?id=1) ($string) of type string is deprecated"

### Checklist:

- [x] My CI is :green_circle:
- [x] I have verified the fix removes the PHP 8.1 deprecation warning
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
