### PR TITLE
Style: Paper - Add Additional Default Size Options

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
+- Add additional sizes to Paper [@rasamassen](https://github.com/rasamassen), partially fixing [#1656](https://github.com/PHPOffice/PHPWord/issues/1656), in [#2829](https://github.com/PHPOffice/PHPWord/pull/2829)
 
 ### Miscellaneous
 

--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -7,7 +7,7 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
-- Add additional sizes to Paper [@rasamassen](https://github.com/rasamassen), partially fixing [#1656](https://github.com/PHPOffice/PHPWord/issues/1656), in [#2829](https://github.com/PHPOffice/PHPWord/pull/2829)
+- Add additional sizes to Paper [@rasamassen](https://github.com/rasamassen), partially fixing [#1656](https://github.com/PHPOffice/PHPWord/issues/1656), in [#2830](https://github.com/PHPOffice/PHPWord/pull/2830)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Style/Paper.php
+++ b/src/PhpWord/Style/Paper.php
@@ -100,13 +100,18 @@ class Paper extends AbstractStyle
      * @var array
      */
     private $sizes = [
+        'Letter' => [8.5, 11, 'in'],
+        'Tabloid' => [11, 17, 'in'],
+        'Ledger' => [17, 11, 'in'],
+        'Legal' => [8.5, 14, 'in'],
+        'Statement' => [5.5, 8.5, 'in'],
+        'Executive' => [7.25, 10.5, 'in'],
         'A3' => [297, 420, 'mm'],
         'A4' => [210, 297, 'mm'],
         'A5' => [148, 210, 'mm'],
+        'B4' => [250, 353, 'mm'],
         'B5' => [176, 250, 'mm'],
         'Folio' => [8.5, 13, 'in'],
-        'Legal' => [8.5, 14, 'in'],
-        'Letter' => [8.5, 11, 'in'],
     ];
 
     /**


### PR DESCRIPTION
### Description

Some of the most common size options weren't included. Now they are.

Partially Fixes #1656 (issue)

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
