### PR TITLE
RTF Writer: Section - Add support for Columns and BreakTypes

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
+- Writer RTF: Support for columns and breakType in Section by [@rasamassen](https://github.com/rasamassen) in [#2835](https://github.com/PHPOffice/PHPWord/pull/2835)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Writer/RTF/Style/Section.php
+++ b/src/PhpWord/Writer/RTF/Style/Section.php
@@ -53,8 +53,23 @@ class Section extends AbstractStyle
         $content .= $this->getValueIf($style->getMarginLeft() !== null, '\marglsxn' . round($style->getMarginLeft()));
         $content .= $this->getValueIf($style->getHeaderHeight() !== null, '\headery' . round($style->getHeaderHeight()));
         $content .= $this->getValueIf($style->getFooterHeight() !== null, '\footery' . round($style->getFooterHeight()));
-        $content .= $this->getValueIf($style->getGutter() !== null, '\guttersxn' . round($style->getGutter()));
+        $content .= $this->getValueIf($style->getGutter() !== null && $style->getGutter() !== SectionStyle::DEFAULT_GUTTER, '\guttersxn' . round($style->getGutter()));
         $content .= $this->getValueIf($style->getPageNumberingStart() !== null, '\pgnstarts' . $style->getPageNumberingStart() . '\pgnrestart');
+        $content .= $this->getValueIf($style->getColsNum() !== null && $style->getColsNum() !== SectionStyle::DEFAULT_COLUMN_COUNT, '\cols' . $style->getColsNum());
+        $content .= $this->getValueIf($style->getColsSpace() !== null && $style->getColsNum() !== SectionStyle::DEFAULT_COLUMN_COUNT, '\colsx' . round($style->getColsSpace()));
+
+        // Break Type
+        $breakTypes = [
+            'nextPage' => '\sbkpage',
+            'nextColumn' => '\sbkcol',
+            'continuous' => '\sbknone',
+            'evenPage' => '\sbkeven',
+            'oddPage' => '\sbkodd',
+        ];
+        if (isset($breakTypes[$style->getBreakType()])) {
+            $content .= $breakTypes[$style->getBreakType()];
+        }
+
         $content .= ' ';
 
         // Borders


### PR DESCRIPTION
### Description

Section Style now supports ColsNum, ColsSpace, and BreakType.
For consistency, Gutter is no longer set value is default.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
