### PR TITLE
RTF Writer: Indentation - Add missing commands and don't set if == 0.

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
+- Writer RTF: Improve Indentation and add missing commands by [@rasamassen](https://github.com/rasamassen) in [#2836](https://github.com/PHPOffice/PHPWord/pull/2836)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Writer/RTF/Style/Indentation.php
+++ b/src/PhpWord/Writer/RTF/Style/Indentation.php
@@ -39,11 +39,11 @@ class Indentation extends AbstractStyle
 
         $content = '';
 
-        $content .= $this->getValueIf($style->getFirstLine() !== 0, '\fi' . round($style->getFirstLine()));
-        $content .= $this->getValueIf($style->getFirstLineChars() !== 0, '\cufi' . round($style->getFirstLineChars()));
-        $content .= $this->getValueIf($style->getHanging() !== 0, '\fi-' . round($style->getHanging()));
-        $content .= $this->getValueIf($style->getLeft() !== 0, '\li' . round($style->getLeft()));
-        $content .= $this->getValueIf($style->getRight() !== 0, '\ri' . round($style->getRight()));
+        $content .= $this->getValueIf($style->getFirstLine() != 0, '\fi' . round($style->getFirstLine()));
+        $content .= $this->getValueIf($style->getFirstLineChars() != 0, '\cufi' . round($style->getFirstLineChars()));
+        $content .= $this->getValueIf($style->getHanging() != 0, '\fi-' . round($style->getHanging()));
+        $content .= $this->getValueIf($style->getLeft() != 0, '\li' . round($style->getLeft()));
+        $content .= $this->getValueIf($style->getRight() != 0, '\ri' . round($style->getRight()));
 
         return $content . ' ';
     }

--- a/src/PhpWord/Writer/RTF/Style/Indentation.php
+++ b/src/PhpWord/Writer/RTF/Style/Indentation.php
@@ -37,9 +37,13 @@ class Indentation extends AbstractStyle
             return '';
         }
 
-        $content = '\fi' . round($style->getFirstLine());
-        $content .= '\li' . round($style->getLeft());
-        $content .= '\ri' . round($style->getRight());
+        $content = '';
+        
+        $content .= getValueIf($style->getFirstLine() !== 0, '\fi' . round($style->getFirstLine()));
+        $content .= getValueIf($style->getFirstLineChars() !== 0, '\cufi' . round($style->getFirstLineChars()));
+        $content .= getValueIf($style->getHanging() !== 0, '\fi-' . round($style->getHanging()));
+        $content .= getValueIf($style->getLeft() !== 0, '\li' . round($style->getLeft()));
+        $content .= getValueIf($style->getRight() !== 0, '\ri' . round($style->getRight()));
 
         return $content . ' ';
     }

--- a/src/PhpWord/Writer/RTF/Style/Indentation.php
+++ b/src/PhpWord/Writer/RTF/Style/Indentation.php
@@ -38,12 +38,12 @@ class Indentation extends AbstractStyle
         }
 
         $content = '';
-        
-        $content .= getValueIf($style->getFirstLine() !== 0, '\fi' . round($style->getFirstLine()));
-        $content .= getValueIf($style->getFirstLineChars() !== 0, '\cufi' . round($style->getFirstLineChars()));
-        $content .= getValueIf($style->getHanging() !== 0, '\fi-' . round($style->getHanging()));
-        $content .= getValueIf($style->getLeft() !== 0, '\li' . round($style->getLeft()));
-        $content .= getValueIf($style->getRight() !== 0, '\ri' . round($style->getRight()));
+
+        $content .= $this->getValueIf($style->getFirstLine() !== 0, '\fi' . round($style->getFirstLine()));
+        $content .= $this->getValueIf($style->getFirstLineChars() !== 0, '\cufi' . round($style->getFirstLineChars()));
+        $content .= $this->getValueIf($style->getHanging() !== 0, '\fi-' . round($style->getHanging()));
+        $content .= $this->getValueIf($style->getLeft() !== 0, '\li' . round($style->getLeft()));
+        $content .= $this->getValueIf($style->getRight() !== 0, '\ri' . round($style->getRight()));
 
         return $content . ' ';
     }

--- a/tests/PhpWordTests/Writer/RTF/Style/Indentation.php
+++ b/tests/PhpWordTests/Writer/RTF/Style/Indentation.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWordTests\Writer\RTF\Style;
+
+use PhpOffice\PhpWord\Settings;
+use PhpOffice\PhpWord\Style\Indentation as IndentationStyle;
+use PhpOffice\PhpWord\Writer\RTF;
+use PhpOffice\PhpWord\Writer\RTF\Style\Indentation as IndentationWriter;
+use PHPUnit\Framework\TestCase;
+
+class ParagraphTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Settings::setDefaultRtl(null);
+    }
+
+    /**
+     * @param ParagraphWriter $field
+     */
+    public function removeCr($field): string
+    {
+        return str_replace("\r\n", "\n", $field->write());
+    }
+
+    /**
+     * Test indentation.
+     * See page 79 of RTF Specification 1.9.1 for Indentation.
+     */
+    public function testIndentation(): void
+    {
+        $parentWriter = new RTF();
+        $style = new IndentationStyle();
+        $writer = new IndentationWriter($style);
+        $writer->setParentWriter($parentWriter);
+
+        $expect = ' ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setLeft(1440);
+        $style->setRight(720);
+        $style->setFirstLine(360);
+        $style->setFirstLineChars(180);
+        $expect = '\fi360\cufi180\li1440\ri720 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style = new IndentationStyle();
+        $writer = new IndentationWriter($style);
+        $writer->setParentWriter($parentWriter);
+
+        $style->setLeft(1440);
+        $style->setRight(720);
+        $style->setHanging(360);
+        $expect = '\fi-360\li1440\ri720 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+    }
+}

--- a/tests/PhpWordTests/Writer/RTF/Style/Indentation.php
+++ b/tests/PhpWordTests/Writer/RTF/Style/Indentation.php
@@ -24,7 +24,7 @@ use PhpOffice\PhpWord\Writer\RTF;
 use PhpOffice\PhpWord\Writer\RTF\Style\Indentation as IndentationWriter;
 use PHPUnit\Framework\TestCase;
 
-class ParagraphTest extends TestCase
+class IndentationTest extends TestCase
 {
     protected function tearDown(): void
     {

--- a/tests/PhpWordTests/Writer/RTF/Style/IndentationTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Style/IndentationTest.php
@@ -32,7 +32,7 @@ class IndentationTest extends TestCase
     }
 
     /**
-     * @param ParagraphWriter $field
+     * @param IndentationWriter $field
      */
     public function removeCr($field): string
     {

--- a/tests/PhpWordTests/Writer/RTF/StyleTest.php
+++ b/tests/PhpWordTests/Writer/RTF/StyleTest.php
@@ -70,20 +70,6 @@ class StyleTest extends \PHPUnit\Framework\TestCase
         self::assertEquals($expected, $content);
     }
 
-    public function testIndentation(): void
-    {
-        $indentation = new \PhpOffice\PhpWord\Style\Indentation();
-        $indentation->setLeft(1);
-        $indentation->setRight(2);
-        $indentation->setFirstLine(3);
-
-        $indentWriter = new RTF\Style\Indentation($indentation);
-        $indentWriter->setParentWriter(new RTF());
-        $result = $indentWriter->write();
-
-        Assert::assertEquals('\fi3\li1\ri2 ', $result);
-    }
-
     public function testRightTab(): void
     {
         $tabRight = new \PhpOffice\PhpWord\Style\Tab();


### PR DESCRIPTION
### Description

Add hanging and firstLineChars. Don't set values if == 0 because otherwise firstLine[Chars] and hanging will be in conflict.

Fixes # (issue)

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
