### PR TITLE
RTF Writer: Border - Improved and Prepared for Future Implementations

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
+- Writer RTF: Improve Borders, add missing features, and prepare for future uses by [@rasamassen](https://github.com/rasamassen) in [#2838](https://github.com/PHPOffice/PHPWord/pull/2838)
 
 ### Miscellaneous
 

--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -7,7 +7,7 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
-- Writer RTF: Improve Borders, add missing features, and prepare for future uses by [@rasamassen](https://github.com/rasamassen) in [#2838](https://github.com/PHPOffice/PHPWord/pull/2838)
+- Writer RTF: Border - Improve add missing features, also adds spaces to Styles > Border and fixes hasBorder to check all border variables by [@rasamassen](https://github.com/rasamassen) in [#2838](https://github.com/PHPOffice/PHPWord/pull/2838)
 
 ### Miscellaneous
 

--- a/src/PhpWord/SimpleType/Border.php
+++ b/src/PhpWord/SimpleType/Border.php
@@ -48,7 +48,7 @@ final class Border extends AbstractEnum
     const THIN_THICK_LARGE_GAP = 'thinThickLargeGap'; //A thin line contained within a thick line with a large-sized intermediate gap
     const THIN_THICK_MEDIUM_GAP = 'thinThickMediumGap'; //A thick line contained within a thin line with a medium-sized intermediate gap
     const THIN_THICK_SMALL_GAP = 'thinThickSmallGap'; //A thick line contained within a thin line with a small intermediate gap
-    const THIN_THICK_THINLARGE_GAP = 'thinThickThinLargeGap'; //A thin-thick-thin line with a large gap
+    const THIN_THICK_THIN_LARGE_GAP = 'thinThickThinLargeGap'; //A thin-thick-thin line with a large gap
     const THIN_THICK_THIN_MEDIUM_GAP = 'thinThickThinMediumGap'; //A thin-thick-thin line with a medium gap
     const THIN_THICK_THIN_SMALL_GAP = 'thinThickThinSmallGap'; //A thin-thick-thin line with a small gap
     const THREE_D_EMBOSS = 'threeDEmboss'; //A three-staged gradient line, getting darker towards the paragraph

--- a/src/PhpWord/Style/Border.php
+++ b/src/PhpWord/Style/Border.php
@@ -685,6 +685,9 @@ class Border extends AbstractStyle
     public function hasBorder()
     {
         $borders = $this->getBorderSize();
+        array_push($borders, $this->getBorderColor());
+        array_push($borders, $this->getBorderStyle());
+        array_push($borders, $this->getBorderSpace());
 
         return $borders !== array_filter($borders, 'is_null');
     }

--- a/src/PhpWord/Style/Border.php
+++ b/src/PhpWord/Style/Border.php
@@ -168,7 +168,7 @@ class Border extends AbstractStyle
     /**
      * Get border size.
      *
-     * @return int[]
+     * @return float[]|int[]
      */
     public function getBorderSize()
     {

--- a/src/PhpWord/Style/Border.php
+++ b/src/PhpWord/Style/Border.php
@@ -264,7 +264,7 @@ class Border extends AbstractStyle
     /**
      * Get border space.
      *
-     * @return int[]
+     * @return float|int[]
      */
     public function getBorderSpace()
     {

--- a/src/PhpWord/Style/Border.php
+++ b/src/PhpWord/Style/Border.php
@@ -684,10 +684,7 @@ class Border extends AbstractStyle
      */
     public function hasBorder()
     {
-        $borders = $this->getBorderSize();
-        array_push($borders, $this->getBorderColor());
-        array_push($borders, $this->getBorderStyle());
-        array_push($borders, $this->getBorderSpace());
+        $borders = array_merge($this->getBorderSize(), $this->getBorderColor(), $this->getBorderStyle(), $this->getBorderSpace());
 
         return $borders !== array_filter($borders, 'is_null');
     }

--- a/src/PhpWord/Style/Border.php
+++ b/src/PhpWord/Style/Border.php
@@ -264,7 +264,7 @@ class Border extends AbstractStyle
     /**
      * Get border space.
      *
-     * @return float|int[]
+     * @return float[]|int[]
      */
     public function getBorderSpace()
     {

--- a/src/PhpWord/Style/Border.php
+++ b/src/PhpWord/Style/Border.php
@@ -47,6 +47,13 @@ class Border extends AbstractStyle
     protected $borderTopStyle;
 
     /**
+     * Border Top Space. For section and paragraph borders only.
+     *
+     * @var string
+     */
+    protected $borderTopSpace;
+
+    /**
      * Border Left Size.
      *
      * @var float|int
@@ -66,6 +73,13 @@ class Border extends AbstractStyle
      * @var string
      */
     protected $borderLeftStyle;
+
+    /**
+     * Border Left Space. For section and paragraph borders only.
+     *
+     * @var string
+     */
+    protected $borderLeftSpace;
 
     /**
      * Border Right Size.
@@ -89,6 +103,13 @@ class Border extends AbstractStyle
     protected $borderRightStyle;
 
     /**
+     * Border Right Space. For section and paragraph borders only.
+     *
+     * @var string
+     */
+    protected $borderRightSpace;
+
+    /**
      * Border Bottom Size.
      *
      * @var float|int
@@ -108,6 +129,13 @@ class Border extends AbstractStyle
      * @var string
      */
     protected $borderBottomStyle;
+
+    /**
+     * Border Bottom Space. For section and paragraph borders only.
+     *
+     * @var string
+     */
+    protected $borderBottomSpace;
 
     /**
      * Top margin spacing.
@@ -234,6 +262,38 @@ class Border extends AbstractStyle
     }
 
     /**
+     * Get border space.
+     *
+     * @return string[]
+     */
+    public function getBorderSpace()
+    {
+        return [
+            $this->getBorderTopSpace(),
+            $this->getBorderLeftSpace(),
+            $this->getBorderRightSpace(),
+            $this->getBorderBottomSpace(),
+        ];
+    }
+
+    /**
+     * Set border space.
+     *
+     * @param string $value
+     *
+     * @return self
+     */
+    public function setBorderSpace($value = null)
+    {
+        $this->setBorderTopSpace($value);
+        $this->setBorderLeftSpace($value);
+        $this->setBorderRightSpace($value);
+        $this->setBorderBottomSpace($value);
+
+        return $this;
+    }
+
+    /**
      * Get border top size.
      *
      * @return float|int
@@ -292,7 +352,7 @@ class Border extends AbstractStyle
     }
 
     /**
-     * Set border top Style.
+     * Set border top style.
      *
      * @param string $value
      *
@@ -301,6 +361,30 @@ class Border extends AbstractStyle
     public function setBorderTopStyle($value = null)
     {
         $this->borderTopStyle = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get border top space.
+     *
+     * @return string
+     */
+    public function getBorderTopSpace()
+    {
+        return $this->borderTopSpace;
+    }
+
+    /**
+     * Set border top space.
+     *
+     * @param string $value
+     *
+     * @return self
+     */
+    public function setBorderTopSpace($value = null)
+    {
+        $this->borderTopSpace = $value;
 
         return $this;
     }
@@ -378,6 +462,30 @@ class Border extends AbstractStyle
     }
 
     /**
+     * Get border left space.
+     *
+     * @return string
+     */
+    public function getBorderLeftSpace()
+    {
+        return $this->borderLeftSpace;
+    }
+
+    /**
+     * Set border left space.
+     *
+     * @param string $value
+     *
+     * @return self
+     */
+    public function setBorderLeftSpace($value = null)
+    {
+        $this->borderLeftSpace = $value;
+
+        return $this;
+    }
+
+    /**
      * Get border right size.
      *
      * @return float|int
@@ -450,6 +558,30 @@ class Border extends AbstractStyle
     }
 
     /**
+     * Get border right space.
+     *
+     * @return string
+     */
+    public function getBorderRightSpace()
+    {
+        return $this->borderRightSpace;
+    }
+
+    /**
+     * Set border right space.
+     *
+     * @param string $value
+     *
+     * @return self
+     */
+    public function setBorderRightSpace($value = null)
+    {
+        $this->borderRightSpace = $value;
+
+        return $this;
+    }
+
+    /**
      * Get border bottom size.
      *
      * @return float|int
@@ -517,6 +649,30 @@ class Border extends AbstractStyle
     public function setBorderBottomStyle($value = null)
     {
         $this->borderBottomStyle = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get border bottom space.
+     *
+     * @return string
+     */
+    public function getBorderBottomSpace()
+    {
+        return $this->borderBottomSpace;
+    }
+
+    /**
+     * Set border bottom space.
+     *
+     * @param string $value
+     *
+     * @return self
+     */
+    public function setBorderBottomSpace($value = null)
+    {
+        $this->borderBottomSpace = $value;
 
         return $this;
     }

--- a/src/PhpWord/Style/Border.php
+++ b/src/PhpWord/Style/Border.php
@@ -168,7 +168,7 @@ class Border extends AbstractStyle
     /**
      * Get border size.
      *
-     * @return float[]|int[]
+     * @return array<float|int>
      */
     public function getBorderSize()
     {
@@ -264,7 +264,7 @@ class Border extends AbstractStyle
     /**
      * Get border space.
      *
-     * @return float[]|int[]
+     * @return array<float|int>
      */
     public function getBorderSpace()
     {

--- a/src/PhpWord/Style/Border.php
+++ b/src/PhpWord/Style/Border.php
@@ -49,7 +49,7 @@ class Border extends AbstractStyle
     /**
      * Border Top Space. For section and paragraph borders only.
      *
-     * @var string
+     * @var float|int
      */
     protected $borderTopSpace;
 
@@ -77,7 +77,7 @@ class Border extends AbstractStyle
     /**
      * Border Left Space. For section and paragraph borders only.
      *
-     * @var string
+     * @var float|int
      */
     protected $borderLeftSpace;
 
@@ -105,7 +105,7 @@ class Border extends AbstractStyle
     /**
      * Border Right Space. For section and paragraph borders only.
      *
-     * @var string
+     * @var float|int
      */
     protected $borderRightSpace;
 
@@ -133,7 +133,7 @@ class Border extends AbstractStyle
     /**
      * Border Bottom Space. For section and paragraph borders only.
      *
-     * @var string
+     * @var float|int
      */
     protected $borderBottomSpace;
 
@@ -264,7 +264,7 @@ class Border extends AbstractStyle
     /**
      * Get border space.
      *
-     * @return string[]
+     * @return int[]
      */
     public function getBorderSpace()
     {
@@ -279,7 +279,7 @@ class Border extends AbstractStyle
     /**
      * Set border space.
      *
-     * @param string $value
+     * @param float|int $value
      *
      * @return self
      */
@@ -368,7 +368,7 @@ class Border extends AbstractStyle
     /**
      * Get border top space.
      *
-     * @return string
+     * @return float|int
      */
     public function getBorderTopSpace()
     {
@@ -378,7 +378,7 @@ class Border extends AbstractStyle
     /**
      * Set border top space.
      *
-     * @param string $value
+     * @param float|int $value
      *
      * @return self
      */
@@ -464,7 +464,7 @@ class Border extends AbstractStyle
     /**
      * Get border left space.
      *
-     * @return string
+     * @return float|int
      */
     public function getBorderLeftSpace()
     {
@@ -474,7 +474,7 @@ class Border extends AbstractStyle
     /**
      * Set border left space.
      *
-     * @param string $value
+     * @param float|int $value
      *
      * @return self
      */
@@ -560,7 +560,7 @@ class Border extends AbstractStyle
     /**
      * Get border right space.
      *
-     * @return string
+     * @return float|int
      */
     public function getBorderRightSpace()
     {
@@ -570,7 +570,7 @@ class Border extends AbstractStyle
     /**
      * Set border right space.
      *
-     * @param string $value
+     * @param float|int $value
      *
      * @return self
      */
@@ -656,7 +656,7 @@ class Border extends AbstractStyle
     /**
      * Get border bottom space.
      *
-     * @return string
+     * @return float|int
      */
     public function getBorderBottomSpace()
     {
@@ -666,7 +666,7 @@ class Border extends AbstractStyle
     /**
      * Set border bottom space.
      *
-     * @param string $value
+     * @param float|int $value
      *
      * @return self
      */

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -18,6 +18,8 @@
 
 namespace PhpOffice\PhpWord\Writer\RTF\Style;
 
+use PhpOffice\PhpWord\SimpleType\Border as BorderType;
+
 /**
  * Border style writer.
  *
@@ -40,20 +42,44 @@ class Border extends AbstractStyle
     private $colors = [];
 
     /**
+     * Styles.
+     *
+     * @var array
+     */
+    private $styles = [];
+
+    /**
+     * Spaces.
+     *
+     * @var array
+     */
+    private $spaces = [];
+
+    /**
+     * Type
+     * 
+     * Can be page, header, footer, paragraph, character, row, or cell.
+     *
+     * @var string
+     */
+    private $type;
+
+    /**
      * Write style.
      *
      * @return string
      */
     public function write()
     {
+        $style = $this->getStyle();
+        if (!$style instanceof \PhpOffice\PhpWord\Style\Border) {
+            return '';
+        }
+
         $content = '';
 
         $sides = ['top', 'left', 'right', 'bottom'];
         $sizeCount = count($this->sizes);
-
-        // Page border measure
-        // 8 = from text, infront off; 32 = from edge, infront on; 40 = from edge, infront off
-        $content .= '\pgbrdropt32';
 
         for ($i = 0; $i < $sizeCount; ++$i) {
             if ($this->sizes[$i] !== null) {
@@ -61,7 +87,7 @@ class Border extends AbstractStyle
                 if (isset($this->colors[$i])) {
                     $color = $this->colors[$i];
                 }
-                $content .= $this->writeSide($sides[$i], $this->sizes[$i], $color);
+                $content .= $this->writeSide($sides[$i], $this->sizes[$i], $color, $this->styles[$i], $this->spaces[$i]);
             }
         }
 
@@ -74,29 +100,94 @@ class Border extends AbstractStyle
      * @param string $side
      * @param int $width
      * @param string $color
+     * @param string $style
      *
      * @return string
      */
-    private function writeSide($side, $width, $color = '')
+    private function writeSide($side, $width, $color = '', $style, $space)
     {
-        /** @var \PhpOffice\PhpWord\Writer\RTF $rtfWriter */
-        $rtfWriter = $this->getParentWriter();
+        $types = [
+            'page' => '\pgbrdr',
+            'header' => '\pgbrdrhead',
+            'footer' => '\pgbrdrfoot',
+            'paragraph' => '\brdr',
+            'character' => '\chbrdr',
+            'row' => '\trbrdr',
+            'cell' => '\clbrdr',
+        ];
+
+        $styles = [
+            BorderType::SINGLE => '\brdrs',
+            BorderType::DASH_DOT_STROKED => '\brdrdashd', // no equivalent in RTF
+            BorderType::DASHED => '\brdrdash',
+            BorderType::DASH_SMALL_GAP => '\brdrdashsm',
+            BorderType::DOT_DASH => '\brdrdashd',
+            BorderType::DOT_DOT_DASH => '\brdrdashdd',
+            BorderType::DOTTED => '\brdrdot',
+            BorderType::DOUBLE => '\brdrdb',
+            BorderType::DOUBLE_WAVE => '\brdrwavydb',
+            BorderType::INSET => '\brdrinset',
+            BorderType::NIL => '\brdrnil',
+            BorderType::NONE => '\brdrnone',
+            BorderType::OUTSET => '\brdroutset',
+            BorderType::THICK => '\brdrth',
+            BorderType::THICK_THIN_LARGE_GAP => '\brdrtnthlg',
+            BorderType::THICK_THIN_MEDIUM_GAP => '\brdrtnthmg',
+            BorderType::THICK_THIN_SMALL_GAP => '\brdrtnthsg',
+            BorderType::THIN_THICK_LARGE_GAP => '\brdrthtnlg',
+            BorderType::THIN_THICK_MEDIUM_GAP => '\brdrthtnmg',
+            BorderType::THIN_THICK_SMALL_GAP => '\brdrthtnsg',
+            BorderType::THIN_THICK_THIN_LARGE_GAP => '\brdrtnthtnlg',
+            BorderType::THIN_THICK_THIN_MEDIUM_GAP => '\brdrtnthtnmg',
+            BorderType::THIN_THICK_THIN_SMALL_GAP => '\brdrtnthtnmg',
+            BorderType::THREE_D_EMBOSS => '\brdremboss',
+            BorderType::THREE_D_ENGRAVE => '\brdrengrave',
+            BorderType::TRIPLE => '\brdrtriple',
+            BorderType::WAVE => '\brdrwavy',
+        ];
+
+        /** @var \PhpOffice\PhpWord\Writer\RTF $parentWriter */
+        $parentWriter = $this->getParentWriter();
         $colorIndex = 0;
-        if ($rtfWriter !== null) {
-            $colorTable = $rtfWriter->getColorTable();
-            $index = array_search($color, $colorTable);
+        if ($parentWriter !== null) {
+            $index = array_search($color, $parentWriter->getColorTable());
             if ($index !== false) {
                 $colorIndex = $index + 1;
             }
         }
 
         $content = '';
+        $type = 'paragraph';
+        if (isset($types[$this->type])) {
+            if (in_array($types[$this->type], ['header', 'footer', 'character'])) {                
+                $content .= $types[$this->type]; // header, footer, and character borders cannot vary by side
+            } else {
+                $content .= $types[$this->type] . substr($side, 0, 1);
+            }
+        } else {
+            return '';
+        }
 
-        $content .= '\pgbrdr' . substr($side, 0, 1);
-        $content .= '\brdrs'; // Single-thickness border; @todo Get other type of border
+        if (isset($styles[$style])) {
+            $content .= $styles[$style];
+        } else {
+            $content .= '\brdrs'; // default style
+        }
         $content .= '\brdrw' . round($width); // Width
         $content .= '\brdrcf' . $colorIndex; // Color
-        $content .= '\brsp480'; // Space in twips between borders and the paragraph (24pt, following OOXML)
+
+        // Space
+        if ($this->type == 'page') {
+            $space = $space !== null ? $space : '480';
+        } elseif ($this->type == 'paragraph') {
+            if ($side == 'top' || $side == 'bottom') {
+                $space = $space !== null ? $space : '20';
+            } elseif ($side == 'left' || $side == 'right') {
+                $space = $space !== null ? $space : '80';
+            }
+        }
+        $content .= $this->getValueIf($space !== null, '\brsp' . round($space ?? 0));
+
         $content .= ' ';
 
         return $content;
@@ -120,5 +211,35 @@ class Border extends AbstractStyle
     public function setColors($value): void
     {
         $this->colors = $value;
+    }
+
+    /**
+     * Set styles.
+     *
+     * @param string[] $value
+     */
+    public function setStyles($value): void
+    {
+        $this->styles = $value;
+    }
+
+    /**
+     * Set styles.
+     *
+     * @param string[] $value
+     */
+    public function setSpaces($value): void
+    {
+        $this->spaces = $value;
+    }
+
+    /**
+     * Set type.
+     *
+     * @param string $value
+     */
+    public function setType($value = 'paragraph'): void
+    {
+        $this->type = $value;
     }
 }

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -136,7 +136,7 @@ class Border extends AbstractStyle
 
         $content = '';
         if (isset($types[$this->type])) {
-            if ($types[$this->type] == 'font') {
+            if ($this->type == 'font') {
                 $content .= $types[$this->type]; // character borders cannot vary by side
             } else {
                 $content .= $types[$this->type] . substr($side, 0, 1);
@@ -151,7 +151,7 @@ class Border extends AbstractStyle
             $content .= '\brdrs'; // default style
         }
         $content .= $this->getValueIf($width !== null, '\brdrw' . round($width)); // Width
-        $content .= $this->getValueIf($colorIndex !== 0, '\brdrcf' . $colorIndex); // Color
+        $content .= '\brdrcf' . $colorIndex; // Color
 
         // Space
         if ($this->type == 'section') {
@@ -163,7 +163,7 @@ class Border extends AbstractStyle
                 $space = $space !== null ? $space : '80';
             }
         }
-        if (in_array($types[$this->type], ['section', 'paragraph'])) {
+        if (in_array($this->type, ['section', 'paragraph'])) {
             $content .= $this->getValueIf($space !== null, '\brsp' . round($space ?? 0));
         }
 

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -86,7 +86,7 @@ class Border extends AbstractStyle
      */
     private function writeSide($side, $width, $color, $style, $space)
     {
-        if ($side === null && $width == null && $color === null && $style === null) {
+        if ($width == null && $color === null && $style === null) {
             if ($this->type == 'font' || $this->type == 'row' || $this->type == 'cell') {
                 return '';
             } elseif ($space === null) {

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -29,7 +29,7 @@ class Border extends AbstractStyle
 {
     /**
      * Type
-     * 
+     *
      * Can be section, header, footer, paragraph, font, row, or cell.
      *
      * @var string
@@ -55,7 +55,7 @@ class Border extends AbstractStyle
             // 8 = from text, infront off; 32 = from edge, infront on; 40 = from edge, infront off
             $content .= '\pgbrdropt32';
         }
-        
+
         $sides = ['top', 'left', 'right', 'bottom'];
         $sizeCount = 4;
 
@@ -84,10 +84,11 @@ class Border extends AbstractStyle
      * @param int $width
      * @param string $color
      * @param string $style
+     * @param int $space
      *
      * @return string
      */
-    private function writeSide($side, $width, $color = '', $style, $space)
+    private function writeSide($side, $width, $color, $style, $space)
     {
         $types = [
             'section' => '\pgbrdr',
@@ -142,7 +143,7 @@ class Border extends AbstractStyle
         $content = '';
         $type = 'paragraph';
         if (isset($types[$this->type])) {
-            if (in_array($types[$this->type], ['header', 'footer', 'font'])) {                
+            if (in_array($types[$this->type], ['header', 'footer', 'font'])) {
                 $content .= $types[$this->type]; // header, footer, and character borders cannot vary by side
             } else {
                 $content .= $types[$this->type] . substr($side, 0, 1);

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -152,8 +152,8 @@ class Border extends AbstractStyle
         } else {
             $content .= '\brdrs'; // default style
         }
-        $content .= '\brdrw' . round($width); // Width
-        $content .= '\brdrcf' . $colorIndex; // Color
+        $content .= $this->getValueIf($width !== null, '\brdrw' . round($width)); // Width
+        $content .= $this->getValueIf($colorIndex !== 0, '\brdrcf' . $colorIndex); // Color
 
         // Space
         if ($this->type == 'section') {

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -67,9 +67,7 @@ class Border extends AbstractStyle
         $spaces = $style->getBorderSpace();
 
         for ($i = 0; $i < $sizeCount; ++$i) {
-            if ($sides[$i] !== null) {
-                $content .= $this->writeSide($sides[$i], $sizes[$i], $colors[$i], $styles[$i], $spaces[$i]);
-            }
+            $content .= $this->writeSide($sides[$i], $sizes[$i], $colors[$i], $styles[$i], $spaces[$i]);
         }
 
         return $content;

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -86,6 +86,14 @@ class Border extends AbstractStyle
      */
     private function writeSide($side, $width, $color, $style, $space)
     {
+        if ($side === null && $width == null && $color === null && $style === null) {
+            if ($this->type == 'font' || $this->type == 'row' || $this->type == 'cell') {
+                return '';
+            } elseif ($space === null) {
+                return '';
+            }
+        }
+        
         $types = [
             'section' => '\pgbrdr',
             'paragraph' => '\brdr',
@@ -151,21 +159,21 @@ class Border extends AbstractStyle
             $content .= '\brdrs'; // default style
         }
         $content .= $this->getValueIf($width !== null, '\brdrw' . round($width ?? 0)); // Width
-        $content .= '\brdrcf' . $colorIndex; // Color
+        $content .= $this->getValueIf($color !== null, '\brdrcf' . $colorIndex); // Color
 
         // Space
         if ($this->type == 'section') {
-            $space = $space !== null ? $space : '480';
+            $space = $space !== null ? $space : '480'; // section default is 480
         } elseif ($this->type == 'paragraph') {
             if ($side == 'top' || $side == 'bottom') {
-                $space = $space !== null ? $space : '20';
+                $space = $space !== null ? $space : '20'; // paragraph top|bottom default is 20
             } elseif ($side == 'left' || $side == 'right') {
-                $space = $space !== null ? $space : '80';
+                $space = $space !== null ? $space : '80'; // paragraph left|rigth default is 80
             }
+        } else {
+            $space === null; // font|row|cell don't use space
         }
-        if (in_array($this->type, ['section', 'paragraph'])) {
-            $content .= $this->getValueIf($space !== null, '\brsp' . round($space ?? 0));
-        }
+        $content .= $this->getValueIf($space !== null, '\brsp' . round($space ?? 0));
 
         $content .= ' ';
 

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -170,8 +170,6 @@ class Border extends AbstractStyle
             } elseif ($side == 'left' || $side == 'right') {
                 $space = $space !== null ? $space : '80'; // paragraph left|rigth default is 80
             }
-        } else {
-            $space === null; // font|row|cell don't use space
         }
         $content .= $this->getValueIf($space !== null, '\brsp' . round($space ?? 0));
 

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -93,7 +93,7 @@ class Border extends AbstractStyle
                 return '';
             }
         }
-        
+
         $types = [
             'section' => '\pgbrdr',
             'paragraph' => '\brdr',

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -117,7 +117,7 @@ class Border extends AbstractStyle
             BorderType::THIN_THICK_SMALL_GAP => '\brdrthtnsg',
             BorderType::THIN_THICK_THIN_LARGE_GAP => '\brdrtnthtnlg',
             BorderType::THIN_THICK_THIN_MEDIUM_GAP => '\brdrtnthtnmg',
-            BorderType::THIN_THICK_THIN_SMALL_GAP => '\brdrtnthtnmg',
+            BorderType::THIN_THICK_THIN_SMALL_GAP => '\brdrtnthtnsg',
             BorderType::THREE_D_EMBOSS => '\brdremboss',
             BorderType::THREE_D_ENGRAVE => '\brdrengrave',
             BorderType::TRIPLE => '\brdrtriple',

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -56,8 +56,8 @@ class Border extends AbstractStyle
     private $spaces = [];
 
     /**
-     * Type
-     * 
+     * Type.
+     *
      * Can be page, header, footer, paragraph, character, row, or cell.
      *
      * @var string
@@ -101,10 +101,11 @@ class Border extends AbstractStyle
      * @param int $width
      * @param string $color
      * @param string $style
+     * @param int $space
      *
      * @return string
      */
-    private function writeSide($side, $width, $color = '', $style, $space)
+    private function writeSide($side, $width, $color, $style, $space)
     {
         $types = [
             'page' => '\pgbrdr',
@@ -159,7 +160,7 @@ class Border extends AbstractStyle
         $content = '';
         $type = 'paragraph';
         if (isset($types[$this->type])) {
-            if (in_array($types[$this->type], ['header', 'footer', 'character'])) {                
+            if (in_array($types[$this->type], ['header', 'footer', 'character'])) {
                 $content .= $types[$this->type]; // header, footer, and character borders cannot vary by side
             } else {
                 $content .= $types[$this->type] . substr($side, 0, 1);

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -28,37 +28,9 @@ use PhpOffice\PhpWord\SimpleType\Border as BorderType;
 class Border extends AbstractStyle
 {
     /**
-     * Sizes.
-     *
-     * @var array
-     */
-    private $sizes = [];
-
-    /**
-     * Colors.
-     *
-     * @var array
-     */
-    private $colors = [];
-
-    /**
-     * Styles.
-     *
-     * @var array
-     */
-    private $styles = [];
-
-    /**
-     * Spaces.
-     *
-     * @var array
-     */
-    private $spaces = [];
-
-    /**
-     * Type.
-     *
-     * Can be page, header, footer, paragraph, character, row, or cell.
+     * Type
+     * 
+     * Can be section, header, footer, paragraph, font, row, or cell.
      *
      * @var string
      */
@@ -78,16 +50,27 @@ class Border extends AbstractStyle
 
         $content = '';
 
+        if ($this->type == 'section') {
+            // Page border measure
+            // 8 = from text, infront off; 32 = from edge, infront on; 40 = from edge, infront off
+            $content .= '\pgbrdropt32';
+        }
+        
         $sides = ['top', 'left', 'right', 'bottom'];
-        $sizeCount = count($this->sizes);
+        $sizeCount = 4;
+
+        if (in_array($this->type, ['header', 'footer', 'font'])) {
+            $sizeCount = 1;
+        }
+
+        $sizes = $style->getBorderSize();
+        $colors = $style->getBorderColor();
+        $styles = $style->getBorderStyle();
+        $spaces = $style->getBorderSpace();
 
         for ($i = 0; $i < $sizeCount; ++$i) {
-            if ($this->sizes[$i] !== null) {
-                $color = null;
-                if (isset($this->colors[$i])) {
-                    $color = $this->colors[$i];
-                }
-                $content .= $this->writeSide($sides[$i], $this->sizes[$i], $color, $this->styles[$i], $this->spaces[$i]);
+            if ($sides[$i] !== null) {
+                $content .= $this->writeSide($sides[$i], $sizes[$i], $colors[$i], $styles[$i], $spaces[$i]);
             }
         }
 
@@ -101,18 +84,17 @@ class Border extends AbstractStyle
      * @param int $width
      * @param string $color
      * @param string $style
-     * @param int $space
      *
      * @return string
      */
-    private function writeSide($side, $width, $color, $style, $space)
+    private function writeSide($side, $width, $color = '', $style, $space)
     {
         $types = [
-            'page' => '\pgbrdr',
+            'section' => '\pgbrdr',
             'header' => '\pgbrdrhead',
             'footer' => '\pgbrdrfoot',
             'paragraph' => '\brdr',
-            'character' => '\chbrdr',
+            'font' => '\chbrdr',
             'row' => '\trbrdr',
             'cell' => '\clbrdr',
         ];
@@ -160,7 +142,7 @@ class Border extends AbstractStyle
         $content = '';
         $type = 'paragraph';
         if (isset($types[$this->type])) {
-            if (in_array($types[$this->type], ['header', 'footer', 'character'])) {
+            if (in_array($types[$this->type], ['header', 'footer', 'font'])) {                
                 $content .= $types[$this->type]; // header, footer, and character borders cannot vary by side
             } else {
                 $content .= $types[$this->type] . substr($side, 0, 1);
@@ -178,7 +160,7 @@ class Border extends AbstractStyle
         $content .= '\brdrcf' . $colorIndex; // Color
 
         // Space
-        if ($this->type == 'page') {
+        if ($this->type == 'section') {
             $space = $space !== null ? $space : '480';
         } elseif ($this->type == 'paragraph') {
             if ($side == 'top' || $side == 'bottom') {
@@ -192,46 +174,6 @@ class Border extends AbstractStyle
         $content .= ' ';
 
         return $content;
-    }
-
-    /**
-     * Set sizes.
-     *
-     * @param int[] $value
-     */
-    public function setSizes($value): void
-    {
-        $this->sizes = $value;
-    }
-
-    /**
-     * Set colors.
-     *
-     * @param string[] $value
-     */
-    public function setColors($value): void
-    {
-        $this->colors = $value;
-    }
-
-    /**
-     * Set styles.
-     *
-     * @param string[] $value
-     */
-    public function setStyles($value): void
-    {
-        $this->styles = $value;
-    }
-
-    /**
-     * Set styles.
-     *
-     * @param string[] $value
-     */
-    public function setSpaces($value): void
-    {
-        $this->spaces = $value;
     }
 
     /**

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -150,7 +150,7 @@ class Border extends AbstractStyle
         } else {
             $content .= '\brdrs'; // default style
         }
-        $content .= $this->getValueIf($width !== null, '\brdrw' . round($width)); // Width
+        $content .= $this->getValueIf($width !== null, '\brdrw' . round($width ?? 0)); // Width
         $content .= '\brdrcf' . $colorIndex; // Color
 
         // Space

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -28,7 +28,7 @@ use PhpOffice\PhpWord\SimpleType\Border as BorderType;
 class Border extends AbstractStyle
 {
     /**
-     * Type. Can be section, header, footer, paragraph, font, row, or cell.
+     * Type. Can be section, paragraph, font, row, or cell.
      *
      * @var string
      */
@@ -57,7 +57,7 @@ class Border extends AbstractStyle
         $sides = ['top', 'left', 'right', 'bottom'];
         $sizeCount = 4;
 
-        if (in_array($this->type, ['header', 'footer', 'font'])) {
+        if ($this->type == 'font') {
             $sizeCount = 1;
         }
 
@@ -88,8 +88,6 @@ class Border extends AbstractStyle
     {
         $types = [
             'section' => '\pgbrdr',
-            'header' => '\pgbrdrhead',
-            'footer' => '\pgbrdrfoot',
             'paragraph' => '\brdr',
             'font' => '\chbrdr',
             'row' => '\trbrdr',
@@ -138,8 +136,8 @@ class Border extends AbstractStyle
 
         $content = '';
         if (isset($types[$this->type])) {
-            if (in_array($types[$this->type], ['header', 'footer', 'font'])) {
-                $content .= $types[$this->type]; // header, footer, and character borders cannot vary by side
+            if ($types[$this->type] == 'font') {
+                $content .= $types[$this->type]; // character borders cannot vary by side
             } else {
                 $content .= $types[$this->type] . substr($side, 0, 1);
             }

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -28,9 +28,7 @@ use PhpOffice\PhpWord\SimpleType\Border as BorderType;
 class Border extends AbstractStyle
 {
     /**
-     * Type
-     *
-     * Can be section, header, footer, paragraph, font, row, or cell.
+     * Type. Can be section, header, footer, paragraph, font, row, or cell.
      *
      * @var string
      */

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -96,7 +96,7 @@ class Border extends AbstractStyle
 
         $styles = [
             BorderType::SINGLE => '\brdrs',
-            BorderType::DASH_DOT_STROKED => '\brdrdashd', // no equivalent in RTF
+            BorderType::DASH_DOT_STROKED => '\brdrdashdotstr',
             BorderType::DASHED => '\brdrdash',
             BorderType::DASH_SMALL_GAP => '\brdrdashsm',
             BorderType::DOT_DASH => '\brdrdashd',

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -77,10 +77,10 @@ class Border extends AbstractStyle
      * Write side.
      *
      * @param string $side
-     * @param int $width
+     * @param float|int $width
      * @param string $color
      * @param string $style
-     * @param int $space
+     * @param float|int $space
      *
      * @return string
      */

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -165,7 +165,9 @@ class Border extends AbstractStyle
                 $space = $space !== null ? $space : '80';
             }
         }
-        $content .= $this->getValueIf($space !== null, '\brsp' . round($space ?? 0));
+        if (in_array($types[$this->type], ['section', 'paragraph'])) {
+            $content .= $this->getValueIf($space !== null, '\brsp' . round($space ?? 0));
+        }
 
         $content .= ' ';
 

--- a/src/PhpWord/Writer/RTF/Style/Border.php
+++ b/src/PhpWord/Writer/RTF/Style/Border.php
@@ -32,7 +32,7 @@ class Border extends AbstractStyle
      *
      * @var string
      */
-    private $type;
+    private $type = 'paragraph';
 
     /**
      * Write style.
@@ -137,7 +137,6 @@ class Border extends AbstractStyle
         }
 
         $content = '';
-        $type = 'paragraph';
         if (isset($types[$this->type])) {
             if (in_array($types[$this->type], ['header', 'footer', 'font'])) {
                 $content .= $types[$this->type]; // header, footer, and character borders cannot vary by side

--- a/src/PhpWord/Writer/RTF/Style/Paragraph.php
+++ b/src/PhpWord/Writer/RTF/Style/Paragraph.php
@@ -106,10 +106,6 @@ class Paragraph extends AbstractStyle
             $styleWriter = new Border($style);
             $styleWriter->setParentWriter($this->getParentWriter());
             $styleWriter->setType('paragraph');
-            $styleWriter->setSizes($style->getBorderSize());
-            $styleWriter->setColors($style->getBorderColor());
-            $styleWriter->setStyles($style->getBorderStyle());
-            $styleWriter->setSpaces($style->getBorderSpace());
             $content .= $styleWriter->write();
         }
 

--- a/src/PhpWord/Writer/RTF/Style/Paragraph.php
+++ b/src/PhpWord/Writer/RTF/Style/Paragraph.php
@@ -101,6 +101,18 @@ class Paragraph extends AbstractStyle
         $styles = $style->getStyleValues();
         $content .= $this->writeTabs($styles['tabs']);
 
+        // Borders
+        if ($style->hasBorder()) {
+            $styleWriter = new Border($style);
+            $styleWriter->setParentWriter($this->getParentWriter());
+            $styleWriter->setType('paragraph');
+            $styleWriter->setSizes($style->getBorderSize());
+            $styleWriter->setColors($style->getBorderColor());
+            $styleWriter->setStyles($style->getBorderStyle());
+            $styleWriter->setSpaces($style->getBorderSpace());
+            $content .= $styleWriter->write();
+        }
+
         return $content;
     }
 

--- a/src/PhpWord/Writer/RTF/Style/Section.php
+++ b/src/PhpWord/Writer/RTF/Style/Section.php
@@ -59,16 +59,9 @@ class Section extends AbstractStyle
 
         // Borders
         if ($style->hasBorder()) {
-            // Page border measure
-            // 8 = from text, infront off; 32 = from edge, infront on; 40 = from edge, infront off
-            $content .= '\pgbrdropt32';
             $styleWriter = new Border($style);
             $styleWriter->setParentWriter($this->getParentWriter());
-            $styleWriter->setType('page');
-            $styleWriter->setSizes($style->getBorderSize());
-            $styleWriter->setColors($style->getBorderColor());
-            $styleWriter->setStyles($style->getBorderStyle());
-            $styleWriter->setSpaces($style->getBorderSpace());
+            $styleWriter->setType('section');
             $content .= $styleWriter->write();
         }
 

--- a/src/PhpWord/Writer/RTF/Style/Section.php
+++ b/src/PhpWord/Writer/RTF/Style/Section.php
@@ -59,10 +59,16 @@ class Section extends AbstractStyle
 
         // Borders
         if ($style->hasBorder()) {
+            // Page border measure
+            // 8 = from text, infront off; 32 = from edge, infront on; 40 = from edge, infront off
+            $content .= '\pgbrdropt32';
             $styleWriter = new Border($style);
             $styleWriter->setParentWriter($this->getParentWriter());
+            $styleWriter->setType('page');
             $styleWriter->setSizes($style->getBorderSize());
             $styleWriter->setColors($style->getBorderColor());
+            $styleWriter->setStyles($style->getBorderStyle());
+            $styleWriter->setSpaces($style->getBorderSpace());
             $content .= $styleWriter->write();
         }
 

--- a/src/PhpWord/Writer/Word2007/Style/MarginBorder.php
+++ b/src/PhpWord/Writer/Word2007/Style/MarginBorder.php
@@ -30,7 +30,7 @@ class MarginBorder extends AbstractStyle
     /**
      * Sizes.
      *
-     * @var int[]
+     * @var array<float|int>
      */
     private $sizes = [];
 
@@ -80,7 +80,7 @@ class MarginBorder extends AbstractStyle
      * Write side.
      *
      * @param string $side
-     * @param int $width
+     * @param float|int $width
      * @param string $color
      * @param string $borderStyle
      */
@@ -111,7 +111,7 @@ class MarginBorder extends AbstractStyle
     /**
      * Set sizes.
      *
-     * @param int[] $value
+     * @param array<float|int> $value
      */
     public function setSizes($value): void
     {

--- a/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
@@ -51,10 +51,10 @@ class BorderTest extends TestCase
         $writer = new BorderWriter($style);
         $writer->setParentWriter($parentWriter);
 
-        $expect = '\brdrt\brdrs\brdrcf0\brsp20 ';
-        $expect .= '\brdrl\brdrs\brdrcf0\brsp80 ';
-        $expect .= '\brdrr\brdrs\brdrcf0\brsp80 ';
-        $expect .= '\brdrb\brdrs\brdrcf0\brsp20 ';
+        $expect = '\brdrt\brdrs\brsp20 ';
+        $expect .= '\brdrl\brdrs\brsp80 ';
+        $expect .= '\brdrr\brdrs\brsp80 ';
+        $expect .= '\brdrb\brdrs\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
     }
 
@@ -74,35 +74,35 @@ class BorderTest extends TestCase
 
         $writer->setType('section');
         $expect = '\pgbrdropt32';
-        $expect .= '\pgbrdrt\brdrs\brdrcf0\brsp480 ';
-        $expect .= '\pgbrdrl\brdrs\brdrcf0\brsp480 ';
-        $expect .= '\pgbrdrr\brdrs\brdrcf0\brsp480 ';
-        $expect .= '\pgbrdrb\brdrs\brdrcf0\brsp480 ';
+        $expect .= '\pgbrdrt\brdrs\brsp480 ';
+        $expect .= '\pgbrdrl\brdrs\brsp480 ';
+        $expect .= '\pgbrdrr\brdrs\brsp480 ';
+        $expect .= '\pgbrdrb\brdrs\brsp480 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $writer->setType('paragraph');
-        $expect = '\brdrt\brdrs\brdrcf0\brsp20 ';
-        $expect .= '\brdrl\brdrs\brdrcf0\brsp80 ';
-        $expect .= '\brdrr\brdrs\brdrcf0\brsp80 ';
-        $expect .= '\brdrb\brdrs\brdrcf0\brsp20 ';
+        $expect = '\brdrt\brdrs\brsp20 ';
+        $expect .= '\brdrl\brdrs\brsp80 ';
+        $expect .= '\brdrr\brdrs\brsp80 ';
+        $expect .= '\brdrb\brdrs\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $writer->setType('font');
-        $expect = '\chbrdr\brdrs\brdrcf0 ';
+        $expect = '\chbrdr\brdrs ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $writer->setType('row');
-        $expect = '\trbrdrt\brdrs\brdrcf0 ';
-        $expect .= '\trbrdrl\brdrs\brdrcf0 ';
-        $expect .= '\trbrdrr\brdrs\brdrcf0 ';
-        $expect .= '\trbrdrb\brdrs\brdrcf0 ';
+        $expect = '\trbrdrt\brdrs ';
+        $expect .= '\trbrdrl\brdrs ';
+        $expect .= '\trbrdrr\brdrs ';
+        $expect .= '\trbrdrb\brdrs ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $writer->setType('cell');
-        $expect = '\clbrdrt\brdrs\brdrcf0 ';
-        $expect .= '\clbrdrl\brdrs\brdrcf0 ';
-        $expect .= '\clbrdrr\brdrs\brdrcf0 ';
-        $expect .= '\clbrdrb\brdrs\brdrcf0 ';
+        $expect = '\clbrdrt\brdrs ';
+        $expect .= '\clbrdrl\brdrs ';
+        $expect .= '\clbrdrr\brdrs ';
+        $expect .= '\clbrdrb\brdrs ';
         self::assertEquals($expect, $this->removeCr($writer));
     }
 
@@ -118,77 +118,77 @@ class BorderTest extends TestCase
         $writer->setParentWriter($parentWriter);
 
         $style->setBorderStyle(BorderType::DASH_DOT_STROKED);
-        $expect = '\brdrt\brdrdashdotstr\brdrcf0\brsp20 ';
-        $expect .= '\brdrl\brdrdashdotstr\brdrcf0\brsp80 ';
-        $expect .= '\brdrr\brdrdashdotstr\brdrcf0\brsp80 ';
-        $expect .= '\brdrb\brdrdashdotstr\brdrcf0\brsp20 ';
+        $expect = '\brdrt\brdrdashdotstr\brsp20 ';
+        $expect .= '\brdrl\brdrdashdotstr\brsp80 ';
+        $expect .= '\brdrr\brdrdashdotstr\brsp80 ';
+        $expect .= '\brdrb\brdrdashdotstr\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $style->setBorderTopStyle(BorderType::DASHED);
         $style->setBorderLeftStyle(BorderType::DASH_SMALL_GAP);
         $style->setBorderRightStyle(BorderType::DOT_DASH);
         $style->setBorderBottomStyle(BorderType::DOT_DOT_DASH);
-        $expect = '\brdrt\brdrdash\brdrcf0\brsp20 ';
-        $expect .= '\brdrl\brdrdashsm\brdrcf0\brsp80 ';
-        $expect .= '\brdrr\brdrdashd\brdrcf0\brsp80 ';
-        $expect .= '\brdrb\brdrdashdd\brdrcf0\brsp20 ';
+        $expect = '\brdrt\brdrdash\brsp20 ';
+        $expect .= '\brdrl\brdrdashsm\brsp80 ';
+        $expect .= '\brdrr\brdrdashd\brsp80 ';
+        $expect .= '\brdrb\brdrdashdd\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $style->setBorderTopStyle(BorderType::DOTTED);
         $style->setBorderLeftStyle(BorderType::DOUBLE);
         $style->setBorderRightStyle(BorderType::DOUBLE_WAVE);
         $style->setBorderBottomStyle(BorderType::INSET);
-        $expect = '\brdrt\brdrdot\brdrcf0\brsp20 ';
-        $expect .= '\brdrl\brdrdb\brdrcf0\brsp80 ';
-        $expect .= '\brdrr\brdrwavydb\brdrcf0\brsp80 ';
-        $expect .= '\brdrb\brdrinset\brdrcf0\brsp20 ';
+        $expect = '\brdrt\brdrdot\brsp20 ';
+        $expect .= '\brdrl\brdrdb\brsp80 ';
+        $expect .= '\brdrr\brdrwavydb\brsp80 ';
+        $expect .= '\brdrb\brdrinset\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $style->setBorderTopStyle(BorderType::NIL);
         $style->setBorderLeftStyle(BorderType::NONE);
         $style->setBorderRightStyle(BorderType::OUTSET);
         $style->setBorderBottomStyle(BorderType::THICK);
-        $expect = '\brdrt\brdrnil\brdrcf0\brsp20 ';
-        $expect .= '\brdrl\brdrnone\brdrcf0\brsp80 ';
-        $expect .= '\brdrr\brdroutset\brdrcf0\brsp80 ';
-        $expect .= '\brdrb\brdrth\brdrcf0\brsp20 ';
+        $expect = '\brdrt\brdrnil\brsp20 ';
+        $expect .= '\brdrl\brdrnone\brsp80 ';
+        $expect .= '\brdrr\brdroutset\brsp80 ';
+        $expect .= '\brdrb\brdrth\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $style->setBorderTopStyle(BorderType::THICK_THIN_LARGE_GAP);
         $style->setBorderLeftStyle(BorderType::THICK_THIN_MEDIUM_GAP);
         $style->setBorderRightStyle(BorderType::THICK_THIN_SMALL_GAP);
         $style->setBorderBottomStyle(BorderType::THIN_THICK_LARGE_GAP);
-        $expect = '\brdrt\brdrtnthlg\brdrcf0\brsp20 ';
-        $expect .= '\brdrl\brdrtnthmg\brdrcf0\brsp80 ';
-        $expect .= '\brdrr\brdrtnthsg\brdrcf0\brsp80 ';
-        $expect .= '\brdrb\brdrthtnlg\brdrcf0\brsp20 ';
+        $expect = '\brdrt\brdrtnthlg\brsp20 ';
+        $expect .= '\brdrl\brdrtnthmg\brsp80 ';
+        $expect .= '\brdrr\brdrtnthsg\brsp80 ';
+        $expect .= '\brdrb\brdrthtnlg\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $style->setBorderTopStyle(BorderType::THIN_THICK_MEDIUM_GAP);
         $style->setBorderLeftStyle(BorderType::THIN_THICK_SMALL_GAP);
         $style->setBorderRightStyle(BorderType::THIN_THICK_THIN_LARGE_GAP);
         $style->setBorderBottomStyle(BorderType::THIN_THICK_THIN_MEDIUM_GAP);
-        $expect = '\brdrt\brdrthtnmg\brdrcf0\brsp20 ';
-        $expect .= '\brdrl\brdrthtnsg\brdrcf0\brsp80 ';
-        $expect .= '\brdrr\brdrtnthtnlg\brdrcf0\brsp80 ';
-        $expect .= '\brdrb\brdrtnthtnmg\brdrcf0\brsp20 ';
+        $expect = '\brdrt\brdrthtnmg\brsp20 ';
+        $expect .= '\brdrl\brdrthtnsg\brsp80 ';
+        $expect .= '\brdrr\brdrtnthtnlg\brsp80 ';
+        $expect .= '\brdrb\brdrtnthtnmg\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $style->setBorderTopStyle(BorderType::THIN_THICK_THIN_SMALL_GAP);
         $style->setBorderLeftStyle(BorderType::THREE_D_EMBOSS);
         $style->setBorderRightStyle(BorderType::THREE_D_ENGRAVE);
         $style->setBorderBottomStyle(BorderType::TRIPLE);
-        $expect = '\brdrt\brdrtnthtnsg\brdrcf0\brsp20 ';
-        $expect .= '\brdrl\brdremboss\brdrcf0\brsp80 ';
-        $expect .= '\brdrr\brdrengrave\brdrcf0\brsp80 ';
-        $expect .= '\brdrb\brdrtriple\brdrcf0\brsp20 ';
+        $expect = '\brdrt\brdrtnthtnsg\brsp20 ';
+        $expect .= '\brdrl\brdremboss\brsp80 ';
+        $expect .= '\brdrr\brdrengrave\brsp80 ';
+        $expect .= '\brdrb\brdrtriple\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $style->setBorderStyle(BorderType::WAVE);
-        $expect = '\brdrt\brdrwavy\brdrcf0\brsp20 ';
-        $expect .= '\brdrl\brdrwavy\brdrcf0\brsp80 ';
-        $expect .= '\brdrr\brdrwavy\brdrcf0\brsp80 ';
-        $expect .= '\brdrb\brdrwavy\brdrcf0\brsp20 ';
+        $expect = '\brdrt\brdrwavy\brsp20 ';
+        $expect .= '\brdrl\brdrwavy\brsp80 ';
+        $expect .= '\brdrr\brdrwavy\brsp80 ';
+        $expect .= '\brdrb\brdrwavy\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
     }
 
@@ -204,20 +204,20 @@ class BorderTest extends TestCase
         $writer->setParentWriter($parentWriter);
 
         $style->setBorderSize(100);
-        $expect = '\brdrt\brdrs\brdrw100\brdrcf0\brsp20 ';
-        $expect .= '\brdrl\brdrs\brdrw100\brdrcf0\brsp80 ';
-        $expect .= '\brdrr\brdrs\brdrw100\brdrcf0\brsp80 ';
-        $expect .= '\brdrb\brdrs\brdrw100\brdrcf0\brsp20 ';
+        $expect = '\brdrt\brdrs\brdrw100\brsp20 ';
+        $expect .= '\brdrl\brdrs\brdrw100\brsp80 ';
+        $expect .= '\brdrr\brdrs\brdrw100\brsp80 ';
+        $expect .= '\brdrb\brdrs\brdrw100\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $style->setBorderTopSize(200);
         $style->setBorderLeftSize(150);
         $style->setBorderRightSize(50);
         $style->setBorderBottomSize(20);
-        $expect = '\brdrt\brdrs\brdrw200\brdrcf0\brsp20 ';
-        $expect .= '\brdrl\brdrs\brdrw150\brdrcf0\brsp80 ';
-        $expect .= '\brdrr\brdrs\brdrw50\brdrcf0\brsp80 ';
-        $expect .= '\brdrb\brdrs\brdrw20\brdrcf0\brsp20 ';
+        $expect = '\brdrt\brdrs\brdrw200\brsp20 ';
+        $expect .= '\brdrl\brdrs\brdrw150\brsp80 ';
+        $expect .= '\brdrr\brdrs\brdrw50\brsp80 ';
+        $expect .= '\brdrb\brdrs\brdrw20\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
     }
 
@@ -240,40 +240,40 @@ class BorderTest extends TestCase
         $writer->setParentWriter($parentWriter);
 
         $style->setBorderSpace(100);
-        $expect = '\brdrt\brdrs\brdrcf0\brsp100 ';
-        $expect .= '\brdrl\brdrs\brdrcf0\brsp100 ';
-        $expect .= '\brdrr\brdrs\brdrcf0\brsp100 ';
-        $expect .= '\brdrb\brdrs\brdrcf0\brsp100 ';
+        $expect = '\brdrt\brdrs\brsp100 ';
+        $expect .= '\brdrl\brdrs\brsp100 ';
+        $expect .= '\brdrr\brdrs\brsp100 ';
+        $expect .= '\brdrb\brdrs\brsp100 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $style->setBorderTopSpace(200);
         $style->setBorderLeftSpace(150);
         $style->setBorderRightSpace(50);
         $style->setBorderBottomSpace(20);
-        $expect = '\brdrt\brdrs\brdrcf0\brsp200 ';
-        $expect .= '\brdrl\brdrs\brdrcf0\brsp150 ';
-        $expect .= '\brdrr\brdrs\brdrcf0\brsp50 ';
-        $expect .= '\brdrb\brdrs\brdrcf0\brsp20 ';
+        $expect = '\brdrt\brdrs\brsp200 ';
+        $expect .= '\brdrl\brdrs\brsp150 ';
+        $expect .= '\brdrr\brdrs\brsp50 ';
+        $expect .= '\brdrb\brdrs\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $writer->setType('font');
-        $expect = '\chbrdr\brdrs\brdrcf0 ';
+        $expect = '\chbrdr\brdrs ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         // Technically rows can have space, but it messes up the table drawing - margin/padding should be used instead.
         $writer->setType('row');
-        $expect = '\trbrdrt\brdrs\brdrcf0 ';
-        $expect .= '\trbrdrl\brdrs\brdrcf0 ';
-        $expect .= '\trbrdrr\brdrs\brdrcf0 ';
-        $expect .= '\trbrdrb\brdrs\brdrcf0 ';
+        $expect = '\trbrdrt\brdrs ';
+        $expect .= '\trbrdrl\brdrs ';
+        $expect .= '\trbrdrr\brdrs ';
+        $expect .= '\trbrdrb\brdrs ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         // Technically cells can have space, but it messes up the table drawing - margin/padding should be used instead.
         $writer->setType('cell');
-        $expect = '\clbrdrt\brdrs\brdrcf0 ';
-        $expect .= '\clbrdrl\brdrs\brdrcf0 ';
-        $expect .= '\clbrdrr\brdrs\brdrcf0 ';
-        $expect .= '\clbrdrb\brdrs\brdrcf0 ';
+        $expect = '\clbrdrt\brdrs ';
+        $expect .= '\clbrdrl\brdrs ';
+        $expect .= '\clbrdrr\brdrs ';
+        $expect .= '\clbrdrb\brdrs ';
         self::assertEquals($expect, $this->removeCr($writer));
     }
 }

--- a/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
@@ -21,7 +21,6 @@ namespace PhpOffice\PhpWordTests\Writer\RTF\Style;
 use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\SimpleType\Border as BorderType;
 use PhpOffice\PhpWord\Style\Border as BorderStyle;
-use PhpOffice\PhpWord\Style\Paragraph as ParagraphStyle;
 use PhpOffice\PhpWord\Writer\RTF;
 use PhpOffice\PhpWord\Writer\RTF\Style\Border as BorderWriter;
 use PHPUnit\Framework\TestCase;
@@ -74,7 +73,8 @@ class BorderTest extends TestCase
         $writer->setParentWriter($parentWriter);
 
         $writer->setType('section');
-        $expect = '\pgbrdrt\brdrs\brdrcf0\brsp480 ';
+        $exoect = '\pgbrdropt32';
+        $expect .= '\pgbrdrt\brdrs\brdrcf0\brsp480 ';
         $expect .= '\pgbrdrl\brdrs\brdrcf0\brsp480 ';
         $expect .= '\pgbrdrr\brdrs\brdrcf0\brsp480 ';
         $expect .= '\pgbrdrb\brdrs\brdrcf0\brsp480 ';
@@ -107,10 +107,10 @@ class BorderTest extends TestCase
     }
 
     /**
-     * Test Border size.
+     * Test Border style.
      * See page 89-90 of RTF Specification 1.9.1 for Paragraph Borders.
      */
-    public function testBorderSize(): void
+    public function testBorderStyle(): void
     {
         $parentWriter = new RTF();
         $style = new BorderStyle();
@@ -136,9 +136,42 @@ class BorderTest extends TestCase
     }
 
     /**
-     * Test Border colors.
+     * Test Border size.
      * See page 89-90 of RTF Specification 1.9.1 for Paragraph Borders.
      */
+    public function testBorderSize(): void
+    {
+        $parentWriter = new RTF();
+        $style = new BorderStyle();
+        $writer = new BorderWriter($style);
+        $writer->setParentWriter($parentWriter);
+
+        $style->setBorderStyle(BorderType::DASH_DOT_STROKED);
+        $expect = '\brdrt\brdrdashd\brdrcf0\brsp20 ';
+        $expect .= '\brdrl\brdrdashd\brdrcf0\brsp80 ';
+        $expect .= '\brdrr\brdrdashd\brdrcf0\brsp80 ';
+        $expect .= '\brdrb\brdrdashd\brdrcf0\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setBorderTopStyle(BorderType::DASHED);
+        $style->setBorderLeftStyle(BorderType::DASH_SMALL_GAP);
+        $style->setBorderRightStyle(BorderType::DOT_DASH);
+        $style->setBorderBottomStyle(BorderType::DOT_DOT_DASH);
+        $expect = '\brdrt\brdrdash\brdrcf0\brsp20 ';
+        $expect .= '\brdrl\brdrdashsm\brdrcf0\brsp80 ';
+        $expect .= '\brdrr\brdrdashd\brdrcf0\brsp80 ';
+        $expect .= '\brdrb\brdrdashdd\brdrcf0\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+    }
+
+    /**
+     * Test Border colors.
+     * See page 89-90 of RTF Specification 1.9.1 for Paragraph Borders.
+     *
+     * Create test when paragraph inherits border.
+     */
+
+    /**
     public function testBorderColor(): void
     {
         $phpWord = new \PhpOffice\PhpWord\PhpWord();
@@ -172,7 +205,7 @@ class BorderTest extends TestCase
         $expect .= '\brdrr\brdrs\brdrcf4\brsp80 ';
         $expect .= '\brdrb\brdrs\brdrcf5\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
-    }
+    } */
 
     /**
      * Test Border space.
@@ -198,7 +231,7 @@ class BorderTest extends TestCase
         $style->setBorderBottomSpace(20);
         $expect = '\brdrt\brdrs\brdrcf0\brsp200 ';
         $expect .= '\brdrl\brdrs\brdrcf0\brsp150 ';
-        $expect .= '\brdrr\brdrs\brdrcf0\brsp500 ';
+        $expect .= '\brdrr\brdrs\brdrcf0\brsp50 ';
         $expect .= '\brdrb\brdrs\brdrcf0\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
 

--- a/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
@@ -44,22 +44,64 @@ class BorderTest extends TestCase
      * Test Border styles in paragraph.
      * See page 89-90 of RTF Specification 1.9.1 for Paragraph Borders.
      */
-    public function testBorderStyle(): void
+    public function testBorderBasic(): void
     {
         $parentWriter = new RTF();
         $style = new BorderStyle();
         $writer = new BorderWriter($style);
         $writer->setParentWriter($parentWriter);
 
-        $style->setBorderSize(40);
-        $style->setBorderColor('#FF0000');
-        $style->setBorderStyle(BorderType::DASHED);
-        $style->setBorderSpace(20);
+        $expect = '\brdrt\brdrs\brsp20 ';
+        $expect .= '\brdrl\brdrs\brsp80 ';
+        $expect .= '\brdrr\brdrs\brsp80 ';
+        $expect .= '\brdrb\brdrs\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+    }
 
-        $expect = '\brdrt\brdrdash\brdrw40\brdrcf0\brsp20 ';
-        $expect .= '\brdrl\brdrdash\brdrw40\brdrcf0\brsp20 ';
-        $expect .= '\brdrr\brdrdash\brdrw40\brdrcf0\brsp20 ';
-        $expect .= '\brdrb\brdrdash\brdrw40\brdrcf0\brsp20 ';
+    /**
+     * Test Border styles in paragraph.
+     * See page 76 of RTF Specification 1.9.1 for Page Borders.
+     * See page 89-90 of RTF Specification 1.9.1 for Paragraph Borders.
+     * See page 103 of RTF Specification 1.9.1 for Row Borders and Cell Borders.
+     * See page 139 of RTF Specification 1.9.1 for Character Borders.
+     */
+    public function testBorderType(): void
+    {
+        $parentWriter = new RTF();
+        $style = new BorderStyle();
+        $writer = new BorderWriter($style);
+        $writer->setParentWriter($parentWriter);
+
+        $writer->setType('section');
+        $expect = '\pgbrdrt\brdrs\brsp480 ';
+        $expect .= '\pgbrdrl\brdrs\brsp480 ';
+        $expect .= '\pgbrdrr\brdrs\brsp480 ';
+        $expect .= '\pgbrdrb\brdrs\brsp480 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $writer->setType('paragraph');
+        $expect = '\brdrt\brdrs\brsp20 ';
+        $expect .= '\brdrl\brdrs\brsp80 ';
+        $expect .= '\brdrr\brdrs\brsp80 ';
+        $expect .= '\brdrb\brdrs\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $writer->setType('font');
+        $expect = '\chbrdr\brdrs ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $writer->setType('row');
+        $expect = '\tdbrdrt\brdrs ';
+        $expect .= '\tdbrdrl\brdrs ';
+        $expect .= '\tdbrdrr\brdrs ';
+        $expect .= '\tdbrdrb\brdrs ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $writer->setType('cell');
+        $expect = '\clbrdrt\brdrs ';
+        $expect .= '\clbrdrl\brdrs ';
+        $expect .= '\clbrdrr\brdrs ';
+        $expect .= '\clbrdrb\brdrs ';
         self::assertEquals($expect, $this->removeCr($writer));
     }
 }

--- a/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
@@ -51,15 +51,15 @@ class BorderTest extends TestCase
         $writer = new BorderWriter($style);
         $writer->setParentWriter($parentWriter);
 
-        $border->setBorderSize(40);
-        $border->setBorderColor('#FF0000');
-        $border->setBorderStyle(BorderType::DASHED);
-        $border->setBorderSpace(20);
+        $style->setBorderSize(40);
+        $style->setBorderColor('#FF0000');
+        $style->setBorderStyle(BorderType::DASHED);
+        $style->setBorderSpace(20);
 
-        $expected .= '\brdrt\brdrdash\brdrw40\brdrcf0\brsp20 ';
-        $expected .= '\brdrl\brdrdash\brdrw40\brdrcf0\brsp20 ';
-        $expected .= '\brdrr\brdrdash\brdrw40\brdrcf0\brsp20 ';
-        $expected .= '\brdrb\brdrdash\brdrw40\brdrcf0\brsp20 ';
+        $expect = '\brdrt\brdrdash\brdrw40\brdrcf0\brsp20 ';
+        $expect .= '\brdrl\brdrdash\brdrw40\brdrcf0\brsp20 ';
+        $expect .= '\brdrr\brdrdash\brdrw40\brdrcf0\brsp20 ';
+        $expect .= '\brdrb\brdrdash\brdrw40\brdrcf0\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
     }
 }

--- a/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWordTests\Writer\RTF\Style;
+
+use PhpOffice\PhpWord\Settings;
+use PhpOffice\PhpWord\SimpleType\Border as BorderType;
+use PhpOffice\PhpWord\Style\Border as BorderStyle;
+use PhpOffice\PhpWord\Writer\RTF;
+use PhpOffice\PhpWord\Writer\RTF\Style\Border as BorderWriter;
+use PHPUnit\Framework\TestCase;
+
+class BorderTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Settings::setDefaultRtl(null);
+    }
+
+    /**
+     * @param BorderWriter $field
+     */
+    public function removeCr($field): string
+    {
+        return str_replace("\r\n", "\n", $field->write());
+    }
+
+    /**
+     * Test Border styles in paragraph.
+     * See page 89-90 of RTF Specification 1.9.1 for Paragraph Borders.
+     */
+    public function testBorderStyle(): void
+    {
+        $parentWriter = new RTF();
+        $style = new BorderStyle();
+        $writer = new BorderWriter($style);
+        $writer->setParentWriter($parentWriter);
+
+        $border->setBorderSize(40);
+        $border->setBorderColor('#FF0000');
+        $border->setBorderStyle(BorderType::DASHED);
+        $border->setBorderSpace(20);
+
+        $expected .= '\brdrt\brdrdash\brdrw40\brdrcf0\brsp20 ';
+        $expected .= '\brdrl\brdrdash\brdrw40\brdrcf0\brsp20 ';
+        $expected .= '\brdrr\brdrdash\brdrw40\brdrcf0\brsp20 ';
+        $expected .= '\brdrb\brdrdash\brdrw40\brdrcf0\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+    }
+}

--- a/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
@@ -92,10 +92,10 @@ class BorderTest extends TestCase
         self::assertEquals($expect, $this->removeCr($writer));
 
         $writer->setType('row');
-        $expect = '\tdbrdrt\brdrs\brdrcf0 ';
-        $expect .= '\tdbrdrl\brdrs\brdrcf0 ';
-        $expect .= '\tdbrdrr\brdrs\brdrcf0 ';
-        $expect .= '\tdbrdrb\brdrs\brdrcf0 ';
+        $expect = '\trbrdrt\brdrs\brdrcf0 ';
+        $expect .= '\trbrdrl\brdrs\brdrcf0 ';
+        $expect .= '\trbrdrr\brdrs\brdrcf0 ';
+        $expect .= '\trbrdrb\brdrs\brdrcf0 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $writer->setType('cell');
@@ -111,35 +111,6 @@ class BorderTest extends TestCase
      * See page 89-90 of RTF Specification 1.9.1 for Paragraph Borders.
      */
     public function testBorderStyle(): void
-    {
-        $parentWriter = new RTF();
-        $style = new BorderStyle();
-        $writer = new BorderWriter($style);
-        $writer->setParentWriter($parentWriter);
-
-        $style->setBorderSize(100);
-        $expect = '\brdrt\brdrs\brdrw100\brdrcf0\brsp20 ';
-        $expect .= '\brdrl\brdrs\brdrw100\brdrcf0\brsp80 ';
-        $expect .= '\brdrr\brdrs\brdrw100\brdrcf0\brsp80 ';
-        $expect .= '\brdrb\brdrs\brdrw100\brdrcf0\brsp20 ';
-        self::assertEquals($expect, $this->removeCr($writer));
-
-        $style->setBorderTopSize(200);
-        $style->setBorderLeftSize(150);
-        $style->setBorderRightSize(50);
-        $style->setBorderBottomSize(20);
-        $expect = '\brdrt\brdrs\brdrw200\brdrcf0\brsp20 ';
-        $expect .= '\brdrl\brdrs\brdrw150\brdrcf0\brsp80 ';
-        $expect .= '\brdrr\brdrs\brdrw50\brdrcf0\brsp80 ';
-        $expect .= '\brdrb\brdrs\brdrw20\brdrcf0\brsp20 ';
-        self::assertEquals($expect, $this->removeCr($writer));
-    }
-
-    /**
-     * Test Border size.
-     * See page 89-90 of RTF Specification 1.9.1 for Paragraph Borders.
-     */
-    public function testBorderSize(): void
     {
         $parentWriter = new RTF();
         $style = new BorderStyle();
@@ -169,8 +140,8 @@ class BorderTest extends TestCase
         $style->setBorderBottomStyle(BorderType::INSET);
         $expect = '\brdrt\brdrdot\brdrcf0\brsp20 ';
         $expect .= '\brdrl\brdrdb\brdrcf0\brsp80 ';
-        $expect .= '\brdrr\brdrdashd\brdrwavydb\brsp80 ';
-        $expect .= '\brdrb\brdrdashdd\brdrinset\brsp20 ';
+        $expect .= '\brdrr\brdrwavydb\brdrcf0\brsp80 ';
+        $expect .= '\brdrb\brdrinset\brdrcf0\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $style->setBorderTopStyle(BorderType::NIL);
@@ -218,6 +189,35 @@ class BorderTest extends TestCase
         $expect .= '\brdrl\brdrwavy\brdrcf0\brsp80 ';
         $expect .= '\brdrr\brdrwavy\brdrcf0\brsp80 ';
         $expect .= '\brdrb\brdrwavy\brdrcf0\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+    }
+
+    /**
+     * Test Border size.
+     * See page 89-90 of RTF Specification 1.9.1 for Paragraph Borders.
+     */
+    public function testBorderSize(): void
+    {
+        $parentWriter = new RTF();
+        $style = new BorderStyle();
+        $writer = new BorderWriter($style);
+        $writer->setParentWriter($parentWriter);
+
+        $style->setBorderSize(100);
+        $expect = '\brdrt\brdrs\brdrw100\brdrcf0\brsp20 ';
+        $expect .= '\brdrl\brdrs\brdrw100\brdrcf0\brsp80 ';
+        $expect .= '\brdrr\brdrs\brdrw100\brdrcf0\brsp80 ';
+        $expect .= '\brdrb\brdrs\brdrw100\brdrcf0\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setBorderTopSize(200);
+        $style->setBorderLeftSize(150);
+        $style->setBorderRightSize(50);
+        $style->setBorderBottomSize(20);
+        $expect = '\brdrt\brdrs\brdrw200\brdrcf0\brsp20 ';
+        $expect .= '\brdrl\brdrs\brdrw150\brdrcf0\brsp80 ';
+        $expect .= '\brdrr\brdrs\brdrw50\brdrcf0\brsp80 ';
+        $expect .= '\brdrb\brdrs\brdrw20\brdrcf0\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
     }
 

--- a/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
@@ -51,10 +51,35 @@ class BorderTest extends TestCase
         $writer = new BorderWriter($style);
         $writer->setParentWriter($parentWriter);
 
-        $expect = '\brdrt\brdrs\brsp20 ';
-        $expect .= '\brdrl\brdrs\brsp80 ';
-        $expect .= '\brdrr\brdrs\brsp80 ';
-        $expect .= '\brdrb\brdrs\brsp20 ';
+        $expect = '';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setBorderSize(1);
+        $expect = '\brdrt\brdrs\brdrw1\brsp20 ';
+        $expect .= '\brdrl\brdrs\brdrw1\brsp80 ';
+        $expect .= '\brdrr\brdrs\brdrw1\brsp80 ';
+        $expect .= '\brdrb\brdrs\brdrw1\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+    }
+
+    /**
+     * Test Border not all all four sides.
+     * See page 89-90 of RTF Specification 1.9.1 for Paragraph Borders.
+     */
+    public function testBorderSide(): void
+    {
+        $parentWriter = new RTF();
+        $style = new BorderStyle();
+        $writer = new BorderWriter($style);
+        $writer->setParentWriter($parentWriter);
+
+        $style->setBorderLeftSize(1);
+        $expect = '\brdrl\brdrs\brdrw1\brsp80 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setBorderBottomSize(100);
+        $expect = '\brdrl\brdrs\brdrw1\brsp80 ';
+        $expect .= '\brdrb\brdrs\brdrw100\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
     }
 
@@ -72,37 +97,39 @@ class BorderTest extends TestCase
         $writer = new BorderWriter($style);
         $writer->setParentWriter($parentWriter);
 
+        $style->setBorderSize(1);
+
         $writer->setType('section');
         $expect = '\pgbrdropt32';
-        $expect .= '\pgbrdrt\brdrs\brsp480 ';
-        $expect .= '\pgbrdrl\brdrs\brsp480 ';
-        $expect .= '\pgbrdrr\brdrs\brsp480 ';
-        $expect .= '\pgbrdrb\brdrs\brsp480 ';
+        $expect .= '\pgbrdrt\brdrs\brdrw1\brsp480 ';
+        $expect .= '\pgbrdrl\brdrs\brdrw1\brsp480 ';
+        $expect .= '\pgbrdrr\brdrs\brdrw1\brsp480 ';
+        $expect .= '\pgbrdrb\brdrs\brdrw1\brsp480 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $writer->setType('paragraph');
-        $expect = '\brdrt\brdrs\brsp20 ';
-        $expect .= '\brdrl\brdrs\brsp80 ';
-        $expect .= '\brdrr\brdrs\brsp80 ';
-        $expect .= '\brdrb\brdrs\brsp20 ';
+        $expect = '\brdrt\brdrs\brdrw1\brsp20 ';
+        $expect .= '\brdrl\brdrs\brdrw1\brsp80 ';
+        $expect .= '\brdrr\brdrs\brdrw1\brsp80 ';
+        $expect .= '\brdrb\brdrs\brdrw1\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $writer->setType('font');
-        $expect = '\chbrdr\brdrs ';
+        $expect = '\chbrdr\brdrs\brdrw1 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $writer->setType('row');
-        $expect = '\trbrdrt\brdrs ';
-        $expect .= '\trbrdrl\brdrs ';
-        $expect .= '\trbrdrr\brdrs ';
-        $expect .= '\trbrdrb\brdrs ';
+        $expect = '\trbrdrt\brdrs\brdrw1 ';
+        $expect .= '\trbrdrl\brdrs\brdrw1 ';
+        $expect .= '\trbrdrr\brdrs\brdrw1 ';
+        $expect .= '\trbrdrb\brdrs\brdrw1 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $writer->setType('cell');
-        $expect = '\clbrdrt\brdrs ';
-        $expect .= '\clbrdrl\brdrs ';
-        $expect .= '\clbrdrr\brdrs ';
-        $expect .= '\clbrdrb\brdrs ';
+        $expect = '\clbrdrt\brdrs\brdrw1 ';
+        $expect .= '\clbrdrl\brdrs\brdrw1 ';
+        $expect .= '\clbrdrr\brdrs\brdrw1 ';
+        $expect .= '\clbrdrb\brdrs\brdrw1 ';
         self::assertEquals($expect, $this->removeCr($writer));
     }
 
@@ -256,24 +283,19 @@ class BorderTest extends TestCase
         $expect .= '\brdrb\brdrs\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
+        // Space doesn't matter for fonts.
         $writer->setType('font');
-        $expect = '\chbrdr\brdrs ';
+        $expect = '';
         self::assertEquals($expect, $this->removeCr($writer));
 
-        // Technically rows can have space, but it messes up the table drawing - margin/padding should be used instead.
+        // Space doesn't matter for rows.
         $writer->setType('row');
-        $expect = '\trbrdrt\brdrs ';
-        $expect .= '\trbrdrl\brdrs ';
-        $expect .= '\trbrdrr\brdrs ';
-        $expect .= '\trbrdrb\brdrs ';
+        $expect = '';
         self::assertEquals($expect, $this->removeCr($writer));
 
-        // Technically cells can have space, but it messes up the table drawing - margin/padding should be used instead.
+        // Space doesn't matter for cells.
         $writer->setType('cell');
-        $expect = '\clbrdrt\brdrs ';
-        $expect .= '\clbrdrl\brdrs ';
-        $expect .= '\clbrdrr\brdrs ';
-        $expect .= '\clbrdrb\brdrs ';
+        $expect = '';
         self::assertEquals($expect, $this->removeCr($writer));
     }
 }

--- a/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
@@ -21,6 +21,7 @@ namespace PhpOffice\PhpWordTests\Writer\RTF\Style;
 use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\SimpleType\Border as BorderType;
 use PhpOffice\PhpWord\Style\Border as BorderStyle;
+use PhpOffice\PhpWord\Style\Paragraph as ParagraphStyle;
 use PhpOffice\PhpWord\Writer\RTF;
 use PhpOffice\PhpWord\Writer\RTF\Style\Border as BorderWriter;
 use PHPUnit\Framework\TestCase;
@@ -51,10 +52,10 @@ class BorderTest extends TestCase
         $writer = new BorderWriter($style);
         $writer->setParentWriter($parentWriter);
 
-        $expect = '\brdrt\brdrs\brsp20 ';
-        $expect .= '\brdrl\brdrs\brsp80 ';
-        $expect .= '\brdrr\brdrs\brsp80 ';
-        $expect .= '\brdrb\brdrs\brsp20 ';
+        $expect = '\brdrt\brdrs\brdrcf0\brsp20 ';
+        $expect .= '\brdrl\brdrs\brdrcf0\brsp80 ';
+        $expect .= '\brdrr\brdrs\brdrcf0\brsp80 ';
+        $expect .= '\brdrb\brdrs\brdrcf0\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
     }
 
@@ -73,35 +74,152 @@ class BorderTest extends TestCase
         $writer->setParentWriter($parentWriter);
 
         $writer->setType('section');
-        $expect = '\pgbrdrt\brdrs\brsp480 ';
-        $expect .= '\pgbrdrl\brdrs\brsp480 ';
-        $expect .= '\pgbrdrr\brdrs\brsp480 ';
-        $expect .= '\pgbrdrb\brdrs\brsp480 ';
+        $expect = '\pgbrdrt\brdrs\brdrcf0\brsp480 ';
+        $expect .= '\pgbrdrl\brdrs\brdrcf0\brsp480 ';
+        $expect .= '\pgbrdrr\brdrs\brdrcf0\brsp480 ';
+        $expect .= '\pgbrdrb\brdrs\brdrcf0\brsp480 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $writer->setType('paragraph');
-        $expect = '\brdrt\brdrs\brsp20 ';
-        $expect .= '\brdrl\brdrs\brsp80 ';
-        $expect .= '\brdrr\brdrs\brsp80 ';
-        $expect .= '\brdrb\brdrs\brsp20 ';
+        $expect = '\brdrt\brdrs\brdrcf0\brsp20 ';
+        $expect .= '\brdrl\brdrs\brdrcf0\brsp80 ';
+        $expect .= '\brdrr\brdrs\brdrcf0\brsp80 ';
+        $expect .= '\brdrb\brdrs\brdrcf0\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $writer->setType('font');
-        $expect = '\chbrdr\brdrs ';
+        $expect = '\chbrdr\brdrs\brdrcf0 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $writer->setType('row');
-        $expect = '\tdbrdrt\brdrs ';
-        $expect .= '\tdbrdrl\brdrs ';
-        $expect .= '\tdbrdrr\brdrs ';
-        $expect .= '\tdbrdrb\brdrs ';
+        $expect = '\tdbrdrt\brdrs\brdrcf0 ';
+        $expect .= '\tdbrdrl\brdrs\brdrcf0 ';
+        $expect .= '\tdbrdrr\brdrs\brdrcf0 ';
+        $expect .= '\tdbrdrb\brdrs\brdrcf0 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $writer->setType('cell');
-        $expect = '\clbrdrt\brdrs ';
-        $expect .= '\clbrdrl\brdrs ';
-        $expect .= '\clbrdrr\brdrs ';
-        $expect .= '\clbrdrb\brdrs ';
+        $expect = '\clbrdrt\brdrs\brdrcf0 ';
+        $expect .= '\clbrdrl\brdrs\brdrcf0 ';
+        $expect .= '\clbrdrr\brdrs\brdrcf0 ';
+        $expect .= '\clbrdrb\brdrs\brdrcf0 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+    }
+
+    /**
+     * Test Border size.
+     * See page 89-90 of RTF Specification 1.9.1 for Paragraph Borders.
+     */
+    public function testBorderSize(): void
+    {
+        $parentWriter = new RTF();
+        $style = new BorderStyle();
+        $writer = new BorderWriter($style);
+        $writer->setParentWriter($parentWriter);
+
+        $style->setBorderSize(100);
+        $expect = '\brdrt\brdrs\brdrw100\brdrcf0\brsp20 ';
+        $expect .= '\brdrl\brdrs\brdrw100\brdrcf0\brsp80 ';
+        $expect .= '\brdrr\brdrs\brdrw100\brdrcf0\brsp80 ';
+        $expect .= '\brdrb\brdrs\brdrw100\brdrcf0\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setBorderTopSize(200);
+        $style->setBorderLeftSize(150);
+        $style->setBorderRightSize(50);
+        $style->setBorderBottomSize(20);
+        $expect = '\brdrt\brdrs\brdrw200\brdrcf0\brsp20 ';
+        $expect .= '\brdrl\brdrs\brdrw150\brdrcf0\brsp80 ';
+        $expect .= '\brdrr\brdrs\brdrw50\brdrcf0\brsp80 ';
+        $expect .= '\brdrb\brdrs\brdrw20\brdrcf0\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+    }
+
+    /**
+     * Test Border colors.
+     * See page 89-90 of RTF Specification 1.9.1 for Paragraph Borders.
+     */
+    public function testBorderColor(): void
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $parentWriter = new RTF($phpWord);
+
+        $style1 = new ParagraphStyle();
+        $style1->setBorderColor('FFFFFF');
+        $phpWord->addParagraphStyle('style1', $style1);
+
+        $style2 = new ParagraphStyle();
+        $style2->setBorderTopColor('FFFF00');
+        $style2->setBorderLeftColor('FF0000');
+        $style2->setBorderRightColor('000000');
+        $style2->setBorderBottomColor('0000FF');
+        $phpWord->addParagraphStyle('style2', $style2);
+
+        $parentWriter->getWriterPart('Header')->write();
+
+        $writer = new BorderWriter(new Border($style1));
+        $writer->setParentWriter($parentWriter);
+        $expect = '\brdrt\brdrs\brdrcf1\brsp20 ';
+        $expect .= '\brdrl\brdrs\brdrcf1\brsp80 ';
+        $expect .= '\brdrr\brdrs\brdrcf1\brsp80 ';
+        $expect .= '\brdrb\brdrs\brdrcf1\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $writer = new BorderWriter(new Border($style2));
+        $writer->setParentWriter($parentWriter);
+        $expect = '\brdrt\brdrs\brdrcf2\brsp20 ';
+        $expect .= '\brdrl\brdrs\brdrcf3\brsp80 ';
+        $expect .= '\brdrr\brdrs\brdrcf4\brsp80 ';
+        $expect .= '\brdrb\brdrs\brdrcf5\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+    }
+
+    /**
+     * Test Border space.
+     * See page 89-90 of RTF Specification 1.9.1 for Paragraph Borders.
+     */
+    public function testBorderSpace(): void
+    {
+        $parentWriter = new RTF();
+        $style = new BorderStyle();
+        $writer = new BorderWriter($style);
+        $writer->setParentWriter($parentWriter);
+
+        $style->setBorderSpace(100);
+        $expect = '\brdrt\brdrs\brdrcf0\brsp100 ';
+        $expect .= '\brdrl\brdrs\brdrcf0\brsp100 ';
+        $expect .= '\brdrr\brdrs\brdrcf0\brsp100 ';
+        $expect .= '\brdrb\brdrs\brdrcf0\brsp100 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setBorderTopSpace(200);
+        $style->setBorderLeftSpace(150);
+        $style->setBorderRightSpace(50);
+        $style->setBorderBottomSpace(20);
+        $expect = '\brdrt\brdrs\brdrcf0\brsp200 ';
+        $expect .= '\brdrl\brdrs\brdrcf0\brsp150 ';
+        $expect .= '\brdrr\brdrs\brdrcf0\brsp500 ';
+        $expect .= '\brdrb\brdrs\brdrcf0\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $writer->setType('font');
+        $expect = '\chbrdr\brdrs\brdrcf0 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        // Technically rows can have \brspN, but it messes up the table drawing - margin/padding should be used instead.
+        $writer->setType('row');
+        $expect = '\tdbrdrt\brdrs\brdrcf0 ';
+        $expect .= '\tdbrdrl\brdrs\brdrcf0 ';
+        $expect .= '\tdbrdrr\brdrs\brdrcf0 ';
+        $expect .= '\tdbrdrb\brdrs\brdrcf0 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        // Technically cells can have \brspN, but it messes up the table drawing - margin/padding should be used instead.
+        $writer->setType('cell');
+        $expect = '\clbrdrt\brdrs\brdrcf0 ';
+        $expect .= '\clbrdrl\brdrs\brdrcf0 ';
+        $expect .= '\clbrdrr\brdrs\brdrcf0 ';
+        $expect .= '\clbrdrb\brdrs\brdrcf0 ';
         self::assertEquals($expect, $this->removeCr($writer));
     }
 }

--- a/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
+++ b/tests/PhpWordTests/Writer/RTF/Style/BorderTest.php
@@ -73,7 +73,7 @@ class BorderTest extends TestCase
         $writer->setParentWriter($parentWriter);
 
         $writer->setType('section');
-        $exoect = '\pgbrdropt32';
+        $expect = '\pgbrdropt32';
         $expect .= '\pgbrdrt\brdrs\brdrcf0\brsp480 ';
         $expect .= '\pgbrdrl\brdrs\brdrcf0\brsp480 ';
         $expect .= '\pgbrdrr\brdrs\brdrcf0\brsp480 ';
@@ -147,10 +147,10 @@ class BorderTest extends TestCase
         $writer->setParentWriter($parentWriter);
 
         $style->setBorderStyle(BorderType::DASH_DOT_STROKED);
-        $expect = '\brdrt\brdrdashd\brdrcf0\brsp20 ';
-        $expect .= '\brdrl\brdrdashd\brdrcf0\brsp80 ';
-        $expect .= '\brdrr\brdrdashd\brdrcf0\brsp80 ';
-        $expect .= '\brdrb\brdrdashd\brdrcf0\brsp20 ';
+        $expect = '\brdrt\brdrdashdotstr\brdrcf0\brsp20 ';
+        $expect .= '\brdrl\brdrdashdotstr\brdrcf0\brsp80 ';
+        $expect .= '\brdrr\brdrdashdotstr\brdrcf0\brsp80 ';
+        $expect .= '\brdrb\brdrdashdotstr\brdrcf0\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
         $style->setBorderTopStyle(BorderType::DASHED);
@@ -162,6 +162,63 @@ class BorderTest extends TestCase
         $expect .= '\brdrr\brdrdashd\brdrcf0\brsp80 ';
         $expect .= '\brdrb\brdrdashdd\brdrcf0\brsp20 ';
         self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setBorderTopStyle(BorderType::DOTTED);
+        $style->setBorderLeftStyle(BorderType::DOUBLE);
+        $style->setBorderRightStyle(BorderType::DOUBLE_WAVE);
+        $style->setBorderBottomStyle(BorderType::INSET);
+        $expect = '\brdrt\brdrdot\brdrcf0\brsp20 ';
+        $expect .= '\brdrl\brdrdb\brdrcf0\brsp80 ';
+        $expect .= '\brdrr\brdrdashd\brdrwavydb\brsp80 ';
+        $expect .= '\brdrb\brdrdashdd\brdrinset\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setBorderTopStyle(BorderType::NIL);
+        $style->setBorderLeftStyle(BorderType::NONE);
+        $style->setBorderRightStyle(BorderType::OUTSET);
+        $style->setBorderBottomStyle(BorderType::THICK);
+        $expect = '\brdrt\brdrnil\brdrcf0\brsp20 ';
+        $expect .= '\brdrl\brdrnone\brdrcf0\brsp80 ';
+        $expect .= '\brdrr\brdroutset\brdrcf0\brsp80 ';
+        $expect .= '\brdrb\brdrth\brdrcf0\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setBorderTopStyle(BorderType::THICK_THIN_LARGE_GAP);
+        $style->setBorderLeftStyle(BorderType::THICK_THIN_MEDIUM_GAP);
+        $style->setBorderRightStyle(BorderType::THICK_THIN_SMALL_GAP);
+        $style->setBorderBottomStyle(BorderType::THIN_THICK_LARGE_GAP);
+        $expect = '\brdrt\brdrtnthlg\brdrcf0\brsp20 ';
+        $expect .= '\brdrl\brdrtnthmg\brdrcf0\brsp80 ';
+        $expect .= '\brdrr\brdrtnthsg\brdrcf0\brsp80 ';
+        $expect .= '\brdrb\brdrthtnlg\brdrcf0\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setBorderTopStyle(BorderType::THIN_THICK_MEDIUM_GAP);
+        $style->setBorderLeftStyle(BorderType::THIN_THICK_SMALL_GAP);
+        $style->setBorderRightStyle(BorderType::THIN_THICK_THIN_LARGE_GAP);
+        $style->setBorderBottomStyle(BorderType::THIN_THICK_THIN_MEDIUM_GAP);
+        $expect = '\brdrt\brdrthtnmg\brdrcf0\brsp20 ';
+        $expect .= '\brdrl\brdrthtnsg\brdrcf0\brsp80 ';
+        $expect .= '\brdrr\brdrtnthtnlg\brdrcf0\brsp80 ';
+        $expect .= '\brdrb\brdrtnthtnmg\brdrcf0\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setBorderTopStyle(BorderType::THIN_THICK_THIN_SMALL_GAP);
+        $style->setBorderLeftStyle(BorderType::THREE_D_EMBOSS);
+        $style->setBorderRightStyle(BorderType::THREE_D_ENGRAVE);
+        $style->setBorderBottomStyle(BorderType::TRIPLE);
+        $expect = '\brdrt\brdrtnthtnsg\brdrcf0\brsp20 ';
+        $expect .= '\brdrl\brdremboss\brdrcf0\brsp80 ';
+        $expect .= '\brdrr\brdrengrave\brdrcf0\brsp80 ';
+        $expect .= '\brdrb\brdrtriple\brdrcf0\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
+
+        $style->setBorderStyle(BorderType::WAVE);
+        $expect = '\brdrt\brdrwavy\brdrcf0\brsp20 ';
+        $expect .= '\brdrl\brdrwavy\brdrcf0\brsp80 ';
+        $expect .= '\brdrr\brdrwavy\brdrcf0\brsp80 ';
+        $expect .= '\brdrb\brdrwavy\brdrcf0\brsp20 ';
+        self::assertEquals($expect, $this->removeCr($writer));
     }
 
     /**
@@ -170,42 +227,6 @@ class BorderTest extends TestCase
      *
      * Create test when paragraph inherits border.
      */
-
-    /**
-    public function testBorderColor(): void
-    {
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
-        $parentWriter = new RTF($phpWord);
-
-        $style1 = new ParagraphStyle();
-        $style1->setBorderColor('FFFFFF');
-        $phpWord->addParagraphStyle('style1', $style1);
-
-        $style2 = new ParagraphStyle();
-        $style2->setBorderTopColor('FFFF00');
-        $style2->setBorderLeftColor('FF0000');
-        $style2->setBorderRightColor('000000');
-        $style2->setBorderBottomColor('0000FF');
-        $phpWord->addParagraphStyle('style2', $style2);
-
-        $parentWriter->getWriterPart('Header')->write();
-
-        $writer = new BorderWriter(new Border($style1));
-        $writer->setParentWriter($parentWriter);
-        $expect = '\brdrt\brdrs\brdrcf1\brsp20 ';
-        $expect .= '\brdrl\brdrs\brdrcf1\brsp80 ';
-        $expect .= '\brdrr\brdrs\brdrcf1\brsp80 ';
-        $expect .= '\brdrb\brdrs\brdrcf1\brsp20 ';
-        self::assertEquals($expect, $this->removeCr($writer));
-
-        $writer = new BorderWriter(new Border($style2));
-        $writer->setParentWriter($parentWriter);
-        $expect = '\brdrt\brdrs\brdrcf2\brsp20 ';
-        $expect .= '\brdrl\brdrs\brdrcf3\brsp80 ';
-        $expect .= '\brdrr\brdrs\brdrcf4\brsp80 ';
-        $expect .= '\brdrb\brdrs\brdrcf5\brsp20 ';
-        self::assertEquals($expect, $this->removeCr($writer));
-    } */
 
     /**
      * Test Border space.
@@ -239,15 +260,15 @@ class BorderTest extends TestCase
         $expect = '\chbrdr\brdrs\brdrcf0 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
-        // Technically rows can have \brspN, but it messes up the table drawing - margin/padding should be used instead.
+        // Technically rows can have space, but it messes up the table drawing - margin/padding should be used instead.
         $writer->setType('row');
-        $expect = '\tdbrdrt\brdrs\brdrcf0 ';
-        $expect .= '\tdbrdrl\brdrs\brdrcf0 ';
-        $expect .= '\tdbrdrr\brdrs\brdrcf0 ';
-        $expect .= '\tdbrdrb\brdrs\brdrcf0 ';
+        $expect = '\trbrdrt\brdrs\brdrcf0 ';
+        $expect .= '\trbrdrl\brdrs\brdrcf0 ';
+        $expect .= '\trbrdrr\brdrs\brdrcf0 ';
+        $expect .= '\trbrdrb\brdrs\brdrcf0 ';
         self::assertEquals($expect, $this->removeCr($writer));
 
-        // Technically cells can have \brspN, but it messes up the table drawing - margin/padding should be used instead.
+        // Technically cells can have space, but it messes up the table drawing - margin/padding should be used instead.
         $writer->setType('cell');
         $expect = '\clbrdrt\brdrs\brdrcf0 ';
         $expect .= '\clbrdrl\brdrs\brdrcf0 ';

--- a/tests/PhpWordTests/Writer/RTF/StyleTest.php
+++ b/tests/PhpWordTests/Writer/RTF/StyleTest.php
@@ -64,7 +64,7 @@ class StyleTest extends \PHPUnit\Framework\TestCase
         $content = $borderWriter->write();
 
         $expected = '\pgbrdropt32';
-        $expected . = '\pgbrdrt\brdrs\brdrw40\brdrcf0\brsp480 ';
+        $expected .= '\pgbrdrt\brdrs\brdrw40\brdrcf0\brsp480 ';
         $expected .= '\pgbrdrl\brdrs\brdrw20\brdrcf0\brsp480 ';
         $expected .= '\pgbrdrr\brdrs\brdrw20\brdrcf0\brsp480 ';
         $expected .= '\pgbrdrb\brdrs\brdrw20\brdrcf0\brsp480 ';

--- a/tests/PhpWordTests/Writer/RTF/StyleTest.php
+++ b/tests/PhpWordTests/Writer/RTF/StyleTest.php
@@ -60,14 +60,14 @@ class StyleTest extends \PHPUnit\Framework\TestCase
         $borderWriter = new RTF\Style\Border($border);
         $borderWriter->setParentWriter(new RTF());
         $borderWriter->setType('section');
-        
+
         $content = $borderWriter->write();
 
         $expected = '\pgbrdropt32';
-        $expected .= '\pgbrdrt\brdrs\brdrw40\brdrcf0\brsp480 ';
-        $expected .= '\pgbrdrl\brdrs\brdrw20\brdrcf0\brsp480 ';
-        $expected .= '\pgbrdrr\brdrs\brdrw20\brdrcf0\brsp480 ';
-        $expected .= '\pgbrdrb\brdrs\brdrw20\brdrcf0\brsp480 ';
+        $expected .= '\pgbrdrt\brdrs\brdrw20\brdrcf0\brsp480 ';
+        $expected .= '\pgbrdrl\brdrs\brdrw40\brdrcf0\brsp480 ';
+        $expected .= '\pgbrdrr\brdrs\brdrw40\brdrcf0\brsp480 ';
+        $expected .= '\pgbrdrb\brdrs\brdrw40\brdrcf0\brsp480 ';
 
         self::assertEquals($expected, $content);
     }

--- a/tests/PhpWordTests/Writer/RTF/StyleTest.php
+++ b/tests/PhpWordTests/Writer/RTF/StyleTest.php
@@ -20,7 +20,6 @@ namespace PhpOffice\PhpWordTests\Writer\RTF;
 
 use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\Writer\RTF;
-use PhpOffice\PhpWord\Writer\RTF\Style\Border;
 use PHPUnit\Framework\Assert;
 
 /**
@@ -54,12 +53,15 @@ class StyleTest extends \PHPUnit\Framework\TestCase
 
     public function testBorderWithNonRegisteredColors(): void
     {
-        $border = new Border();
-        $border->setSizes([1, 2, 3, 4]);
-        $border->setColors(['#FF0000', '#FF0000', '#FF0000', '#FF0000']);
-        $border->setSizes([20, 20, 20, 20]);
+        $border = new \PhpOffice\PhpWord\Style\Border();
+        $borderWriter = new RTF\Style\Border($border);
+        $borderWriter->setParentWriter(new RTF());
+        $borderWriter->setType('page');
+        $borderWriter->setSizes([1, 2, 3, 4]);
+        $borderWriter->setColors(['#FF0000', '#FF0000', '#FF0000', '#FF0000']);
+        $borderWriter->setSizes([20, 20, 20, 20]);
 
-        $content = $border->write();
+        $content = $borderWriter->write();
 
         $expected = '\pgbrdropt32';
         $expected .= '\pgbrdrt\brdrs\brdrw20\brdrcf0\brsp480 ';

--- a/tests/PhpWordTests/Writer/RTF/StyleTest.php
+++ b/tests/PhpWordTests/Writer/RTF/StyleTest.php
@@ -54,18 +54,17 @@ class StyleTest extends \PHPUnit\Framework\TestCase
     public function testBorderWithNonRegisteredColors(): void
     {
         $border = new \PhpOffice\PhpWord\Style\Border();
+        $border->setBorderSize(40);
+        $border->setBorderTopSize(20);
+        $border->setBorderColor('#FF0000');
         $borderWriter = new RTF\Style\Border($border);
         $borderWriter->setParentWriter(new RTF());
-        $borderWriter->setType('page');
-        $borderWriter->setSizes([1, 2, 3, 4]);
-        $borderWriter->setColors(['#FF0000', '#FF0000', '#FF0000', '#FF0000']);
-        $borderWriter->setSizes([20, 20, 20, 20]);
-        $borderWriter->setStyles($border->getBorderStyle());
-        $borderWriter->setSpaces($border->getBorderSpace());
-
+        $borderWriter->setType('section');
+        
         $content = $borderWriter->write();
 
-        $expected = '\pgbrdrt\brdrs\brdrw20\brdrcf0\brsp480 ';
+        $expected = '\pgbrdropt32';
+        $expected . = '\pgbrdrt\brdrs\brdrw40\brdrcf0\brsp480 ';
         $expected .= '\pgbrdrl\brdrs\brdrw20\brdrcf0\brsp480 ';
         $expected .= '\pgbrdrr\brdrs\brdrw20\brdrcf0\brsp480 ';
         $expected .= '\pgbrdrb\brdrs\brdrw20\brdrcf0\brsp480 ';

--- a/tests/PhpWordTests/Writer/RTF/StyleTest.php
+++ b/tests/PhpWordTests/Writer/RTF/StyleTest.php
@@ -51,27 +51,6 @@ class StyleTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function testBorderWithNonRegisteredColors(): void
-    {
-        $border = new \PhpOffice\PhpWord\Style\Border();
-        $border->setBorderSize(40);
-        $border->setBorderTopSize(20);
-        $border->setBorderColor('#FF0000');
-        $borderWriter = new RTF\Style\Border($border);
-        $borderWriter->setParentWriter(new RTF());
-        $borderWriter->setType('section');
-
-        $content = $borderWriter->write();
-
-        $expected = '\pgbrdropt32';
-        $expected .= '\pgbrdrt\brdrs\brdrw20\brdrcf0\brsp480 ';
-        $expected .= '\pgbrdrl\brdrs\brdrw40\brdrcf0\brsp480 ';
-        $expected .= '\pgbrdrr\brdrs\brdrw40\brdrcf0\brsp480 ';
-        $expected .= '\pgbrdrb\brdrs\brdrw40\brdrcf0\brsp480 ';
-
-        self::assertEquals($expected, $content);
-    }
-
     public function testIndentation(): void
     {
         $indentation = new \PhpOffice\PhpWord\Style\Indentation();

--- a/tests/PhpWordTests/Writer/RTF/StyleTest.php
+++ b/tests/PhpWordTests/Writer/RTF/StyleTest.php
@@ -60,6 +60,8 @@ class StyleTest extends \PHPUnit\Framework\TestCase
         $borderWriter->setSizes([1, 2, 3, 4]);
         $borderWriter->setColors(['#FF0000', '#FF0000', '#FF0000', '#FF0000']);
         $borderWriter->setSizes([20, 20, 20, 20]);
+        $borderWriter->setStyles($border->getBorderStyle());
+        $borderWriter->setSpaces($border->getBorderSpace());
 
         $content = $borderWriter->write();
 

--- a/tests/PhpWordTests/Writer/RTF/StyleTest.php
+++ b/tests/PhpWordTests/Writer/RTF/StyleTest.php
@@ -65,8 +65,7 @@ class StyleTest extends \PHPUnit\Framework\TestCase
 
         $content = $borderWriter->write();
 
-        $expected = '\pgbrdropt32';
-        $expected .= '\pgbrdrt\brdrs\brdrw20\brdrcf0\brsp480 ';
+        $expected = '\pgbrdrt\brdrs\brdrw20\brdrcf0\brsp480 ';
         $expected .= '\pgbrdrl\brdrs\brdrw20\brdrcf0\brsp480 ';
         $expected .= '\pgbrdrr\brdrs\brdrw20\brdrcf0\brsp480 ';
         $expected .= '\pgbrdrb\brdrs\brdrw20\brdrcf0\brsp480 ';


### PR DESCRIPTION
### Description

RTF BorderWriter now detects the border type with the $type variable (each type of border has a different initial tag that must be set), implements setStyle and, for sections and paragraphs, setSpace.

RTF BorderWriter is prepared for future improvements to the RTF TableWriter, which currently doesn't use BorderWriter to write its borders.

RTF BorderWriter is prepared for future improvements to the elements FontStyle and RowStyle to allow borders there as well.

Documentation will be updated after this pull and pull #2831 are approved (as that pull created numerous documentation files, including borders.md).

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
