### PR TITLE
Update Sample_09_Tables.php - Fix Wrong Sizes in Sample

### DIFF
--- a/samples/Sample_09_Tables.php
+++ b/samples/Sample_09_Tables.php
@@ -125,8 +125,8 @@ $row->addCell(1000)->addText('2');
 
 $row = $table->addRow();
 $row->addCell(1000, ['vMerge' => 'continue']);
-$row->addCell(1000)->addText('C');
-$row->addCell(1000)->addText('D');
+$row->addCell(500)->addText('C');
+$row->addCell(500)->addText('D');
 $row->addCell(1000)->addText('3');
 
 // 5. Nested table


### PR DESCRIPTION
### Description

I don't know how this was effecting other writers, but in RTF, "B" and "C" were the same width, resulting in "D" being below "1" and "2" and "3" being in its own column.

This was due to the following:
"B" -> 1000 width, gridspan 2
"C" -> 1000 width
"D" -> 1000 width

The chart shows C and D below B, but this wasn't possible because C + D was double the width of B. This has been fixed.

Fixes #909 (I don't know if it fixes all of #909), but it at least improves it.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [ ] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
