### PR TITLE
Writer HTML: ListItemRun render as unordered lists

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
+- Writer HTML: ListItemRun render as unordered lists by [@andomiell](https://github.com/andomiell) partially fixing [#1462](https://github.com/PHPOffice/PHPWord/issues/1462)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Writer/HTML/Element/Container.php
+++ b/src/PhpWord/Writer/HTML/Element/Container.php
@@ -50,13 +50,42 @@ class Container extends AbstractElement
         $content = '';
 
         $elements = $container->getElements();
-        foreach ($elements as $element) {
+        foreach ($elements as $index => $element) {
+            if ($element instanceof \PhpOffice\PhpWord\Element\ListItemRun) {
+                $prevElement = $elements[$index - 1] ?? null;
+
+                if ($prevElement === null) {
+                    $content .= '<ul>';
+                } elseif (!$prevElement instanceof \PhpOffice\PhpWord\Element\ListItemRun) {
+                    $content .= '<ul>';
+                } elseif ($prevElement->getDepth() < $element->getDepth()) {
+                    if (str_ends_with($content, '</li>')) {
+                        $content = substr($content, 0, -5);
+                    }
+                    $content .= '<ul>';
+                }
+            }
+
             $elementClass = get_class($element);
             $writerClass = str_replace('PhpOffice\\PhpWord\\Element', $this->namespace, $elementClass);
             if (class_exists($writerClass)) {
                 /** @var AbstractElement $writer Type hint */
                 $writer = new $writerClass($this->parentWriter, $element, $withoutP);
                 $content .= $writer->write();
+            }
+
+            if ($element instanceof \PhpOffice\PhpWord\Element\ListItemRun) {
+                $nextElement = $elements[$index + 1] ?? null;
+
+                if ($nextElement === null) {
+                    $content .= '</ul>';
+                } elseif (!$nextElement instanceof \PhpOffice\PhpWord\Element\ListItemRun) {
+                    $content .= '</ul>';
+                } elseif ($nextElement->getDepth() < $element->getDepth()) {
+                    for ($i = $element->getDepth() - $nextElement->getDepth(); $i !== 0; --$i) {
+                        $content .= '</ul></li>';
+                    }
+                }
             }
         }
 

--- a/src/PhpWord/Writer/HTML/Element/ListItemRun.php
+++ b/src/PhpWord/Writer/HTML/Element/ListItemRun.php
@@ -36,9 +36,22 @@ class ListItemRun extends TextRun
             return '';
         }
 
-        $writer = new Container($this->parentWriter, $this->element);
-        $content = $writer->write() . PHP_EOL;
+        $content = '<li>';
 
-        return $content;
+        foreach ($this->element->getElements() as $element) {
+            $namespace = 'PhpOffice\\PhpWord\\Writer\\HTML\\Element';
+            $elementClass = get_class($element);
+            $writerClass = str_replace('PhpOffice\\PhpWord\\Element', $namespace, $elementClass);
+
+            if (!class_exists($writerClass)) {
+                continue;
+            }
+
+            /** @var AbstractElement $writer */
+            $writer = new $writerClass($this->parentWriter, $element, true);
+            $content .= $writer->write();
+        }
+
+        return "$content</li>";
     }
 }

--- a/tests/PhpWordTests/Writer/HTML/ElementTest.php
+++ b/tests/PhpWordTests/Writer/HTML/ElementTest.php
@@ -20,6 +20,8 @@ namespace PhpOffice\PhpWordTests\Writer\HTML;
 
 use DateTime;
 use DOMDocument;
+use DOMNode;
+use DOMNodeList;
 use DOMXPath;
 use PhpOffice\PhpWord\Element\Text as TextElement;
 use PhpOffice\PhpWord\Element\TextRun;
@@ -200,15 +202,35 @@ class ElementTest extends \PHPUnit\Framework\TestCase
      */
     public function testListItemRun(): void
     {
-        $expected1 = 'List item run 1';
-        $expected2 = 'List item run 1 in bold';
+        $expected11 = 'List item run 1.1';
+        $expected11InBold = 'List item run 1.1 in bold';
+        $expected12 = 'List item run 1.2';
+        $expected21 = 'List item run 2.1';
+        $expected22 = 'List item run 2.2';
+        $expected31 = 'List item run 3.1';
+        $expected13 = 'List item run 1.3';
 
         $phpWord = new PhpWord();
         $section = $phpWord->addSection();
 
-        $listItemRun = $section->addListItemRun(0, null, 'MyParagraphStyle');
-        $listItemRun->addText($expected1);
-        $listItemRun->addText($expected2, ['bold' => true]);
+        $listItemRun11 = $section->addListItemRun(0, null, 'MyParagraphStyle');
+        $listItemRun11->addText($expected11);
+        $listItemRun11->addText($expected11InBold, ['bold' => true]);
+
+        $listItemRun12 = $section->addListItemRun(0);
+        $listItemRun12->addText($expected12);
+
+        $listItemRun21 = $section->addListItemRun(1);
+        $listItemRun21->addText($expected21);
+
+        $listItemRun22 = $section->addListItemRun(1);
+        $listItemRun22->addText($expected22);
+
+        $listItemRun31 = $section->addListItemRun(2);
+        $listItemRun31->addText($expected31);
+
+        $listItemRun13 = $section->addListItemRun(0);
+        $listItemRun13->addText($expected13);
 
         $htmlWriter = new HTML($phpWord);
         $content = $htmlWriter->getContent();
@@ -216,8 +238,32 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $dom = new DOMDocument();
         $dom->loadHTML($content);
 
-        self::assertEquals($expected1, $dom->getElementsByTagName('p')->item(0)->textContent);
-        self::assertEquals($expected2, $dom->getElementsByTagName('p')->item(1)->textContent);
+        $xpath = new DOMXPath($dom);
+
+        /** @var DOMNodeList<DOMNode> $list */
+        $list = $xpath->query('//body/div/ul/li');
+
+        $item11 = $list->item(0);
+        $item12 = $list->item(1);
+        $item13 = $list->item(2);
+
+        self::assertEquals($expected11, $item11->childNodes->item(0)->textContent);
+        self::assertEquals('span', $item11->childNodes->item(1)->nodeName);
+        self::assertEquals($expected11InBold, $item11->childNodes->item(1)->textContent);
+
+        self::assertEquals($expected12, $item12->childNodes->item(0)->textContent);
+        self::assertEquals('ul', $item12->childNodes->item(1)->nodeName);
+
+        self::assertEquals($expected21, $item12->childNodes->item(1)->childNodes->item(0)->textContent);
+
+        $item22 = $item12->childNodes->item(1)->childNodes->item(1);
+
+        self::assertEquals($expected22, $item22->childNodes->item(0)->textContent);
+        self::assertEquals('ul', $item22->childNodes->item(1)->nodeName);
+
+        self::assertEquals($expected31, $item22->childNodes->item(1)->childNodes->item(0)->textContent);
+
+        self::assertEquals($expected13, $item13->childNodes->item(0)->textContent);
     }
 
     /**


### PR DESCRIPTION
### Description

Writer HTML: ListItemRun render as unordered lists

Before:
<img width="236" height="246" alt="Before" src="https://github.com/user-attachments/assets/4ea95a0c-6f82-46ca-ae17-0d9ac05e00c7" />

After:
<img width="207" height="109" alt="image" src="https://github.com/user-attachments/assets/d80826a2-5d44-447f-a0d4-df622b4fc17c" />

Fixes #1462 (Partially: numbered lists and bullet types are not yet supported)

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
