### PR TITLE
Fix Phpstan errors

### DIFF
--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -368,7 +368,7 @@ abstract class AbstractPart
                         }
                     }
                     $formField->setEntries($listEntries);
-                    if (null !== $formField->getValue()) {
+                    if (null !== $formField->getValue() && isset($listEntries[$formField->getValue()])) {
                         $formField->setText($listEntries[$formField->getValue()]);
                     }
 

--- a/tests/PhpWordTests/Writer/HTML/Element/RubyTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/RubyTest.php
@@ -49,7 +49,9 @@ class RubyTest extends TestCase
 
         $dom = Helper::getAsHTML($phpWord, '', '', ['ruby', 'rt', 'rp']);
         $xpath = new DOMXPath($dom);
-        self::assertEquals(1, $xpath->query('/html/body/div/ruby')->length);
+        $query = $xpath->query('/html/body/div/ruby');
+        self::assertNotFalse($query);
+        self::assertEquals(1, $query->length);
         // ensure text is right
         $rubyElement = $dom->getElementsByTagName('ruby')->item(0);
         $rtElement = $dom->getElementsByTagName('rt')->item(0);
@@ -84,7 +86,9 @@ class RubyTest extends TestCase
 
         $dom = Helper::getAsHTML($phpWord, '', '', ['ruby', 'rt', 'rp']);
         $xpath = new DOMXPath($dom);
-        self::assertEquals(1, $xpath->query('/html/body/div/ruby')->length);
+        $query = $xpath->query('/html/body/div/ruby');
+        self::assertNotFalse($query);
+        self::assertEquals(1, $query->length);
         // ensure text is right
         $rubyElement = $dom->getElementsByTagName('ruby')->item(0);
         $rtElement = $dom->getElementsByTagName('rt')->item(0);

--- a/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
@@ -200,7 +200,7 @@ class TableTest extends TestCase
         $cell3Query = $xpath->query('//table/tr/td[3]');
         self::assertNotFalse($cell3Query);
         self::assertCount(1, $cell3Query);
-        self::assertObjectHasProperty('attributes', $cell3Query->item(0));
+        self::assertInstanceOf(DOMNode::class, $cell3Query->item(0));
         $cell3Style = $cell3Query->item(0)->attributes->getNamedItem('style');
         self::assertNull($cell3Style);
     }

--- a/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
@@ -232,7 +232,7 @@ class TableTest extends TestCase
         $cell3Query = $xpath->query('//table/tr[3]/td[1]');
         self::assertNotFalse($cell3Query);
         self::assertCount(1, $cell3Query);
-        self::assertObjectHasProperty('attributes', $cell3Query->item(0));
+        self::assertClassHasAttribute($cell3Query->item(0), 'attributes');
         self::assertNull($cell3Query->item(0)->attributes->getNamedItem('rowspan'));
     }
 }

--- a/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
@@ -232,7 +232,7 @@ class TableTest extends TestCase
         $cell3Query = $xpath->query('//table/tr[3]/td[1]');
         self::assertNotFalse($cell3Query);
         self::assertCount(1, $cell3Query);
-        self::assertClassHasAttribute($cell3Query->item(0), 'attributes');
+        self::assertClassHasAttribute('attributes', $cell3Query->item(0));
         self::assertNull($cell3Query->item(0)->attributes->getNamedItem('rowspan'));
     }
 }

--- a/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
@@ -18,6 +18,7 @@
 
 namespace PhpOffice\PhpWordTests\Writer\HTML\Element;
 
+use DOMNode;
 use DOMXPath;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\SimpleType\VerticalJc;

--- a/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
@@ -232,7 +232,7 @@ class TableTest extends TestCase
         $cell3Query = $xpath->query('//table/tr[3]/td[1]');
         self::assertNotFalse($cell3Query);
         self::assertCount(1, $cell3Query);
-        self::assertClassHasAttribute('attributes', $cell3Query->item(0));
+        self::assertObjectHasAttribute('attributes', $cell3Query->item(0));
         self::assertNull($cell3Query->item(0)->attributes->getNamedItem('rowspan'));
     }
 }

--- a/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
@@ -232,7 +232,7 @@ class TableTest extends TestCase
         $cell3Query = $xpath->query('//table/tr[3]/td[1]');
         self::assertNotFalse($cell3Query);
         self::assertCount(1, $cell3Query);
-        self::assertObjectHasAttribute('attributes', $cell3Query->item(0));
+        self::assertInstanceOf(DOMNode::class, $cell3Query->item(0));
         self::assertNull($cell3Query->item(0)->attributes->getNamedItem('rowspan'));
     }
 }

--- a/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
@@ -199,7 +199,7 @@ class TableTest extends TestCase
         $cell3Query = $xpath->query('//table/tr/td[3]');
         self::assertNotFalse($cell3Query);
         self::assertCount(1, $cell3Query);
-
+        self::assertObjectHasProperty('attributes', $cell3Query->item(0));
         $cell3Style = $cell3Query->item(0)->attributes->getNamedItem('style');
         self::assertNull($cell3Style);
     }
@@ -232,6 +232,7 @@ class TableTest extends TestCase
         $cell3Query = $xpath->query('//table/tr[3]/td[1]');
         self::assertNotFalse($cell3Query);
         self::assertCount(1, $cell3Query);
+        self::assertObjectHasProperty('attributes', $cell3Query->item(0));
         self::assertNull($cell3Query->item(0)->attributes->getNamedItem('rowspan'));
     }
 }

--- a/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
@@ -161,7 +161,9 @@ class TableTest extends TestCase
         self::assertEmpty(Helper::getNamedItem($xpath, '/html/body/div/table[6]', 'style'));
         self::assertEquals('tstyle', Helper::getTextContent($xpath, '/html/body/div/table[6]', 'class'));
         $style = Helper::getTextContent($xpath, '/html/head/style');
-        self::assertNotFalse(preg_match('/^[.]tstyle[^\\r\\n]*/m', $style, $matches));
+        $prg = preg_match('/^[.]tstyle[^\\r\\n]*/m', $style, $matches);
+        self::assertNotEmpty($matches);
+        self::assertNotFalse($prg);
         self::assertEquals(".tstyle {table-layout: auto; $cssnone}", $matches[0]);
     }
 

--- a/tests/PhpWordTests/Writer/HTML/ElementTest.php
+++ b/tests/PhpWordTests/Writer/HTML/ElementTest.php
@@ -149,8 +149,6 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $query = $xpath->query('/html/body/div/table/tr[1]/td');
         self::assertNotFalse($query);
         self::assertCount(2, $query);
-        self::assertInstanceOf(DOMNode::class, $query->item(0));
-        self::assertEquals('2', $query->item(0)->attributes->getNamedItem('colspan')->textContent);
 
         $query = $xpath->query('/html/body/div/table/tr[1]/td[1]');
         self::assertNotFalse($query);
@@ -159,7 +157,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
 
         $query = $xpath->query('/html/body/div/table/tr[2]/td');
         self::assertNotFalse($query);
-        self::assertEquals(1, $query->length);
+        self::assertCount(1, $query);
     }
 
     /**
@@ -191,18 +189,26 @@ class ElementTest extends \PHPUnit\Framework\TestCase
 
         $query = $xpath->query('/html/body/div/table/tr[1]/td');
         self::assertNotFalse($query);
-        self::assertEquals(3, $query->length);
-        self::assertEquals('2', $xpath->query('/html/body/div/table/tr[1]/td[2]')->item(0)->attributes->getNamedItem('colspan')->textContent);
-        self::assertEquals('3', $xpath->query('/html/body/div/table/tr[1]/td[3]')->item(0)->attributes->getNamedItem('rowspan')->textContent);
+        self::assertCount(3, $query);
+
+        $query = $xpath->query('/html/body/div/table/tr[1]/td[2]');
+        self::assertNotFalse($query);
+        self::assertInstanceOf(DOMNode::class, $query->item(0));
+        self::assertEquals('2', $query->item(0)->attributes->getNamedItem('colspan')->textContent);
+
+        $query = $xpath->query('/html/body/div/table/tr[1]/td[3]');
+        self::assertNotFalse($query);
+        self::assertInstanceOf(DOMNode::class, $query->item(0));
+        self::assertEquals('3', $query->item(0)->attributes->getNamedItem('rowspan')->textContent);
 
         $query = $xpath->query('/html/body/div/table/tr[2]/td');
         self::assertNotFalse($query);
-        self::assertEquals(1, $query->length);
+        self::assertCount(1, $query);
         self::assertEquals('3', $xpath->query('/html/body/div/table/tr[2]/td[1]')->item(0)->attributes->getNamedItem('colspan')->textContent);
 
         $query = $xpath->query('/html/body/div/table/tr[3]/td');
         self::assertNotFalse($query);
-        self::assertEquals(3, $query->length);
+        self::assertCount(3, $query);
     }
 
     public function testWriteTitleTextRun(): void
@@ -268,7 +274,14 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $dom = Helper::getAsHTML($phpWord);
         $xpath = new DOMXPath($dom);
 
-        self::assertEquals('table-layout: fixed;', $xpath->query('/html/body/div/table[1]')->item(0)->attributes->getNamedItem('style')->textContent);
-        self::assertEquals('table-layout: auto;', $xpath->query('/html/body/div/table[2]')->item(0)->attributes->getNamedItem('style')->textContent);
+        $query = $xpath->query('/html/body/div/table[1]');
+        self::assertNotFalse($query);
+        self::assertInstanceOf(DOMNode::class, $query->item(0));
+        self::assertEquals('table-layout: fixed;', $query->item(0)->attributes->getNamedItem('style')->textContent);
+
+        $query = $xpath->query('/html/body/div/table[2]');
+        self::assertNotFalse($query);
+        self::assertInstanceOf(DOMNode::class, $query->item(0));
+        self::assertEquals('table-layout: auto;', $query->item(0)->attributes->getNamedItem('style')->textContent);
     }
 }

--- a/tests/PhpWordTests/Writer/HTML/ElementTest.php
+++ b/tests/PhpWordTests/Writer/HTML/ElementTest.php
@@ -77,8 +77,12 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $dom = Helper::getAsHTML($phpWord);
         $xpath = new DOMXPath($dom);
 
-        self::assertEquals(1, $xpath->query('/html/body/div/p[1]/ins')->length);
-        self::assertEquals(1, $xpath->query('/html/body/div/p[2]/del')->length);
+        $query = $xpath->query('/html/body/div/p[1]/ins');
+        self::assertNotFalse($query);
+        self::assertEquals(1, $query->length);
+        $query = $xpath->query('/html/body/div/p[2]/del');
+        self::assertNotFalse($query);
+        self::assertEquals(1, $query->length);
     }
 
     /**
@@ -101,9 +105,13 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $dom = Helper::getAsHTML($phpWord);
         $xpath = new DOMXPath($dom);
 
-        self::assertEquals(1, $xpath->query('/html/body/div/table/tr[1]/td')->length);
+        $query = $xpath->query('/html/body/div/table/tr[1]/td');
+        self::assertNotFalse($query);
+        self::assertEquals(1, $query->length);
         self::assertEquals('2', $xpath->query('/html/body/div/table/tr/td[1]')->item(0)->attributes->getNamedItem('colspan')->textContent);
-        self::assertEquals(2, $xpath->query('/html/body/div/table/tr[2]/td')->length);
+        $query = $xpath->query('/html/body/div/table/tr[2]/td');
+        self::assertNotFalse($query);
+        self::assertEquals(2, $query->length);
 
         self::assertEquals('#6086B8', $xpath->query('/html/body/div/table/tr[1]/td')->item(0)->attributes->getNamedItem('bgcolor')->textContent);
         self::assertEquals('#ffffff', $xpath->query('/html/body/div/table/tr[1]/td')->item(0)->attributes->getNamedItem('color')->textContent);
@@ -135,9 +143,13 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $dom = Helper::getAsHTML($phpWord);
         $xpath = new DOMXPath($dom);
 
-        self::assertEquals(2, $xpath->query('/html/body/div/table/tr[1]/td')->length);
+        $query = $xpath->query('/html/body/div/table/tr[1]/td');
+        self::assertNotFalse($query);
+        self::assertEquals(2, $query->length);
         self::assertEquals('3', $xpath->query('/html/body/div/table/tr[1]/td[1]')->item(0)->attributes->getNamedItem('rowspan')->textContent);
-        self::assertEquals(1, $xpath->query('/html/body/div/table/tr[2]/td')->length);
+        $query = $xpath->query('/html/body/div/table/tr[2]/td');
+        self::assertNotFalse($query);
+        self::assertEquals(1, $query->length);
     }
 
     /**
@@ -167,14 +179,20 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $dom = Helper::getAsHTML($phpWord);
         $xpath = new DOMXPath($dom);
 
-        self::assertEquals(3, $xpath->query('/html/body/div/table/tr[1]/td')->length);
+        $query = $xpath->query('/html/body/div/table/tr[1]/td');
+        self::assertNotFalse($query);
+        self::assertEquals(3, $query->length);
         self::assertEquals('2', $xpath->query('/html/body/div/table/tr[1]/td[2]')->item(0)->attributes->getNamedItem('colspan')->textContent);
         self::assertEquals('3', $xpath->query('/html/body/div/table/tr[1]/td[3]')->item(0)->attributes->getNamedItem('rowspan')->textContent);
 
-        self::assertEquals(1, $xpath->query('/html/body/div/table/tr[2]/td')->length);
+        $query = $xpath->query('/html/body/div/table/tr[2]/td');
+        self::assertNotFalse($query);
+        self::assertEquals(1, $query->length);
         self::assertEquals('3', $xpath->query('/html/body/div/table/tr[2]/td[1]')->item(0)->attributes->getNamedItem('colspan')->textContent);
 
-        self::assertEquals(3, $xpath->query('/html/body/div/table/tr[3]/td')->length);
+        $query = $xpath->query('/html/body/div/table/tr[3]/td');
+        self::assertNotFalse($query);
+        self::assertEquals(3, $query->length);
     }
 
     public function testWriteTitleTextRun(): void

--- a/tests/PhpWordTests/Writer/HTML/ElementTest.php
+++ b/tests/PhpWordTests/Writer/HTML/ElementTest.php
@@ -20,6 +20,7 @@ namespace PhpOffice\PhpWordTests\Writer\HTML;
 
 use DateTime;
 use DOMDocument;
+use DOMNode;
 use DOMXPath;
 use PhpOffice\PhpWord\Element\Text as TextElement;
 use PhpOffice\PhpWord\Element\TextRun;
@@ -107,16 +108,18 @@ class ElementTest extends \PHPUnit\Framework\TestCase
 
         $query = $xpath->query('/html/body/div/table/tr[1]/td');
         self::assertNotFalse($query);
-        self::assertEquals(1, $query->length);
-        self::assertEquals('2', $xpath->query('/html/body/div/table/tr/td[1]')->item(0)->attributes->getNamedItem('colspan')->textContent);
+        self::assertCount(1, $query);
+        self::assertInstanceOf(DOMNode::class, $query->item(0));
+        self::assertEquals('2', $query->item(0)->attributes->getNamedItem('colspan')->textContent);
+        self::assertEquals('#6086B8', $query->item(0)->attributes->getNamedItem('bgcolor')->textContent);
+        self::assertEquals('#ffffff', $query->item(0)->attributes->getNamedItem('color')->textContent);
+
         $query = $xpath->query('/html/body/div/table/tr[2]/td');
         self::assertNotFalse($query);
-        self::assertEquals(2, $query->length);
-
-        self::assertEquals('#6086B8', $xpath->query('/html/body/div/table/tr[1]/td')->item(0)->attributes->getNamedItem('bgcolor')->textContent);
-        self::assertEquals('#ffffff', $xpath->query('/html/body/div/table/tr[1]/td')->item(0)->attributes->getNamedItem('color')->textContent);
-        self::assertEquals('#ffffff', $xpath->query('/html/body/div/table/tr[2]/td')->item(0)->attributes->getNamedItem('bgcolor')->textContent);
-        self::assertNull($xpath->query('/html/body/div/table/tr[2]/td')->item(0)->attributes->getNamedItem('color'));
+        self::assertCount(2, $query);
+        self::assertInstanceOf(DOMNode::class, $query->item(0));
+        self::assertEquals('#ffffff', $query->item(0)->attributes->getNamedItem('bgcolor')->textContent);
+        self::assertNull($query->item(0)->attributes->getNamedItem('color'));
     }
 
     /**
@@ -145,8 +148,15 @@ class ElementTest extends \PHPUnit\Framework\TestCase
 
         $query = $xpath->query('/html/body/div/table/tr[1]/td');
         self::assertNotFalse($query);
-        self::assertEquals(2, $query->length);
-        self::assertEquals('3', $xpath->query('/html/body/div/table/tr[1]/td[1]')->item(0)->attributes->getNamedItem('rowspan')->textContent);
+        self::assertCount(2, $query);
+        self::assertInstanceOf(DOMNode::class, $query->item(0));
+        self::assertEquals('2', $query->item(0)->attributes->getNamedItem('colspan')->textContent);
+
+        $query = $xpath->query('/html/body/div/table/tr[1]/td[1]');
+        self::assertNotFalse($query);
+        self::assertInstanceOf(DOMNode::class, $query->item(0));
+        self::assertEquals('3', $query->item(0)->attributes->getNamedItem('rowspan')->textContent);
+
         $query = $xpath->query('/html/body/div/table/tr[2]/td');
         self::assertNotFalse($query);
         self::assertEquals(1, $query->length);

--- a/tests/PhpWordTests/Writer/HTML/ElementTest.php
+++ b/tests/PhpWordTests/Writer/HTML/ElementTest.php
@@ -201,10 +201,11 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         self::assertInstanceOf(DOMNode::class, $query->item(0));
         self::assertEquals('3', $query->item(0)->attributes->getNamedItem('rowspan')->textContent);
 
-        $query = $xpath->query('/html/body/div/table/tr[2]/td');
+        $query = $xpath->query('/html/body/div/table/tr[2]/td[1]');
         self::assertNotFalse($query);
         self::assertCount(1, $query);
-        self::assertEquals('3', $xpath->query('/html/body/div/table/tr[2]/td[1]')->item(0)->attributes->getNamedItem('colspan')->textContent);
+        self::assertInstanceOf(DOMNode::class, $query->item(0));
+        self::assertEquals('3', $query->item(0)->attributes->getNamedItem('colspan')->textContent);
 
         $query = $xpath->query('/html/body/div/table/tr[3]/td');
         self::assertNotFalse($query);

--- a/tests/PhpWordTests/Writer/HTML/FontTest.php
+++ b/tests/PhpWordTests/Writer/HTML/FontTest.php
@@ -274,7 +274,9 @@ class FontTest extends \PHPUnit\Framework\TestCase
         $xpath = new DOMXPath($dom);
 
         $style = Helper::getTextContent($xpath, '/html/head/style');
-        self::assertNotFalse(preg_match('/^[*][^\\r\\n]*/m', $style, $matches));
+        $prg = preg_match('/^[*][^\\r\\n]*/m', $style, $matches);
+        self::assertNotEmpty($matches);
+        self::assertNotFalse($prg);
         self::assertEquals('* {font-family: \'Arial\'; font-size: 12pt; color: #000000; white-space: pre-wrap;}', $matches[0]);
         $prg = preg_match('/^[.]style1[^\\r\\n]*/m', $style, $matches);
         self::assertNotEmpty($matches);

--- a/tests/PhpWordTests/Writer/HTML/Helper.php
+++ b/tests/PhpWordTests/Writer/HTML/Helper.php
@@ -41,14 +41,26 @@ class Helper extends \PHPUnit\Framework\TestCase
             if ($item2 === null) {
                 self::fail('Unexpected null return requesting item');
             } elseif ($namedItem !== '') {
-                $item3 = $item2->attributes->getNamedItem($namedItem);
-                if ($item3 === null) {
-                    self::fail('Unexpected null return requesting namedItem');
+                if (!property_exists('attributes', $item2)) {
+                    self::fail('Unexpected incorrect object');
                 } else {
-                    $returnVal = $item3->textContent;
+                    $item3 = $item2->attributes->getNamedItem($namedItem);
+                    if ($item3 === null) {
+                        self::fail('Unexpected null return requesting namedItem');
+                    } else {
+                        if (!property_exists('textContent', $item3)) {
+                            self::fail('Unexpected incorrect object');
+                        } else {
+                            $returnVal = $item3->textContent;
+                        }
+                    }
                 }
             } else {
-                $returnVal = $item2->textContent;
+                if (!property_exists('textContent', $item2)) {
+                    self::fail('Unexpected incorrect object');
+                } else {
+                    $returnVal = $item2->textContent;
+                }
             }
         }
 
@@ -66,6 +78,8 @@ class Helper extends \PHPUnit\Framework\TestCase
             $item2 = $item->item($itemNumber);
             if ($item2 === null) {
                 self::fail('Unexpected null return requesting item');
+            } elseif (!property_exists('attributes', $item2)) {
+                self::fail('Unexpected incorrect object');
             } else {
                 $returnValue = $item2->attributes->getNamedItem($namedItem);
             }

--- a/tests/PhpWordTests/Writer/HTML/Helper.php
+++ b/tests/PhpWordTests/Writer/HTML/Helper.php
@@ -41,14 +41,14 @@ class Helper extends \PHPUnit\Framework\TestCase
             if ($item2 === null) {
                 self::fail('Unexpected null return requesting item');
             } elseif ($namedItem !== '') {
-                if (!property_exists('attributes', $item2)) {
+                if (!property_exists($item2, 'attributes')) {
                     self::fail('Unexpected incorrect object');
                 } else {
                     $item3 = $item2->attributes->getNamedItem($namedItem);
                     if ($item3 === null) {
                         self::fail('Unexpected null return requesting namedItem');
                     } else {
-                        if (!property_exists('textContent', $item3)) {
+                        if (!property_exists($item3, 'textContent')) {
                             self::fail('Unexpected incorrect object');
                         } else {
                             $returnVal = $item3->textContent;
@@ -56,7 +56,7 @@ class Helper extends \PHPUnit\Framework\TestCase
                     }
                 }
             } else {
-                if (!property_exists('textContent', $item2)) {
+                if (!property_exists($item2, 'textContent')) {
                     self::fail('Unexpected incorrect object');
                 } else {
                     $returnVal = $item2->textContent;
@@ -78,7 +78,7 @@ class Helper extends \PHPUnit\Framework\TestCase
             $item2 = $item->item($itemNumber);
             if ($item2 === null) {
                 self::fail('Unexpected null return requesting item');
-            } elseif (!property_exists('attributes', $item2)) {
+            } elseif (!property_exists($item2, 'attributes')) {
                 self::fail('Unexpected incorrect object');
             } else {
                 $returnValue = $item2->attributes->getNamedItem($namedItem);

--- a/tests/PhpWordTests/Writer/HTML/ParagraphTest.php
+++ b/tests/PhpWordTests/Writer/HTML/ParagraphTest.php
@@ -54,7 +54,9 @@ class ParagraphTest extends \PHPUnit\Framework\TestCase
         self::assertEquals('indented', Helper::getTextContent($xpath, '/html/body/div/p[2]', 'class'));
 
         $style = Helper::getTextContent($xpath, '/html/head/style');
-        self::assertNotFalse(preg_match('/^[.]indented[^\\r\\n]*/m', $style, $matches));
+        $prg = preg_match('/^[.]indented[^\\r\\n]*/m', $style, $matches);
+        self::assertNotEmpty($matches);
+        self::assertNotFalse($prg);
         self::assertEquals('.indented {margin-left: 0.5in; margin-right: 0.6in;}', $matches[0]);
     }
 
@@ -87,9 +89,13 @@ class ParagraphTest extends \PHPUnit\Framework\TestCase
         self::assertEquals('font-family: \'Verdana\'; font-size: 12pt;', Helper::getTextContent($xpath, '/html/body/div/p[2]/span', 'style'));
 
         $style = Helper::getTextContent($xpath, '/html/head/style');
-        self::assertNotFalse(preg_match('/^[.]indented[^\\r\\n]*/m', $style, $matches));
+        $prg = preg_match('/^[.]indented[^\\r\\n]*/m', $style, $matches);
+        self::assertNotEmpty($matches);
+        self::assertNotFalse($prg);
         self::assertEquals('.indented {margin-left: 0.5in; margin-right: 0.6in;}', $matches[0]);
-        self::assertNotFalse(preg_match('/^[.]style1[^\\r\\n]*/m', $style, $matches));
+        $prg = preg_match('/^[.]style1[^\\r\\n]*/m', $style, $matches);
+        self::assertNotEmpty($matches);
+        self::assertNotFalse($prg);
         self::assertEquals('.style1 {font-family: \'Courier New\', monospace; font-size: 10pt; white-space: pre-wrap;}', $matches[0]);
     }
 

--- a/tests/PhpWordTests/XmlDocument.php
+++ b/tests/PhpWordTests/XmlDocument.php
@@ -141,7 +141,7 @@ class XmlDocument
     /**
      * Get node list.
      *
-     * @return DOMNodeList<DOMNameSpaceNode|DOMNode>|false
+     * @return DOMNodeList<DOMNode>
      */
     public function getNodeList(string $path, string $file = ''): DOMNodeList
     {
@@ -157,7 +157,13 @@ class XmlDocument
             $this->xpath->registerNamespace('w14', 'http://schemas.microsoft.com/office/word/2010/wordml');
         }
 
-        return $this->xpath->query($path);
+        $query = $this->xpath->query($path);
+
+        if ($query === false) {
+            self::fail('Unexpected false return from xpath query');
+        }
+
+        return $query;
     }
 
     /**

--- a/tests/PhpWordTests/XmlDocument.php
+++ b/tests/PhpWordTests/XmlDocument.php
@@ -142,7 +142,7 @@ class XmlDocument
     /**
      * Get node list.
      *
-     * @return DDOMNodeList<DOMNameSpaceNode|DOMNode>|false
+     * @return DOMNodeList<DOMNameSpaceNode|DOMNode>|false
      */
     public function getNodeList(string $path, string $file = ''): DOMNodeList
     {

--- a/tests/PhpWordTests/XmlDocument.php
+++ b/tests/PhpWordTests/XmlDocument.php
@@ -20,7 +20,6 @@ namespace PhpOffice\PhpWordTests;
 
 use DOMDocument;
 use DOMElement;
-use DOMNameSpaceNode;
 use DOMNode;
 use DOMNodeList;
 use DOMXPath;
@@ -142,7 +141,7 @@ class XmlDocument
     /**
      * Get node list.
      *
-     * @return DOMNodeList<DOMNameSpaceNode|DOMNode>|false
+     * @return DOMNodeList<DOMNode>
      */
     public function getNodeList(string $path, string $file = ''): DOMNodeList
     {
@@ -158,9 +157,7 @@ class XmlDocument
             $this->xpath->registerNamespace('w14', 'http://schemas.microsoft.com/office/word/2010/wordml');
         }
 
-        $query = $this->xpath->query($path);
-
-        return $query;
+        return $this->xpath->query($path);
     }
 
     /**
@@ -168,13 +165,7 @@ class XmlDocument
      */
     public function getElement(string $path, string $file = ''): ?DOMElement
     {
-        $element = $this->getNodeList($path, $file)->item(0);
-
-        if ($element === false) {
-            return null;
-        }
-
-        return $element;
+        return $this->getNodeList($path, $file)->item(0);
     }
 
     /**

--- a/tests/PhpWordTests/XmlDocument.php
+++ b/tests/PhpWordTests/XmlDocument.php
@@ -141,7 +141,7 @@ class XmlDocument
     /**
      * Get node list.
      *
-     * @return DOMNodeList<DOMNode>
+     * @return DOMNodeList<DOMNameSpaceNode|DOMNode>|false
      */
     public function getNodeList(string $path, string $file = ''): DOMNodeList
     {

--- a/tests/PhpWordTests/XmlDocument.php
+++ b/tests/PhpWordTests/XmlDocument.php
@@ -20,6 +20,7 @@ namespace PhpOffice\PhpWordTests;
 
 use DOMDocument;
 use DOMElement;
+use DOMNameSpaceNode;
 use DOMNode;
 use DOMNodeList;
 use DOMXPath;
@@ -141,7 +142,7 @@ class XmlDocument
     /**
      * Get node list.
      *
-     * @return DOMNodeList<DOMNode>
+     * @return DDOMNodeList<DOMNameSpaceNode|DOMNode>|false
      */
     public function getNodeList(string $path, string $file = ''): DOMNodeList
     {
@@ -159,10 +160,6 @@ class XmlDocument
 
         $query = $this->xpath->query($path);
 
-        if ($query === false) {
-            self::fail('Unexpected false return from xpath query');
-        }
-
         return $query;
     }
 
@@ -171,7 +168,13 @@ class XmlDocument
      */
     public function getElement(string $path, string $file = ''): ?DOMElement
     {
-        return $this->getNodeList($path, $file)->item(0);
+        $element = $this->getNodeList($path, $file)->item(0);
+
+        if ($element === false) {
+            return null;
+        }
+
+        return $element;
     }
 
     /**


### PR DESCRIPTION
### Description

The latest PHPStan is throwing 45 errors on every pull request. This fixes those errors.

Fixes all errors except tests/PhpWordTests/XmlDocument.php, line 160, Method PhpOffice\PhpWordTests\XmlDocument::getNodeList() should return DOMNodeList<DOMNode> but returns DOMNodeList<DOMNameSpaceNode|DOMNode>|false.      

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
