### PR TITLE
Fix macro typo

### DIFF
--- a/docs/usage/template.md
+++ b/docs/usage/template.md
@@ -166,7 +166,7 @@ Customer: ${customer_name#3}
 Address: ${customer_address#3}
 ```
 
-It is also possible to pass an array with the values to replace the marcros with.
+It is also possible to pass an array with the values to replace the macros with.
 If an array with replacements is passed, the ``count`` argument is ignored, it is the size of the array that counts.
 
 ``` php


### PR DESCRIPTION
### Description

Just a typo in the doc

### Checklist:

- [ ] My CI is :green_circle:

