### PR TITLE
Underline :: Fixes for Writers Word2007, ODText, and HTML

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
+- Writers: Fix and implement underline styles in Word2007, ODText, and HTML writers by [@rasamassen](https://github.com/rasamassen) in [#2850](https://github.com/PHPOffice/PHPWord/pull/2850)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Style/Font.php
+++ b/src/PhpWord/Style/Font.php
@@ -33,20 +33,20 @@ class Font extends AbstractStyle
      */
     const UNDERLINE_NONE = 'none';
     const UNDERLINE_DASH = 'dash';
-    const UNDERLINE_DASHHEAVY = 'dashHeavy';
+    const UNDERLINE_DASHHEAVY = 'dashedHeavy';
     const UNDERLINE_DASHLONG = 'dashLong';
     const UNDERLINE_DASHLONGHEAVY = 'dashLongHeavy';
-    const UNDERLINE_DOUBLE = 'dbl';
+    const UNDERLINE_DOUBLE = 'double';
     const UNDERLINE_DOTDASH = 'dotDash';
-    const UNDERLINE_DOTDASHHEAVY = 'dotDashHeavy';
+    const UNDERLINE_DOTDASHHEAVY = 'dashDotHeavy';
     const UNDERLINE_DOTDOTDASH = 'dotDotDash';
-    const UNDERLINE_DOTDOTDASHHEAVY = 'dotDotDashHeavy';
+    const UNDERLINE_DOTDOTDASHHEAVY = 'dashDotDotHeavy';
     const UNDERLINE_DOTTED = 'dotted';
     const UNDERLINE_DOTTEDHEAVY = 'dottedHeavy';
-    const UNDERLINE_HEAVY = 'heavy';
+    const UNDERLINE_HEAVY = 'thick';
     const UNDERLINE_SINGLE = 'single';
-    const UNDERLINE_WAVY = 'wavy';
-    const UNDERLINE_WAVYDOUBLE = 'wavyDbl';
+    const UNDERLINE_WAVY = 'wave';
+    const UNDERLINE_WAVYDOUBLE = 'wavyDouble';
     const UNDERLINE_WAVYHEAVY = 'wavyHeavy';
     const UNDERLINE_WORDS = 'words';
 

--- a/src/PhpWord/Writer/HTML/Style/Font.php
+++ b/src/PhpWord/Writer/HTML/Style/Font.php
@@ -40,6 +40,26 @@ class Font extends AbstractStyle
         }
         $css = [];
 
+        $underlines = [
+            FontStyle::UNDERLINE_DASH => 'underline dashed ',
+            FontStyle::UNDERLINE_DASHHEAVY => 'underline dashed 2px ',
+            FontStyle::UNDERLINE_DASHLONG => 'underline dashed ',
+            FontStyle::UNDERLINE_DASHLONGHEAVY => 'underline dashed 2px ',
+            FontStyle::UNDERLINE_DOUBLE => 'underline double ',
+            FontStyle::UNDERLINE_DOTDASH => 'underline dotted ',
+            FontStyle::UNDERLINE_DOTDASHHEAVY => 'underline dotted 2px ',
+            FontStyle::UNDERLINE_DOTDOTDASH => 'underline dotted ',
+            FontStyle::UNDERLINE_DOTDOTDASHHEAVY => 'underline dotted 2px ',
+            FontStyle::UNDERLINE_DOTTED => 'underline dotted ',
+            FontStyle::UNDERLINE_DOTTEDHEAVY => 'underline dotted 2px ',
+            FontStyle::UNDERLINE_HEAVY => 'underline solid 2px ',
+            FontStyle::UNDERLINE_SINGLE => 'underline solid ',
+            FontStyle::UNDERLINE_WAVY => 'underline wavy ',
+            FontStyle::UNDERLINE_WAVYDOUBLE => 'underline wavy ',
+            FontStyle::UNDERLINE_WAVYHEAVY => 'underline wavy 2px ',
+            FontStyle::UNDERLINE_WORDS => 'underline solid ',
+        ];
+
         $font = $this->getFontFamily($style->getName(), $style->getFallbackFont());
         $size = $style->getSize();
         $color = $style->getColor();
@@ -57,7 +77,9 @@ class Font extends AbstractStyle
         $css['vertical-align'] .= $this->getValueIf($style->isSuperScript(), 'super');
         $css['vertical-align'] .= $this->getValueIf($style->isSubScript(), 'sub');
         $css['text-decoration'] = '';
-        $css['text-decoration'] .= $this->getValueIf($underline, 'underline ');
+        if (isset($underlines[$style->getUnderline()])) {
+            $css['text-decoration'] .= $this->getValueIf($underline, $underlines[$style->getUnderline()]);
+        }
         $css['text-decoration'] .= $this->getValueIf($lineThrough, 'line-through ');
         $css['text-transform'] = $this->getValueIf($style->isAllCaps(), 'uppercase');
         $css['font-variant'] = $this->getValueIf($style->isSmallCaps(), 'small-caps');

--- a/src/PhpWord/Writer/ODText/Style/Font.php
+++ b/src/PhpWord/Writer/ODText/Style/Font.php
@@ -18,6 +18,8 @@
 
 namespace PhpOffice\PhpWord\Writer\ODText\Style;
 
+use PhpOffice\PhpWord\Style\Font as FontStyle;
+
 /**
  * Font style writer.
  *
@@ -72,9 +74,34 @@ class Font extends AbstractStyle
         $xmlWriter->writeAttributeIf($style->isItalic(), 'style:font-style-complex', 'italic');
 
         // Underline
-        // @todo Various mode of underline
+        $underlines = [
+            FontStyle::UNDERLINE_DASH => 'dash',
+            FontStyle::UNDERLINE_DASHHEAVY => 'dash',
+            FontStyle::UNDERLINE_DASHLONG => 'long-dash',
+            FontStyle::UNDERLINE_DASHLONGHEAVY => 'long-dash',
+            FontStyle::UNDERLINE_DOUBLE => 'solid',
+            FontStyle::UNDERLINE_DOTDASH => 'dot-dash',
+            FontStyle::UNDERLINE_DOTDASHHEAVY => 'dot-dash',
+            FontStyle::UNDERLINE_DOTDOTDASH => 'dot-dot-dash',
+            FontStyle::UNDERLINE_DOTDOTDASHHEAVY => 'dot-dot-dash',
+            FontStyle::UNDERLINE_DOTTED => 'dotted',
+            FontStyle::UNDERLINE_DOTTEDHEAVY => 'dotted',
+            FontStyle::UNDERLINE_HEAVY => 'solid',
+            FontStyle::UNDERLINE_SINGLE => 'solid',
+            FontStyle::UNDERLINE_WAVY => 'wave',
+            FontStyle::UNDERLINE_WAVYDOUBLE => 'wave',
+            FontStyle::UNDERLINE_WAVYHEAVY => 'wave',
+            FontStyle::UNDERLINE_WORDS => 'solid',
+        ];
+
         $underline = $style->getUnderline();
-        $xmlWriter->writeAttributeIf($underline != 'none', 'style:text-underline-style', 'solid');
+        if (isset($underlines[$underline])) {
+            $xmlWriter->writeAttributeIf($underline != 'none', 'style:text-underline-style', $underlines[$underline]);
+            $xmlWriter->writeAttributeIf(str_contains(strtolower($underline), 'heavy'), 'style:text-underline-width', 'bold');
+            $xmlWriter->writeAttributeIf(str_contains(strtolower($underline), 'thick'), 'style:text-underline-width', 'bold');
+            $xmlWriter->writeAttributeIf(str_contains(strtolower($underline), 'double'), 'style:text-underline-type', 'double');
+            $xmlWriter->writeAttributeIf(str_contains(strtolower($underline), 'words'), 'style:text-underline-mode', 'skip-white-space');
+        }
 
         // Strikethrough, double strikethrough
         $xmlWriter->writeAttributeIf($style->isStrikethrough(), 'style:text-line-through-type', 'single');

--- a/src/PhpWord/Writer/ODText/Style/Font.php
+++ b/src/PhpWord/Writer/ODText/Style/Font.php
@@ -33,7 +33,7 @@ class Font extends AbstractStyle
     public function write(): void
     {
         $style = $this->getStyle();
-        if (!$style instanceof \PhpOffice\PhpWord\Style\Font) {
+        if (!$style instanceof FontStyle) {
             return;
         }
         $xmlWriter = $this->getXmlWriter();
@@ -96,11 +96,11 @@ class Font extends AbstractStyle
 
         $underline = $style->getUnderline();
         if (isset($underlines[$underline])) {
-            $xmlWriter->writeAttributeIf($underline != 'none', 'style:text-underline-style', $underlines[$underline]);
-            $xmlWriter->writeAttributeIf(str_contains(strtolower($underline), 'heavy'), 'style:text-underline-width', 'bold');
-            $xmlWriter->writeAttributeIf(str_contains(strtolower($underline), 'thick'), 'style:text-underline-width', 'bold');
-            $xmlWriter->writeAttributeIf(str_contains(strtolower($underline), 'double'), 'style:text-underline-type', 'double');
-            $xmlWriter->writeAttributeIf(str_contains(strtolower($underline), 'words'), 'style:text-underline-mode', 'skip-white-space');
+            $xmlWriter->writeAttribute('style:text-underline-style', $underlines[$underline]);
+            $xmlWriter->writeAttributeIf(strpos(strtolower($underline), 'heavy') !== false, 'style:text-underline-width', 'bold');
+            $xmlWriter->writeAttributeIf(strpos(strtolower($underline), 'thick') !== false, 'style:text-underline-width', 'bold');
+            $xmlWriter->writeAttributeIf(strpos(strtolower($underline), 'double') !== false, 'style:text-underline-type', 'double');
+            $xmlWriter->writeAttributeIf(strpos(strtolower($underline), 'words') !== false, 'style:text-underline-mode', 'skip-white-space');
         }
 
         // Strikethrough, double strikethrough


### PR DESCRIPTION
### Description

Fixes incorrect underlines in Word2007 Writer. Implements underline styles in ODText Writer. Implements underline styles as supported by CSS in HTML Writer.

Underline in RTF Writer addressed in pull #2819.

### Checklist:

- [x] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
