### PR TITLE
Update TemplateProcessor should replace blocks in footers and headers too

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -13,12 +13,12 @@
  *
  * @see         https://github.com/PHPOffice/PHPWord
  *
+ * @copyright   2010-2018 PHPWord contributors
  * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
 namespace PhpOffice\PhpWord;
 
-use DOMDocument;
 use PhpOffice\PhpWord\Escaper\RegExp;
 use PhpOffice\PhpWord\Escaper\Xml;
 use PhpOffice\PhpWord\Exception\CopyFileException;
@@ -27,17 +27,13 @@ use PhpOffice\PhpWord\Exception\Exception;
 use PhpOffice\PhpWord\Shared\Text;
 use PhpOffice\PhpWord\Shared\XMLWriter;
 use PhpOffice\PhpWord\Shared\ZipArchive;
-use Throwable;
-use XSLTProcessor;
 
 class TemplateProcessor
 {
-    const MAXIMUM_REPLACEMENTS_DEFAULT = -1;
+    public const MAXIMUM_REPLACEMENTS_DEFAULT = -1;
 
     /**
      * ZipArchive object.
-     *
-     * @var mixed
      */
     protected $zipClass;
 
@@ -95,14 +91,13 @@ class TemplateProcessor
      */
     protected $tempDocumentNewImages = [];
 
-    protected static $macroOpeningChars = '${';
-
-    protected static $macroClosingChars = '}';
-
     /**
      * @since 0.12.0 Throws CreateTemporaryFileException and CopyFileException instead of Exception
      *
      * @param string $documentTemplate The fully qualified template filename
+     *
+     * @throws CreateTemporaryFileException
+     * @throws CopyFileException
      */
     public function __construct($documentTemplate)
     {
@@ -133,22 +128,7 @@ class TemplateProcessor
 
         $this->tempDocumentMainPart = $this->readPartWithRels($this->getMainPartName());
         $this->tempDocumentSettingsPart = $this->readPartWithRels($this->getSettingsPartName());
-        $tempDocumentContentTypes = $this->zipClass->getFromName($this->getDocumentContentTypesName());
-        if (is_string($tempDocumentContentTypes)) {
-            $this->tempDocumentContentTypes = $tempDocumentContentTypes;
-        }
-    }
-
-    public function __destruct()
-    {
-        // ZipClass
-        if ($this->zipClass) {
-            try {
-                $this->zipClass->close();
-            } catch (Throwable $e) {
-                // Nothing to do here.
-            }
-        }
+        $this->tempDocumentContentTypes = $this->zipClass->getFromName($this->getDocumentContentTypesName());
     }
 
     /**
@@ -181,17 +161,19 @@ class TemplateProcessor
     }
 
     /**
-     * @param string $xml
-     * @param XSLTProcessor $xsltProcessor
+     * @param string         $xml
+     * @param \XSLTProcessor $xsltProcessor
      *
      * @return string
+     *
+     * @throws Exception
      */
     protected function transformSingleXml($xml, $xsltProcessor)
     {
         if (\PHP_VERSION_ID < 80000) {
             $orignalLibEntityLoader = libxml_disable_entity_loader(true);
         }
-        $domDocument = new DOMDocument();
+        $domDocument = new \DOMDocument();
         if (false === $domDocument->loadXML($xml)) {
             throw new Exception('Could not load the given XML document.');
         }
@@ -208,10 +190,7 @@ class TemplateProcessor
     }
 
     /**
-     * @param mixed $xml
-     * @param XSLTProcessor $xsltProcessor
-     *
-     * @return mixed
+     * @param \XSLTProcessor $xsltProcessor
      */
     protected function transformXml($xml, $xsltProcessor)
     {
@@ -233,13 +212,15 @@ class TemplateProcessor
      * Note: since the method doesn't make any guess on logic of the provided XSL style sheet,
      * make sure that output is correctly escaped. Otherwise you may get broken document.
      *
-     * @param DOMDocument $xslDomDocument
-     * @param array $xslOptions
-     * @param string $xslOptionsUri
+     * @param \DOMDocument $xslDomDocument
+     * @param array        $xslOptions
+     * @param string       $xslOptionsUri
+     *
+     * @throws Exception
      */
-    public function applyXslStyleSheet($xslDomDocument, $xslOptions = [], $xslOptionsUri = ''): void
+    public function applyXslStyleSheet($xslDomDocument, $xslOptions = [], $xslOptionsUri = '')
     {
-        $xsltProcessor = new XSLTProcessor();
+        $xsltProcessor = new \XSLTProcessor();
 
         $xsltProcessor->importStylesheet($xslDomDocument);
         if (false === $xsltProcessor->setParameter($xslOptionsUri, $xslOptions)) {
@@ -258,30 +239,34 @@ class TemplateProcessor
      */
     protected static function ensureMacroCompleted($macro)
     {
-        if (substr($macro, 0, 2) !== self::$macroOpeningChars && substr($macro, -1) !== self::$macroClosingChars) {
-            $macro = self::$macroOpeningChars . $macro . self::$macroClosingChars;
+        if (substr($macro, 0, 2) !== '${' && substr($macro, -1) !== '}') {
+            $macro = '${'.$macro.'}';
         }
 
         return $macro;
     }
 
     /**
-     * @param ?string $subject
+     * @param string $subject
      *
      * @return string
      */
     protected static function ensureUtf8Encoded($subject)
     {
-        return (null !== $subject) ? Text::toUTF8($subject) : '';
+        if (!Text::isUTF8($subject)) {
+            $subject = utf8_encode($subject);
+        }
+
+        return $subject;
     }
 
     /**
      * @param string $search
      */
-    public function setComplexValue($search, Element\AbstractElement $complexType): void
+    public function setComplexValue($search, Element\AbstractElement $complexType)
     {
         $elementName = substr(get_class($complexType), strrpos(get_class($complexType), '\\') + 1);
-        $objectClass = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Element\\' . $elementName;
+        $objectClass = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Element\\'.$elementName;
 
         $xmlWriter = new XMLWriter();
         /** @var Writer\Word2007\Element\AbstractElement $elementWriter */
@@ -305,10 +290,10 @@ class TemplateProcessor
     /**
      * @param string $search
      */
-    public function setComplexBlock($search, Element\AbstractElement $complexType): void
+    public function setComplexBlock($search, Element\AbstractElement $complexType)
     {
         $elementName = substr(get_class($complexType), strrpos(get_class($complexType), '\\') + 1);
-        $objectClass = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Element\\' . $elementName;
+        $objectClass = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Element\\'.$elementName;
 
         $xmlWriter = new XMLWriter();
         /** @var Writer\Word2007\Element\AbstractElement $elementWriter */
@@ -319,11 +304,9 @@ class TemplateProcessor
     }
 
     /**
-     * @param array<string>|string $search
-     * @param null|array<string>|bool|float|int|string $replace
      * @param int $limit
      */
-    public function setValue($search, $replace, $limit = self::MAXIMUM_REPLACEMENTS_DEFAULT): void
+    public function setValue($search, $replace, $limit = self::MAXIMUM_REPLACEMENTS_DEFAULT)
     {
         if (is_array($search)) {
             foreach ($search as &$item) {
@@ -340,21 +323,12 @@ class TemplateProcessor
             }
             unset($item);
         } else {
-            $replace = static::ensureUtf8Encoded(null === $replace ? null : (string) $replace);
+            $replace = static::ensureUtf8Encoded($replace);
         }
 
         if (Settings::isOutputEscapingEnabled()) {
             $xmlEscaper = new Xml();
             $replace = $xmlEscaper->escape($replace);
-        }
-
-        // convert carriage returns
-        if (is_array($replace)) {
-            foreach ($replace as &$item) {
-                $item = $this->replaceCarriageReturns($item);
-            }
-        } else {
-            $replace = $this->replaceCarriageReturns($replace);
         }
 
         $this->tempDocumentHeaders = $this->setValueForPart($search, $replace, $this->tempDocumentHeaders, $limit);
@@ -365,41 +339,20 @@ class TemplateProcessor
     /**
      * Set values from a one-dimensional array of "variable => value"-pairs.
      */
-    public function setValues(array $values, int $limit = self::MAXIMUM_REPLACEMENTS_DEFAULT): void
+    public function setValues(array $values)
     {
         foreach ($values as $macro => $replace) {
-            $this->setValue($macro, $replace, $limit);
+            $this->setValue($macro, $replace);
         }
-    }
-
-    public function setCheckbox(string $search, bool $checked): void
-    {
-        $search = static::ensureMacroCompleted($search);
-        $blockType = 'w:sdt';
-
-        $where = $this->findContainingXmlBlockForMacro($search, $blockType);
-        if (!is_array($where)) {
-            return;
-        }
-
-        $block = $this->getSlice($where['start'], $where['end']);
-
-        $val = $checked ? '1' : '0';
-        $block = preg_replace('/(<w14:checked w14:val=)".*?"(\/>)/', '$1"' . $val . '"$2', $block);
-
-        $text = $checked ? '☒' : '☐';
-        $block = preg_replace('/(<w:t>).*?(<\/w:t>)/', '$1' . $text . '$2', $block);
-
-        $this->replaceXmlBlock($search, $block, $blockType);
     }
 
     /**
      * @param string $search
      */
-    public function setChart($search, Element\AbstractElement $chart): void
+    public function setChart($search, Element\AbstractElement $chart)
     {
         $elementName = substr(get_class($chart), strrpos(get_class($chart), '\\') + 1);
-        $objectClass = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Element\\' . $elementName;
+        $objectClass = 'PhpOffice\\PhpWord\\Writer\\Word2007\\Element\\'.$elementName;
 
         // Get the next relation id
         $rId = $this->getNextRelationsIndex($this->getMainPartName());
@@ -409,7 +362,7 @@ class TemplateProcessor
         $filename = "charts/chart{$rId}.xml";
 
         // Get the part writer
-        $writerPart = new Writer\Word2007\Part\Chart();
+        $writerPart = new \PhpOffice\PhpWord\Writer\Word2007\Part\Chart();
         $writerPart->setElement($chart);
 
         // ContentTypes.xml
@@ -417,11 +370,11 @@ class TemplateProcessor
 
         // add chart to content type
         $xmlRelationsType = "<Override PartName=\"/word/{$filename}\" ContentType=\"application/vnd.openxmlformats-officedocument.drawingml.chart+xml\"/>";
-        $this->tempDocumentContentTypes = str_replace('</Types>', $xmlRelationsType, $this->tempDocumentContentTypes) . '</Types>';
+        $this->tempDocumentContentTypes = str_replace('</Types>', $xmlRelationsType, $this->tempDocumentContentTypes).'</Types>';
 
         // Add the chart to relations
         $xmlChartRelation = "<Relationship Id=\"rId{$rId}\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart\" Target=\"charts/chart{$rId}.xml\"/>";
-        $this->tempDocumentRelations[$this->getMainPartName()] = str_replace('</Relationships>', $xmlChartRelation, $this->tempDocumentRelations[$this->getMainPartName()]) . '</Relationships>';
+        $this->tempDocumentRelations[$this->getMainPartName()] = str_replace('</Relationships>', $xmlChartRelation, $this->tempDocumentRelations[$this->getMainPartName()]).'</Relationships>';
 
         // Write the chart
         $xmlWriter = new XMLWriter();
@@ -429,7 +382,7 @@ class TemplateProcessor
         $elementWriter->write();
 
         // Place it in the template
-        $this->replaceXmlBlock($search, '<w:p>' . $xmlWriter->getData() . '</w:p>', 'w:p');
+        $this->replaceXmlBlock($search, '<w:p>'.$xmlWriter->getData().'</w:p>', 'w:p');
     }
 
     private function getImageArgs($varNameWithArgs)
@@ -441,28 +394,25 @@ class TemplateProcessor
         // size format documentation: https://msdn.microsoft.com/en-us/library/documentformat.openxml.vml.shape%28v=office.14%29.aspx?f=255&MSPPError=-2147217396
         foreach ($varElements as $argIdx => $varArg) {
             if (strpos($varArg, '=')) { // arg=value
-                [$argName, $argValue] = explode('=', $varArg, 2);
+                list($argName, $argValue) = explode('=', $varArg, 2);
                 $argName = strtolower($argName);
                 if ($argName == 'size') {
-                    [$varInlineArgs['width'], $varInlineArgs['height']] = explode('x', $argValue, 2);
+                    list($varInlineArgs['width'], $varInlineArgs['height']) = explode('x', $argValue, 2);
                 } else {
                     $varInlineArgs[strtolower($argName)] = $argValue;
                 }
             } elseif (preg_match('/^([0-9]*[a-z%]{0,2}|auto)x([0-9]*[a-z%]{0,2}|auto)$/i', $varArg)) { // 60x40
-                [$varInlineArgs['width'], $varInlineArgs['height']] = explode('x', $varArg, 2);
+                list($varInlineArgs['width'], $varInlineArgs['height']) = explode('x', $varArg, 2);
             } else { // :60:40:f
                 switch ($argIdx) {
                     case 0:
                         $varInlineArgs['width'] = $varArg;
-
                         break;
                     case 1:
                         $varInlineArgs['height'] = $varArg;
-
                         break;
                     case 2:
                         $varInlineArgs['ratio'] = $varArg;
-
                         break;
                 }
             }
@@ -474,13 +424,13 @@ class TemplateProcessor
     private function chooseImageDimension($baseValue, $inlineValue, $defaultValue)
     {
         $value = $baseValue;
-        if (null === $value && isset($inlineValue)) {
+        if (is_null($value) && isset($inlineValue)) {
             $value = $inlineValue;
         }
-        if (!preg_match('/^([0-9\.]*(cm|mm|in|pt|pc|px|%|em|ex|)|auto)$/i', $value ?? '')) {
+        if (!preg_match('/^([0-9]*(cm|mm|in|pt|pc|px|%|em|ex|)|auto)$/i', $value)) {
             $value = null;
         }
-        if (null === $value) {
+        if (is_null($value)) {
             $value = $defaultValue;
         }
         if (is_numeric($value)) {
@@ -490,43 +440,41 @@ class TemplateProcessor
         return $value;
     }
 
-    private function fixImageWidthHeightRatio(&$width, &$height, $actualWidth, $actualHeight): void
+    private function fixImageWidthHeightRatio(&$width, &$height, $actualWidth, $actualHeight)
     {
         $imageRatio = $actualWidth / $actualHeight;
 
         if (($width === '') && ($height === '')) { // defined size are empty
-            $width = $actualWidth . 'px';
-            $height = $actualHeight . 'px';
+            $width = $actualWidth.'px';
+            $height = $actualHeight.'px';
         } elseif ($width === '') { // defined width is empty
             $heightFloat = (float) $height;
             $widthFloat = $heightFloat * $imageRatio;
             $matches = [];
-            preg_match('/\\d([a-z%]+)$/', $height, $matches);
-            $width = $widthFloat . (!empty($matches) ? $matches[1] : 'px');
+            preg_match("/\d([a-z%]+)$/", $height, $matches);
+            $width = $widthFloat.$matches[1];
         } elseif ($height === '') { // defined height is empty
             $widthFloat = (float) $width;
             $heightFloat = $widthFloat / $imageRatio;
             $matches = [];
-            preg_match('/\\d([a-z%]+)$/', $width, $matches);
-            $height = $heightFloat . (!empty($matches) ? $matches[1] : 'px');
+            preg_match("/\d([a-z%]+)$/", $width, $matches);
+            $height = $heightFloat.$matches[1];
         } else { // we have defined size, but we need also check it aspect ratio
             $widthMatches = [];
-            preg_match('/\\d([a-z%]+)$/', $width, $widthMatches);
+            preg_match("/\d([a-z%]+)$/", $width, $widthMatches);
             $heightMatches = [];
-            preg_match('/\\d([a-z%]+)$/', $height, $heightMatches);
+            preg_match("/\d([a-z%]+)$/", $height, $heightMatches);
             // try to fix only if dimensions are same
-            if (!empty($widthMatches)
-                && !empty($heightMatches)
-                && $widthMatches[1] == $heightMatches[1]) {
+            if ($widthMatches[1] == $heightMatches[1]) {
                 $dimention = $widthMatches[1];
                 $widthFloat = (float) $width;
                 $heightFloat = (float) $height;
                 $definedRatio = $widthFloat / $heightFloat;
 
                 if ($imageRatio > $definedRatio) { // image wider than defined box
-                    $height = ($widthFloat / $imageRatio) . $dimention;
+                    $height = ($widthFloat / $imageRatio).$dimention;
                 } elseif ($imageRatio < $definedRatio) { // image higher than defined box
-                    $width = ($heightFloat * $imageRatio) . $dimention;
+                    $width = ($heightFloat * $imageRatio).$dimention;
                 }
             }
         }
@@ -560,20 +508,20 @@ class TemplateProcessor
             $imgPath = $replaceImage;
         }
 
-        $width = $this->chooseImageDimension($width, $varInlineArgs['width'] ?? null, 115);
-        $height = $this->chooseImageDimension($height, $varInlineArgs['height'] ?? null, 70);
+        $width = $this->chooseImageDimension($width, isset($varInlineArgs['width']) ? $varInlineArgs['width'] : null, 115);
+        $height = $this->chooseImageDimension($height, isset($varInlineArgs['height']) ? $varInlineArgs['height'] : null, 70);
 
         $imageData = @getimagesize($imgPath);
         if (!is_array($imageData)) {
             throw new Exception(sprintf('Invalid image: %s', $imgPath));
         }
-        [$actualWidth, $actualHeight, $imageType] = $imageData;
+        list($actualWidth, $actualHeight, $imageType) = $imageData;
 
         // fix aspect ratio (by default)
-        if (null === $ratio && isset($varInlineArgs['ratio'])) {
+        if (is_null($ratio) && isset($varInlineArgs['ratio'])) {
             $ratio = $varInlineArgs['ratio'];
         }
-        if (null === $ratio || !in_array(strtolower($ratio), ['', '-', 'f', 'false'])) {
+        if (is_null($ratio) || !in_array(strtolower($ratio), ['', '-', 'f', 'false'])) {
             $this->fixImageWidthHeightRatio($width, $height, $actualWidth, $actualHeight);
         }
 
@@ -587,12 +535,12 @@ class TemplateProcessor
         return $imageAttrs;
     }
 
-    private function addImageToRelations($partFileName, $rid, $imgPath, $imageMimeType): void
+    private function addImageToRelations($partFileName, $rid, $imgPath, $imageMimeType)
     {
         // define templates
         $typeTpl = '<Override PartName="/word/media/{IMG}" ContentType="image/{EXT}"/>';
         $relationTpl = '<Relationship Id="{RID}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/{IMG}"/>';
-        $newRelationsTpl = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' . "\n" . '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>';
+        $newRelationsTpl = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'."\n".'<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>';
         $newRelationsTypeTpl = '<Override PartName="/{RELS}" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>';
         $extTransform = [
             'image/jpeg' => 'jpeg',
@@ -613,13 +561,13 @@ class TemplateProcessor
             }
 
             // add image to document
-            $imgName = 'image_' . $rid . '_' . pathinfo($partFileName, PATHINFO_FILENAME) . '.' . $imgExt;
-            $this->zipClass->pclzipAddFile($imgPath, 'word/media/' . $imgName);
+            $imgName = 'image_'.$rid.'_'.pathinfo($partFileName, PATHINFO_FILENAME).'.'.$imgExt;
+            $this->zipClass->pclzipAddFile($imgPath, 'word/media/'.$imgName);
             $this->tempDocumentNewImages[$imgPath] = $imgName;
 
             // setup type for image
             $xmlImageType = str_replace(['{IMG}', '{EXT}'], [$imgName, $imgExt], $typeTpl);
-            $this->tempDocumentContentTypes = str_replace('</Types>', $xmlImageType, $this->tempDocumentContentTypes) . '</Types>';
+            $this->tempDocumentContentTypes = str_replace('</Types>', $xmlImageType, $this->tempDocumentContentTypes).'</Types>';
         }
 
         $xmlImageRelation = str_replace(['{RID}', '{IMG}'], [$rid, $imgName], $relationTpl);
@@ -629,19 +577,18 @@ class TemplateProcessor
             $this->tempDocumentRelations[$partFileName] = $newRelationsTpl;
             // and add it to content types
             $xmlRelationsType = str_replace('{RELS}', $this->getRelationsName($partFileName), $newRelationsTypeTpl);
-            $this->tempDocumentContentTypes = str_replace('</Types>', $xmlRelationsType, $this->tempDocumentContentTypes) . '</Types>';
+            $this->tempDocumentContentTypes = str_replace('</Types>', $xmlRelationsType, $this->tempDocumentContentTypes).'</Types>';
         }
 
         // add image to relations
-        $this->tempDocumentRelations[$partFileName] = str_replace('</Relationships>', $xmlImageRelation, $this->tempDocumentRelations[$partFileName]) . '</Relationships>';
+        $this->tempDocumentRelations[$partFileName] = str_replace('</Relationships>', $xmlImageRelation, $this->tempDocumentRelations[$partFileName]).'</Relationships>';
     }
 
     /**
-     * @param mixed $search
      * @param mixed $replace Path to image, or array("path" => xx, "width" => yy, "height" => zz)
-     * @param int $limit
+     * @param int   $limit
      */
-    public function setImageValue($search, $replace, $limit = self::MAXIMUM_REPLACEMENTS_DEFAULT): void
+    public function setImageValue($search, $replace, $limit = self::MAXIMUM_REPLACEMENTS_DEFAULT)
     {
         // prepare $search_replace
         if (!is_array($search)) {
@@ -657,7 +604,7 @@ class TemplateProcessor
 
         $searchReplace = [];
         foreach ($search as $searchIdx => $searchString) {
-            $searchReplace[$searchString] = $replacesList[$searchIdx] ?? $replacesList[0];
+            $searchReplace[$searchString] = isset($replacesList[$searchIdx]) ? $replacesList[$searchIdx] : $replacesList[0];
         }
 
         // collect document parts
@@ -667,13 +614,13 @@ class TemplateProcessor
         foreach (array_keys($this->tempDocumentHeaders) as $headerIndex) {
             $searchParts[$this->getHeaderName($headerIndex)] = &$this->tempDocumentHeaders[$headerIndex];
         }
-        foreach (array_keys($this->tempDocumentFooters) as $footerIndex) {
-            $searchParts[$this->getFooterName($footerIndex)] = &$this->tempDocumentFooters[$footerIndex];
+        foreach (array_keys($this->tempDocumentFooters) as $headerIndex) {
+            $searchParts[$this->getFooterName($headerIndex)] = &$this->tempDocumentFooters[$headerIndex];
         }
 
         // define templates
         // result can be verified via "Open XML SDK 2.5 Productivity Tool" (http://www.microsoft.com/en-us/download/details.aspx?id=30425)
-        $imgTpl = '<w:pict><v:shape type="#_x0000_t75" style="width:{WIDTH};height:{HEIGHT}" stroked="f" filled="f"><v:imagedata r:id="{RID}" o:title=""/></v:shape></w:pict>';
+        $imgTpl = '<w:pict><v:shape type="#_x0000_t75" style="width:{WIDTH};height:{HEIGHT}" stroked="f"><v:imagedata r:id="{RID}" o:title=""/></v:shape></w:pict>';
 
         $i = 0;
         foreach ($searchParts as $partFileName => &$partContent) {
@@ -681,7 +628,7 @@ class TemplateProcessor
 
             foreach ($searchReplace as $searchString => $replaceImage) {
                 $varsToReplace = array_filter($partVariables, function ($partVar) use ($searchString) {
-                    return ($partVar == $searchString) || preg_match('/^' . preg_quote($searchString, '/') . ':/', $partVar);
+                    return ($partVar == $searchString) || preg_match('/^'.preg_quote($searchString).':/', $partVar);
                 });
 
                 foreach ($varsToReplace as $varNameWithArgs) {
@@ -691,7 +638,7 @@ class TemplateProcessor
 
                     // get image index
                     $imgIndex = $this->getNextRelationsIndex($partFileName);
-                    $rid = 'rId' . $imgIndex;
+                    $rid = 'rId'.$imgIndex;
 
                     // replace preparations
                     $this->addImageToRelations($partFileName, $rid, $imgPath, $preparedImageAttrs['mime']);
@@ -700,11 +647,11 @@ class TemplateProcessor
                     // replace variable
                     $varNameWithArgsFixed = static::ensureMacroCompleted($varNameWithArgs);
                     $matches = [];
-                    if (preg_match('/(<[^<]+>)([^<]*)(' . preg_quote($varNameWithArgsFixed, '/') . ')([^>]*)(<[^>]+>)/Uu', $partContent, $matches)) {
+                    if (preg_match('/(<[^<]+>)([^<]*)('.preg_quote($varNameWithArgsFixed).')([^>]*)(<[^>]+>)/Uu', $partContent, $matches)) {
                         $wholeTag = $matches[0];
                         array_shift($matches);
-                        [$openTag, $prefix, , $postfix, $closeTag] = $matches;
-                        $replaceXml = $openTag . $prefix . $closeTag . $xmlImage . $openTag . $postfix . $closeTag;
+                        list($openTag, $prefix, , $postfix, $closeTag) = $matches;
+                        $replaceXml = $openTag.$prefix.$closeTag.$xmlImage.$openTag.$postfix.$closeTag;
                         // replace on each iteration, because in one tag we can have 2+ inline variables => before proceed next variable we need to change $partContent
                         $partContent = $this->setValueForPart($wholeTag, $replaceXml, $partContent, $limit);
                     }
@@ -743,6 +690,13 @@ class TemplateProcessor
         return array_count_values($variables);
     }
 
+    public function getTplParts()
+    {
+        return $this->getVariablesForPart($this->tempDocumentMainPart);
+
+        // return $this->tempDocumentMainPart;
+    }
+
     /**
      * Returns array of all variables in template.
      *
@@ -757,9 +711,11 @@ class TemplateProcessor
      * Clone a table row in a template document.
      *
      * @param string $search
-     * @param int $numberOfClones
+     * @param int    $numberOfClones
+     *
+     * @throws Exception
      */
-    public function cloneRow($search, $numberOfClones): void
+    public function cloneRow($search, $numberOfClones)
     {
         $search = static::ensureMacroCompleted($search);
 
@@ -787,8 +743,8 @@ class TemplateProcessor
 
                 // If tmpXmlRow doesn't contain continue, this row is no longer part of the spanned row.
                 $tmpXmlRow = $this->getSlice($extraRowStart, $extraRowEnd);
-                if (!preg_match('#<w:vMerge/>#', $tmpXmlRow) &&
-                    !preg_match('#<w:vMerge w:val="continue"\s*/>#', $tmpXmlRow)
+                if (!preg_match('#<w:vMerge/>#', $tmpXmlRow)
+                    && !preg_match('#<w:vMerge w:val="continue"\s*/>#', $tmpXmlRow)
                 ) {
                     break;
                 }
@@ -799,90 +755,26 @@ class TemplateProcessor
         }
 
         $result = $this->getSlice(0, $rowStart);
-        $result .= implode('', $this->indexClonedVariables($numberOfClones, $xmlRow));
+        $result .= implode($this->indexClonedVariables($numberOfClones, $xmlRow));
         $result .= $this->getSlice($rowEnd);
 
         $this->tempDocumentMainPart = $result;
     }
 
     /**
-     * Delete a table row in a template document.
-     */
-    public function deleteRow(string $search): void
-    {
-        if (self::$macroOpeningChars !== substr($search, 0, 2) && self::$macroClosingChars !== substr($search, -1)) {
-            $search = self::$macroOpeningChars . $search . self::$macroClosingChars;
-        }
-
-        $tagPos = strpos($this->tempDocumentMainPart, $search);
-        if (!$tagPos) {
-            throw new Exception(sprintf('Can not delete row %s, template variable not found or variable contains markup.', $search));
-        }
-
-        $tableStart = $this->findTableStart($tagPos);
-        $tableEnd = $this->findTableEnd($tagPos);
-        $xmlTable = $this->getSlice($tableStart, $tableEnd);
-
-        if (substr_count($xmlTable, '<w:tr') === 1) {
-            $this->tempDocumentMainPart = $this->getSlice(0, $tableStart) . $this->getSlice($tableEnd);
-
-            return;
-        }
-
-        $rowStart = $this->findRowStart($tagPos);
-        $rowEnd = $this->findRowEnd($tagPos);
-        $xmlRow = $this->getSlice($rowStart, $rowEnd);
-
-        $this->tempDocumentMainPart = $this->getSlice(0, $rowStart) . $this->getSlice($rowEnd);
-
-        // Check if there's a cell spanning multiple rows.
-        if (preg_match('#<w:vMerge w:val="restart"/>#', $xmlRow)) {
-            $extraRowStart = $rowStart;
-            while (true) {
-                $extraRowStart = $this->findRowStart($extraRowStart + 1);
-                $extraRowEnd = $this->findRowEnd($extraRowStart + 1);
-
-                // If extraRowEnd is lower then 7, there was no next row found.
-                if ($extraRowEnd < 7) {
-                    break;
-                }
-
-                // If tmpXmlRow doesn't contain continue, this row is no longer part of the spanned row.
-                $tmpXmlRow = $this->getSlice($extraRowStart, $extraRowEnd);
-                if (!preg_match('#<w:vMerge/>#', $tmpXmlRow) &&
-                    !preg_match('#<w:vMerge w:val="continue" />#', $tmpXmlRow)
-                ) {
-                    break;
-                }
-
-                $tableStart = $this->findTableStart($extraRowEnd + 1);
-                $tableEnd = $this->findTableEnd($extraRowEnd + 1);
-                $xmlTable = $this->getSlice($tableStart, $tableEnd);
-                if (substr_count($xmlTable, '<w:tr') === 1) {
-                    $this->tempDocumentMainPart = $this->getSlice(0, $tableStart) . $this->getSlice($tableEnd);
-
-                    return;
-                }
-
-                $this->tempDocumentMainPart = $this->getSlice(0, $extraRowStart) . $this->getSlice($extraRowEnd);
-            }
-        }
-    }
-
-    /**
      * Clones a table row and populates it's values from a two-dimensional array in a template document.
      *
      * @param string $search
-     * @param array $values
+     * @param array  $values
      */
-    public function cloneRowAndSetValues($search, $values): void
+    public function cloneRowAndSetValues($search, $values)
     {
         $this->cloneRow($search, count($values));
 
         foreach ($values as $rowKey => $rowData) {
             $rowNumber = $rowKey + 1;
             foreach ($rowData as $macro => $replace) {
-                $this->setValue($macro . '#' . $rowNumber, $replace);
+                $this->setValue($macro.'#'.$rowNumber, $replace);
             }
         }
     }
@@ -891,23 +783,19 @@ class TemplateProcessor
      * Clone a block.
      *
      * @param string $blockname
-     * @param int $clones How many time the block should be cloned
-     * @param bool $replace
-     * @param bool $indexVariables If true, any variables inside the block will be indexed (postfixed with #1, #2, ...)
-     * @param array $variableReplacements Array containing replacements for macros found inside the block to clone
+     * @param int    $clones               How many time the block should be cloned
+     * @param bool   $replace
+     * @param bool   $indexVariables       If true, any variables inside the block will be indexed (postfixed with #1, #2, ...)
+     * @param array  $variableReplacements Array containing replacements for macros found inside the block to clone
      *
-     * @return null|string
+     * @return string|null
      */
     public function cloneBlock($blockname, $clones = 1, $replace = true, $indexVariables = false, $variableReplacements = null)
     {
         $xmlBlock = null;
         $matches = [];
-        $escapedMacroOpeningChars = self::$macroOpeningChars;
-        $escapedMacroClosingChars = self::$macroClosingChars;
         preg_match(
-            //'/(.*((?s)<w:p\b(?:(?!<w:p\b).)*?\{{' . $blockname . '}<\/w:.*?p>))(.*)((?s)<w:p\b(?:(?!<w:p\b).)[^$]*?\{{\/' . $blockname . '}<\/w:.*?p>)/is',
-            '/(.*((?s)<w:p\b(?:(?!<w:p\b).)*?\\' . $escapedMacroOpeningChars . $blockname . $escapedMacroClosingChars . '<\/w:.*?p>))(.*)((?s)<w:p\b(?:(?!<w:p\b).)[^$]*?\\' . $escapedMacroOpeningChars . '\/' . $blockname . $escapedMacroClosingChars . '<\/w:.*?p>)/is',
-            //'/(.*((?s)<w:p\b(?:(?!<w:p\b).)*?\\'. $escapedMacroOpeningChars . $blockname . '}<\/w:.*?p>))(.*)((?s)<w:p\b(?:(?!<w:p\b).)[^$]*?\\'.$escapedMacroOpeningChars.'\/' . $blockname . '}<\/w:.*?p>)/is',
+            '/(.*((?s)<w:p\b(?:(?!<w:p\b).)*?\${'.$blockname.'}<\/w:.*?p>))(.*)((?s)<w:p\b(?:(?!<w:p\b).)[^$]*?\${\/'.$blockname.'}<\/w:.*?p>)/is',
             $this->tempDocumentMainPart,
             $matches
         );
@@ -927,7 +815,7 @@ class TemplateProcessor
 
             if ($replace) {
                 $this->tempDocumentMainPart = str_replace(
-                    $matches[2] . $matches[3] . $matches[4],
+                    $matches[2].$matches[3].$matches[4],
                     implode('', $cloned),
                     $this->tempDocumentMainPart
                 );
@@ -943,20 +831,18 @@ class TemplateProcessor
      * @param string $blockname
      * @param string $replacement
      */
-    public function replaceBlock($blockname, $replacement): void
+    public function replaceBlock($blockname, $replacement)
     {
         $matches = [];
-        $escapedMacroOpeningChars = preg_quote(self::$macroOpeningChars);
-        $escapedMacroClosingChars = preg_quote(self::$macroClosingChars);
         preg_match(
-            '/(<\?xml.*)(<w:p.*>' . $escapedMacroOpeningChars . $blockname . $escapedMacroClosingChars . '<\/w:.*?p>)(.*)(<w:p.*' . $escapedMacroOpeningChars . '\/' . $blockname . $escapedMacroClosingChars . '<\/w:.*?p>)/is',
+            '/(<\?xml.*)(<w:p.*>\${'.$blockname.'}<\/w:.*?p>)(.*)(<w:p.*\${\/'.$blockname.'}<\/w:.*?p>)/is',
             $this->tempDocumentMainPart,
             $matches
         );
 
         if (isset($matches[3])) {
             $this->tempDocumentMainPart = str_replace(
-                $matches[2] . $matches[3] . $matches[4],
+                $matches[2].$matches[3].$matches[4],
                 $replacement,
                 $this->tempDocumentMainPart
             );
@@ -968,7 +854,7 @@ class TemplateProcessor
      *
      * @param string $blockname
      */
-    public function deleteBlock($blockname): void
+    public function deleteBlock($blockname)
     {
         $this->replaceBlock($blockname, '');
     }
@@ -978,14 +864,14 @@ class TemplateProcessor
      *
      * @param bool $update
      */
-    public function setUpdateFields($update = true): void
+    public function setUpdateFields($update = true)
     {
         $string = $update ? 'true' : 'false';
         $matches = [];
         if (preg_match('/<w:updateFields w:val=\"(true|false|1|0|on|off)\"\/>/', $this->tempDocumentSettingsPart, $matches)) {
-            $this->tempDocumentSettingsPart = str_replace($matches[0], '<w:updateFields w:val="' . $string . '"/>', $this->tempDocumentSettingsPart);
+            $this->tempDocumentSettingsPart = str_replace($matches[0], '<w:updateFields w:val="'.$string.'"/>', $this->tempDocumentSettingsPart);
         } else {
-            $this->tempDocumentSettingsPart = str_replace('</w:settings>', '<w:updateFields w:val="' . $string . '"/></w:settings>', $this->tempDocumentSettingsPart);
+            $this->tempDocumentSettingsPart = str_replace('</w:settings>', '<w:updateFields w:val="'.$string.'"/></w:settings>', $this->tempDocumentSettingsPart);
         }
     }
 
@@ -993,6 +879,8 @@ class TemplateProcessor
      * Saves the result document.
      *
      * @return string
+     *
+     * @throws Exception
      */
     public function save()
     {
@@ -1021,7 +909,7 @@ class TemplateProcessor
      * @param string $fileName
      * @param string $xml
      */
-    protected function savePartWithRels($fileName, $xml): void
+    protected function savePartWithRels($fileName, $xml)
     {
         $this->zipClass->addFromString($fileName, $xml);
         if (isset($this->tempDocumentRelations[$fileName])) {
@@ -1037,7 +925,7 @@ class TemplateProcessor
      *
      * @param string $fileName
      */
-    public function saveAs($fileName): void
+    public function saveAs($fileName)
     {
         $tempFileName = $this->save();
 
@@ -1065,12 +953,8 @@ class TemplateProcessor
      */
     protected function fixBrokenMacros($documentPart)
     {
-        $brokenMacroOpeningChars = substr(self::$macroOpeningChars, 0, 1);
-        $endMacroOpeningChars = substr(self::$macroOpeningChars, 1);
-        $macroClosingChars = self::$macroClosingChars;
-
         return preg_replace_callback(
-            '/\\' . $brokenMacroOpeningChars . '(?:\\' . $endMacroOpeningChars . '|[^{$]*\>\{)[^' . $macroClosingChars . '$]*\}/U',
+            '/\$(?:\{|[^{$]*\>\{)[^}$]*\}/U',
             function ($match) {
                 return strip_tags($match[0]);
             },
@@ -1081,12 +965,10 @@ class TemplateProcessor
     /**
      * Find and replace macros in the given XML section.
      *
-     * @param array<string>|string $search
-     * @param array<string>|string $replace
-     * @param array<int, string>|string $documentPartXML
-     * @param int $limit
+     * @param string $documentPartXML
+     * @param int    $limit
      *
-     * @return ($documentPartXML is string ? string : array<string>)
+     * @return string
      */
     protected function setValueForPart($search, $replace, $documentPartXML, $limit)
     {
@@ -1109,10 +991,7 @@ class TemplateProcessor
     protected function getVariablesForPart($documentPartXML)
     {
         $matches = [];
-        $escapedMacroOpeningChars = preg_quote(self::$macroOpeningChars);
-        $escapedMacroClosingChars = preg_quote(self::$macroClosingChars);
-
-        preg_match_all("/$escapedMacroOpeningChars(.*?)$escapedMacroClosingChars/i", $documentPartXML, $matches);
+        preg_match_all('/\$\{(.*?)}/i', $documentPartXML, $matches);
 
         return $matches[1];
     }
@@ -1177,14 +1056,14 @@ class TemplateProcessor
      */
     protected function getRelationsName($documentPartName)
     {
-        return 'word/_rels/' . pathinfo($documentPartName, PATHINFO_BASENAME) . '.rels';
+        return 'word/_rels/'.pathinfo($documentPartName, PATHINFO_BASENAME).'.rels';
     }
 
     protected function getNextRelationsIndex($documentPartName)
     {
         if (isset($this->tempDocumentRelations[$documentPartName])) {
             $candidate = substr_count($this->tempDocumentRelations[$documentPartName], '<Relationship');
-            while (strpos($this->tempDocumentRelations[$documentPartName], 'Id="rId' . $candidate . '"') !== false) {
+            while (strpos($this->tempDocumentRelations[$documentPartName], 'Id="rId'.$candidate.'"') !== false) {
                 ++$candidate;
             }
 
@@ -1203,51 +1082,20 @@ class TemplateProcessor
     }
 
     /**
-     * Find the start position of the nearest table before $offset.
-     */
-    private function findTableStart(int $offset): int
-    {
-        $rowStart = strrpos(
-            $this->tempDocumentMainPart,
-            '<w:tbl ',
-            ((strlen($this->tempDocumentMainPart) - $offset) * -1)
-        );
-
-        if (!$rowStart) {
-            $rowStart = strrpos(
-                $this->tempDocumentMainPart,
-                '<w:tbl>',
-                ((strlen($this->tempDocumentMainPart) - $offset) * -1)
-            );
-        }
-        if (!$rowStart) {
-            throw new Exception('Can not find the start position of the table.');
-        }
-
-        return $rowStart;
-    }
-
-    /**
-     * Find the end position of the nearest table row after $offset.
-     */
-    private function findTableEnd(int $offset): int
-    {
-        return strpos($this->tempDocumentMainPart, '</w:tbl>', $offset) + 7;
-    }
-
-    /**
      * Find the start position of the nearest table row before $offset.
      *
      * @param int $offset
      *
      * @return int
+     *
+     * @throws Exception
      */
     protected function findRowStart($offset)
     {
-        $rowStart = strrpos($this->tempDocumentMainPart, '<w:tr ', ((strlen($this->tempDocumentMainPart) - $offset) * -1));
+        $rowStart = strrpos($this->tempDocumentMainPart, '<w:tr ', (strlen($this->tempDocumentMainPart) - $offset) * -1);
 
         if (!$rowStart) {
-            $rowStart = strrpos($this->tempDocumentMainPart, '<w:tr>', ((strlen($this->tempDocumentMainPart) - $offset) * -1));
+            $rowStart = strrpos($this->tempDocumentMainPart, '<w:tr>', (strlen($this->tempDocumentMainPart) - $offset) * -1);
         }
         if (!$rowStart) {
             throw new Exception('Can not find the start position of the row to clone.');
@@ -1282,43 +1130,32 @@ class TemplateProcessor
             $endPosition = strlen($this->tempDocumentMainPart);
         }
 
-        return substr($this->tempDocumentMainPart, $startPosition, ($endPosition - $startPosition));
+        return substr($this->tempDocumentMainPart, $startPosition, $endPosition - $startPosition);
     }
 
     /**
      * Replaces variable names in cloned
      * rows/blocks with indexed names.
      *
-     * @param int $count
+     * @param int    $count
      * @param string $xmlBlock
      *
-     * @return array<string>
+     * @return string
      */
     protected function indexClonedVariables($count, $xmlBlock)
     {
         $results = [];
-        $escapedMacroOpeningChars = preg_quote(self::$macroOpeningChars);
-        $escapedMacroClosingChars = preg_quote(self::$macroClosingChars);
-
         for ($i = 1; $i <= $count; ++$i) {
-            $results[] = preg_replace("/$escapedMacroOpeningChars([^:]*?)(:.*?)?$escapedMacroClosingChars/", self::$macroOpeningChars . '\1#' . $i . '\2' . self::$macroClosingChars, $xmlBlock);
+            $results[] = preg_replace('/\$\{([^:]*?)(:.*?)?\}/', '\${\1#'.$i.'\2}', $xmlBlock);
         }
 
         return $results;
     }
 
     /**
-     * Replace carriage returns with xml.
-     */
-    public function replaceCarriageReturns(string $string): string
-    {
-        return str_replace(["\r\n", "\r", "\n"], '</w:t><w:br/><w:t>', $string);
-    }
-
-    /**
-     * Replaces variables with values from array, array keys are the variable names.
+     * Raplaces variables with values from array, array keys are the variable names.
      *
-     * @param array $variableReplacements
+     * @param array  $variableReplacements
      * @param string $xmlBlock
      *
      * @return string[]
@@ -1340,17 +1177,40 @@ class TemplateProcessor
     /**
      * Replace an XML block surrounding a macro with a new block.
      *
-     * @param string $macro Name of macro
-     * @param string $block New block content
+     * @param string $macro     Name of macro
+     * @param string $block     New block content
      * @param string $blockType XML tag type of block
      *
      * @return TemplateProcessor Fluent interface
      */
     public function replaceXmlBlock($macro, $block, $blockType = 'w:p')
     {
-        $where = $this->findContainingXmlBlockForMacro($macro, $blockType);
+        // Replace in main document
+        $where = $this->findContainingXmlBlockForMacro($macro, $blockType, $this->tempDocumentMainPart);
         if (is_array($where)) {
-            $this->tempDocumentMainPart = $this->getSlice(0, $where['start']) . $block . $this->getSlice($where['end']);
+            $this->tempDocumentMainPart = $this->getSlice(0, $where['start']).$block.$this->getSlice($where['end']);
+
+            return $this;
+        }
+
+        // Replace in headers
+        foreach ($this->tempDocumentHeaders as $index => &$headerXML) {
+            $where = $this->findContainingXmlBlockForMacro($macro, $blockType, $headerXML);
+            if (is_array($where)) {
+                $headerXML = substr($headerXML, 0, $where['start']).$block.substr($headerXML, $where['end']);
+
+                return $this;
+            }
+        }
+
+        // Replace in footers
+        foreach ($this->tempDocumentFooters as $index => &$footerXML) {
+            $where = $this->findContainingXmlBlockForMacro($macro, $blockType, $footerXML);
+            if (is_array($where)) {
+                $footerXML = substr($footerXML, 0, $where['start']).$block.substr($footerXML, $where['end']);
+
+                return $this;
+            }
         }
 
         return $this;
@@ -1362,28 +1222,86 @@ class TemplateProcessor
      *
      * Note that only the first instance of the macro will be found
      *
-     * @param string $macro Name of macro
+     * @param string $macro     Name of macro
      * @param string $blockType XML tag for block
+     * @param string $xmlSource Source XML to search in (defaults to main document part)
      *
      * @return bool|int[] FALSE if not found, otherwise array with start and end
      */
-    protected function findContainingXmlBlockForMacro($macro, $blockType = 'w:p')
+    protected function findContainingXmlBlockForMacro($macro, $blockType = 'w:p', $xmlSource = null)
     {
-        $macroPos = $this->findMacro($macro);
+        if ($xmlSource === null) {
+            $xmlSource = $this->tempDocumentMainPart;
+        }
+
+        $macroPos = $this->findMacroInSource($macro, $xmlSource);
         if (0 > $macroPos) {
             return false;
         }
-        $start = $this->findXmlBlockStart($macroPos, $blockType);
+        $start = $this->findXmlBlockStartInSource($macroPos, $blockType, $xmlSource);
         if (0 > $start) {
             return false;
         }
-        $end = $this->findXmlBlockEnd($start, $blockType);
-        //if not found or if resulting string does not contain the macro we are searching for
-        if (0 > $end || strstr($this->getSlice($start, $end), $macro) === false) {
+        $end = $this->findXmlBlockEndInSource($start, $blockType, $xmlSource);
+        // if not found or if resulting string does not contain the macro we are searching for
+        if (0 > $end || strstr(substr($xmlSource, $start, $end - $start), $macro) === false) {
             return false;
         }
 
         return ['start' => $start, 'end' => $end];
+    }
+
+    /**
+     * Find the position of (the start of) a macro in a given source.
+     *
+     * @param string $search Macro name
+     * @param string $source XML source to search in
+     * @param int    $offset Offset from which to start searching
+     *
+     * @return int -1 if macro not found
+     */
+    protected function findMacroInSource($search, $source, $offset = 0)
+    {
+        $search = static::ensureMacroCompleted($search);
+        $pos = strpos($source, $search, $offset);
+
+        return ($pos === false) ? -1 : $pos;
+    }
+
+    /**
+     * Find the start position of the nearest XML block start before $offset in source.
+     *
+     * @param int    $offset    Search position
+     * @param string $blockType XML Block tag
+     * @param string $source    XML source to search in
+     *
+     * @return int -1 if block start not found
+     */
+    protected function findXmlBlockStartInSource($offset, $blockType, $source)
+    {
+        $reverseOffset = (strlen($source) - $offset) * -1;
+        $blockStart = strrpos($source, '<'.$blockType.' ', $reverseOffset);
+        if (false === $blockStart || strrpos(substr($source, $blockStart, $offset - $blockStart), '<'.$blockType.'>')) {
+            $blockStart = strrpos($source, '<'.$blockType.'>', $reverseOffset);
+        }
+
+        return ($blockStart === false) ? -1 : $blockStart;
+    }
+
+    /**
+     * Find the nearest block end position after $offset in source.
+     *
+     * @param int    $offset    Search position
+     * @param string $blockType XML Block tag
+     * @param string $source    XML source to search in
+     *
+     * @return int -1 if block end not found
+     */
+    protected function findXmlBlockEndInSource($offset, $blockType, $source)
+    {
+        $blockEndStart = strpos($source, '</'.$blockType.'>', $offset);
+
+        return ($blockEndStart === false) ? -1 : $blockEndStart + 3 + strlen($blockType);
     }
 
     /**
@@ -1394,54 +1312,39 @@ class TemplateProcessor
      * Note that only the first instance of the macro will be found
      *
      * @param string $search Macro name
-     * @param int $offset Offset from which to start searching
+     * @param int    $offset Offset from which to start searching
      *
      * @return int -1 if macro not found
      */
     protected function findMacro($search, $offset = 0)
     {
-        $search = static::ensureMacroCompleted($search);
-        $pos = strpos($this->tempDocumentMainPart, $search, $offset);
-
-        return ($pos === false) ? -1 : $pos;
+        return $this->findMacroInSource($search, $this->tempDocumentMainPart, $offset);
     }
 
     /**
      * Find the start position of the nearest XML block start before $offset.
      *
-     * @param int $offset    Search position
-     * @param string  $blockType XML Block tag
+     * @param int    $offset    Search position
+     * @param string $blockType XML Block tag
      *
      * @return int -1 if block start not found
      */
     protected function findXmlBlockStart($offset, $blockType)
     {
-        $reverseOffset = (strlen($this->tempDocumentMainPart) - $offset) * -1;
-        // first try XML tag with attributes
-        $blockStart = strrpos($this->tempDocumentMainPart, '<' . $blockType . ' ', $reverseOffset);
-        // if not found, or if found but contains the XML tag without attribute
-        if (false === $blockStart || strrpos($this->getSlice($blockStart, $offset), '<' . $blockType . '>')) {
-            // also try XML tag without attributes
-            $blockStart = strrpos($this->tempDocumentMainPart, '<' . $blockType . '>', $reverseOffset);
-        }
-
-        return ($blockStart === false) ? -1 : $blockStart;
+        return $this->findXmlBlockStartInSource($offset, $blockType, $this->tempDocumentMainPart);
     }
 
     /**
      * Find the nearest block end position after $offset.
      *
-     * @param int $offset    Search position
-     * @param string  $blockType XML Block tag
+     * @param int    $offset    Search position
+     * @param string $blockType XML Block tag
      *
      * @return int -1 if block end not found
      */
     protected function findXmlBlockEnd($offset, $blockType)
     {
-        $blockEndStart = strpos($this->tempDocumentMainPart, '</' . $blockType . '>', $offset);
-        // return position of end of tag if found, otherwise -1
-
-        return ($blockEndStart === false) ? -1 : $blockEndStart + 3 + strlen($blockType);
+        return $this->findXmlBlockEndInSource($offset, $blockType, $this->tempDocumentMainPart);
     }
 
     /**
@@ -1464,9 +1367,9 @@ class TemplateProcessor
         }
 
         $unformattedText = preg_replace('/>\s+</', '><', $text);
-        $result = str_replace([self::$macroOpeningChars, self::$macroClosingChars], ['</w:t></w:r><w:r>' . $extractedStyle . '<w:t xml:space="preserve">' . self::$macroOpeningChars, self::$macroClosingChars . '</w:t></w:r><w:r>' . $extractedStyle . '<w:t xml:space="preserve">'], $unformattedText);
+        $result = str_replace(['${', '}'], ['</w:t></w:r><w:r>'.$extractedStyle.'<w:t xml:space="preserve">${', '}</w:t></w:r><w:r>'.$extractedStyle.'<w:t xml:space="preserve">'], $unformattedText);
 
-        return str_replace(['<w:r>' . $extractedStyle . '<w:t xml:space="preserve"></w:t></w:r>', '<w:r><w:t xml:space="preserve"></w:t></w:r>', '<w:t>'], ['', '', '<w:t xml:space="preserve">'], $result);
+        return str_replace(['<w:r>'.$extractedStyle.'<w:t xml:space="preserve"></w:t></w:r>', '<w:r><w:t xml:space="preserve"></w:t></w:r>', '<w:t>'], ['', '', '<w:t xml:space="preserve">'], $result);
     }
 
     /**
@@ -1478,30 +1381,6 @@ class TemplateProcessor
      */
     protected function textNeedsSplitting($text)
     {
-        $escapedMacroOpeningChars = preg_quote(self::$macroOpeningChars);
-        $escapedMacroClosingChars = preg_quote(self::$macroClosingChars);
-
-        return 1 === preg_match('/[^>]' . $escapedMacroOpeningChars . '|' . $escapedMacroClosingChars . '[^<]/i', $text);
-    }
-
-    public function setMacroOpeningChars(string $macroOpeningChars): void
-    {
-        self::$macroOpeningChars = $macroOpeningChars;
-    }
-
-    public function setMacroClosingChars(string $macroClosingChars): void
-    {
-        self::$macroClosingChars = $macroClosingChars;
-    }
-
-    public function setMacroChars(string $macroOpeningChars, string $macroClosingChars): void
-    {
-        self::$macroOpeningChars = $macroOpeningChars;
-        self::$macroClosingChars = $macroClosingChars;
-    }
-
-    public function getTempDocumentFilename(): string
-    {
-        return $this->tempDocumentFilename;
+        return preg_match('/[^>]\${|}[^<]/i', $text) == 1;
     }
 }


### PR DESCRIPTION
### Description

This PR fixes an issue where the replaceXmlBlock() method only searched for and replaced macros in the main document part, ignoring headers and footers.

Fixes # (issue)

The replaceXmlBlock() method was limited to replacing XML blocks only in tempDocumentMainPart. When templates contained macros in headers or footers that needed to be replaced with complex XML blocks (such as images, charts, or formatted content), these replacements would silently fail.

This change brings replaceXmlBlock() in line with other replacement methods like setValue() and setImageValue(), which already search across all document parts. This ensures consistent behavior across the API and allows users to replace complex content in headers and footers, which is a common requirement when working with Word templates.

### Checklist:

- [x] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [ ] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
