### PR TITLE
fix(html): prevent paragraph wrapping inside ListItemRun containers

### DIFF
--- a/src/PhpWord/Writer/HTML/Element/Container.php
+++ b/src/PhpWord/Writer/HTML/Element/Container.php
@@ -46,7 +46,7 @@ class Container extends AbstractElement
             return '';
         }
         $containerClass = substr(get_class($container), strrpos(get_class($container), '\\') + 1);
-        $withoutP = in_array($containerClass, ['TextRun', 'Footnote', 'Endnote']) ? true : false;
+        $withoutP = in_array($containerClass, ['TextRun', 'Footnote', 'Endnote', 'ListItemRun']) ? true : false;
         $content = '';
 
         $elements = $container->getElements();


### PR DESCRIPTION
## Summary
- Text elements inside `ListItemRun` containers were being incorrectly wrapped in `<p>` tags
- This caused list items to be rendered as multiple separate paragraphs instead of a single inline list item
- Added `'ListItemRun'` to the `$withoutP` check in `Container.php` alongside `TextRun`, `Footnote`, and `Endnote`

## Example

**Before (broken):**
```html
<p>Communicating </p>
<p><span style="font-weight: bold;">COMPANY NAME</span></p>
<p>'s</p>
<p> commitment to health and safety </p>
```

**After (fixed):**
```html
Communicating <span style="font-weight: bold;">COMPANY NAME</span>'s commitment to health and safety
```

## Test plan
- [x] Import DOCX with list items containing multiple text runs (bold, italic, etc.)
- [x] Verify HTML output has inline text instead of separate paragraphs

🤖 Generated with [Claude Code](https://claude.ai/code)