### PR TITLE
Fix/php84 deprecations

### DIFF
--- a/src/PhpWord/Media.php
+++ b/src/PhpWord/Media.php
@@ -47,7 +47,7 @@ class Media
      *
      * @return int
      */
-    public static function addElement($container, $mediaType, $source, Image $image = null)
+    public static function addElement($container, $mediaType, $source, ?Image $image = null)
     {
         // Assign unique media Id and initiate media container if none exists
         $mediaId = md5($container . $source);
@@ -214,7 +214,7 @@ class Media
      *
      * @codeCoverageIgnore
      */
-    public static function addSectionMediaElement($src, $type, Image $image = null)
+    public static function addSectionMediaElement($src, $type, ?Image $image = null)
     {
         return self::addElement('section', $type, $src, $image);
     }
@@ -280,7 +280,7 @@ class Media
      *
      * @codeCoverageIgnore
      */
-    public static function addHeaderMediaElement($headerCount, $src, Image $image = null)
+    public static function addHeaderMediaElement($headerCount, $src, ?Image $image = null)
     {
         return self::addElement("header{$headerCount}", 'image', $src, $image);
     }
@@ -328,7 +328,7 @@ class Media
      *
      * @codeCoverageIgnore
      */
-    public static function addFooterMediaElement($footerCount, $src, Image $image = null)
+    public static function addFooterMediaElement($footerCount, $src, ?Image $image = null)
     {
         return self::addElement("footer{$footerCount}", 'image', $src, $image);
     }

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -381,6 +381,9 @@ abstract class AbstractPart
                             if ('w:p' == $cellNode->nodeName) { // Paragraph
                                 $this->readParagraph($xmlReader, $cellNode, $cell, $docPart);
                             }
+                            if ($cellNode->nodeName == 'w:tbl') { // Table
+                                $this->readTable($xmlReader, $cellNode, $cell, $docPart);
+                            }
                         }
                     }
                 }

--- a/src/PhpWord/Shared/XMLWriter.php
+++ b/src/PhpWord/Shared/XMLWriter.php
@@ -171,7 +171,7 @@ class XMLWriter extends \XMLWriter
      * @param mixed $value
      * @return bool
      */
-    public function writeAttribute($name, $value)
+    public function writeAttribute($name, $value): bool
     {
         if (is_float($value)) {
             $value = json_encode($value);

--- a/src/PhpWord/Style/Language.php
+++ b/src/PhpWord/Style/Language.php
@@ -232,7 +232,7 @@ final class Language extends AbstractStyle
             $locale = str_replace('_', '-', $locale);
         }
 
-        if (strlen($locale) === 2) {
+        if ($locale !== null && strlen($locale) === 2) {
             return strtolower($locale) . '-' . strtoupper($locale);
         }
 

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -800,13 +800,13 @@ class TemplateProcessor
         $xmlBlock = null;
         $matches = array();
         preg_match(
-            '/(.*((?s)<w:p\b(?:(?!<w:p\b).)*?\${' . $blockname . '}<\/w:.*?p>))(.*)((?s)<w:p\b(?:(?!<w:p\b).)[^$]*?\${\/' . $blockname . '}<\/w:.*?p>)/is',
+            '/\$\{' . $blockname . '}(.*)\$\{\/' . $blockname . '}/is',
             $this->tempDocumentMainPart,
             $matches
         );
 
-        if (isset($matches[3])) {
-            $xmlBlock = $matches[3];
+        if (isset($matches[1])) {
+            $xmlBlock = $matches[1];
             if ($indexVariables) {
                 $cloned = $this->indexClonedVariables($clones, $xmlBlock);
             } elseif ($variableReplacements !== null && is_array($variableReplacements)) {
@@ -820,7 +820,7 @@ class TemplateProcessor
 
             if ($replace) {
                 $this->tempDocumentMainPart = str_replace(
-                    $matches[2] . $matches[3] . $matches[4],
+                    $matches[0],
                     implode('', $cloned),
                     $this->tempDocumentMainPart
                 );

--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -799,14 +799,15 @@ class TemplateProcessor
     {
         $xmlBlock = null;
         $matches = array();
-        preg_match(
-            '/\$\{' . $blockname . '}(.*)\$\{\/' . $blockname . '}/is',
+        preg_match_all(
+            '/\$\{' . $blockname . '\}(.*?)\$\{\/' . $blockname . '\}/is',
             $this->tempDocumentMainPart,
-            $matches
+            $matches,
+            PREG_SET_ORDER
         );
 
-        if (isset($matches[1])) {
-            $xmlBlock = $matches[1];
+        foreach ($matches as $match) {
+            $xmlBlock = $match[1];
             if ($indexVariables) {
                 $cloned = $this->indexClonedVariables($clones, $xmlBlock);
             } elseif ($variableReplacements !== null && is_array($variableReplacements)) {
@@ -820,7 +821,7 @@ class TemplateProcessor
 
             if ($replace) {
                 $this->tempDocumentMainPart = str_replace(
-                    $matches[0],
+                    $match[0],
                     implode('', $cloned),
                     $this->tempDocumentMainPart
                 );


### PR DESCRIPTION
fix: resolve PHP 8.4 deprecation warnings

      - Use explicit nullable types for Image parameters in Media methods
      - Add bool return type to XMLWriter::writeAttribute() to match parent
      - Guard strlen() call against null in Language::validateLocale()