### PR TITLE
fix: replace repeated complex block macros

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -315,7 +315,11 @@ class TemplateProcessor
         $elementWriter = new $objectClass($xmlWriter, $complexType, false);
         $elementWriter->write();
 
-        $this->replaceXmlBlock($search, $xmlWriter->getData(), 'w:p');
+        $search = static::ensureMacroCompleted($search);
+        $block = $xmlWriter->getData();
+        while (is_array($this->findContainingXmlBlockForMacro($search, 'w:p'))) {
+            $this->replaceXmlBlock($search, $block, 'w:p');
+        }
     }
 
     /**

--- a/tests/PhpWordTests/TemplateProcessorTest.php
+++ b/tests/PhpWordTests/TemplateProcessorTest.php
@@ -550,6 +550,45 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
         self::assertEquals(preg_replace('/>\s+</', '><', $result), preg_replace('/>\s+</', '><', $templateProcessor->getMainPart()));
     }
 
+    public function testSetComplexBlockReplacesMultipleMatchingMacros(): void
+    {
+        $title = new TextRun();
+        $title->addText('This is my repeated title');
+
+        $mainPart = '<?xml version="1.0" encoding="UTF-8"?>
+        <w:p>
+            <w:r>
+                <w:t xml:space="preserve">${document-title}</w:t>
+            </w:r>
+        </w:p>
+        <w:p>
+            <w:r>
+                <w:t xml:space="preserve">${document-title}</w:t>
+            </w:r>
+        </w:p>';
+
+        $result = '<?xml version="1.0" encoding="UTF-8"?>
+        <w:p>
+            <w:pPr/>
+            <w:r>
+                <w:rPr/>
+                <w:t xml:space="preserve">This is my repeated title</w:t>
+            </w:r>
+        </w:p>
+        <w:p>
+            <w:pPr/>
+            <w:r>
+                <w:rPr/>
+                <w:t xml:space="preserve">This is my repeated title</w:t>
+            </w:r>
+        </w:p>';
+
+        $templateProcessor = new TestableTemplateProcesor($mainPart);
+        $templateProcessor->setComplexBlock('document-title', $title);
+
+        self::assertEquals(trim(preg_replace('/>\s+</', '><', $result)), trim(preg_replace('/>\s+</', '><', $templateProcessor->getMainPart())));
+    }
+
     public function testSetComplexValueWithCustomMacro(): void
     {
         $title = new TextRun();


### PR DESCRIPTION
## Summary
- Fixes `TemplateProcessor::setComplexBlock()` so repeated complex-block placeholders with the same macro are all replaced.
- Stores the generated replacement XML once before looping, because `XMLWriter::getData()` consumes the buffer.
- Adds a regression test for two repeated `${document-title}` complex-block placeholders.

Fixes #2804.

## Test Plan
- `vendor/bin/phpunit --filter testSetComplexBlockReplacesMultipleMatchingMacros tests/PhpWordTests/TemplateProcessorTest.php`
- `vendor/bin/phpunit tests/PhpWordTests/TemplateProcessorTest.php`
- `git diff --check`
