### PR TITLE
HTML Reader: Style break-inside and break-after in paragraph

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -4,6 +4,7 @@
 
 ## Enhancements
 - Added support for image alt text by [@jwoodhead](https://github.com/jwoodhead) in [#2873](https://github.com/PHPOffice/PHPWord/pull/2873)
+- HTML Reader: Support setting `keepLine` and `keepNext` on paragraphs by [@jwoodhead](https://github.com/jwoodhead) in [#2871](https://github.com/PHPOffice/PHPWord/pull/2871)
 
 ### Bug fixes
 

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -929,6 +929,20 @@ class Html
                     }
 
                     break;
+                case 'break-inside':
+                    if ($value == 'avoid' || $value == 'avoid-page') {
+                        $styles['keepLines'] = true;
+                    }
+
+                    break;
+                case 'break-after':
+                    if ($value == 'avoid' || $value == 'avoid-page') {
+                        $styles['keepNext'] = true;
+                    } elseif ($value == 'always') {
+                        $styles['isPageBreak'] = true;
+                    }
+
+                    break;
             }
         }
 

--- a/tests/PhpWordTests/Shared/HtmlTest.php
+++ b/tests/PhpWordTests/Shared/HtmlTest.php
@@ -506,6 +506,46 @@ class HtmlTest extends AbstractWebServerEmbedded
     }
 
     /**
+     * Test parsing paragraph with `break-inside: avoid` style.
+     */
+    public function testParseParagraphWithBreakInsideAvoid(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        Html::addHtml($section, '<p style="break-inside: avoid;"></p>');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:pPr/w:keepLines'));
+    }
+
+    /**
+     * Test parsing paragraph with `break-after: avoid` style.
+     */
+    public function testParseParagraphWithBreakAfterAvoid(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        Html::addHtml($section, '<p style="break-after: avoid;"></p>');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:pPr/w:keepNext'));
+    }
+
+    /**
+     * Test parsing paragraph with `break-after: always` style.
+     */
+    public function testParseParagraphWithBreakAfterAlways(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        Html::addHtml($section, '<p style="break-after: always;"></p>');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:br'));
+        self::assertEquals('page', $doc->getElementAttribute('/w:document/w:body/w:p/w:r/w:br', 'w:type'));
+    }
+
+    /**
      * Test parsing table.
      */
     public function testParseTable(): void


### PR DESCRIPTION
### Description

Added support for setting `keepLines` and `keepNext` for paragraphs when reading HTML using the `break-inside` and `break-after` CSS styles.

### Checklist:

- [X] My CI is :green_circle:
- [X] I have covered by unit tests my new code (check build/coverage for coverage report)
- [X] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [X] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
