### PR TITLE
Fix #2876: Remove chunking in Mpdf writer to align with PhpSpreadsheet

### DIFF
--- a/src/PhpWord/Writer/PDF/MPDF.php
+++ b/src/PhpWord/Writer/PDF/MPDF.php
@@ -11,9 +11,9 @@
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
  *
- * @see        https://github.com/PHPOffice/PhpWord
+ * @see         https://github.com/PHPOffice/PhpWord
  *
- * @license    http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
 namespace PhpOffice\PhpWord\Writer\PDF;

--- a/src/PhpWord/Writer/PDF/MPDF.php
+++ b/src/PhpWord/Writer/PDF/MPDF.php
@@ -11,9 +11,9 @@
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
  *
- * @see         https://github.com/PHPOffice/PhpWord
+ * @see        https://github.com/PHPOffice/PhpWord
  *
- * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ * @license    http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
 namespace PhpOffice\PhpWord\Writer\PDF;
@@ -30,7 +30,7 @@ use PhpOffice\PhpWord\Writer\WriterInterface;
  */
 class MPDF extends AbstractRenderer implements WriterInterface
 {
-    public const SIMULATED_BODY_START = '<!-- simulated body start -->';
+    public const SIMULATED_BODY_START = '';
     private const BODY_TAG = '<body>';
 
     /**
@@ -104,9 +104,9 @@ class MPDF extends AbstractRenderer implements WriterInterface
             $pdf->WriteHTML(substr($html, 0, $bodyLocation));
             $html = substr($html, $bodyLocation);
         }
-        foreach (explode("\n", $html) as $line) {
-            $pdf->WriteHTML("$line\n");
-        }
+        
+        // Pass the full HTML string directly to WriteHTML
+        $pdf->WriteHTML($html);
 
         //  Write to file
         fwrite($fileHandle, $pdf->output($filename, 'S'));

--- a/src/PhpWord/Writer/PDF/MPDF.php
+++ b/src/PhpWord/Writer/PDF/MPDF.php
@@ -104,7 +104,6 @@ class MPDF extends AbstractRenderer implements WriterInterface
             $pdf->WriteHTML(substr($html, 0, $bodyLocation));
             $html = substr($html, $bodyLocation);
         }
-        
         // Pass the full HTML string directly to WriteHTML
         $pdf->WriteHTML($html);
 

--- a/tests/PhpWordTests/Writer/PDF/MPDFTest.php
+++ b/tests/PhpWordTests/Writer/PDF/MPDFTest.php
@@ -125,7 +125,7 @@ class MPDFTest extends \PHPUnit\Framework\TestCase
         Settings::setPdfRendererName(Settings::PDF_RENDERER_MPDF);
         Settings::setPdfRendererPath('');
 
-        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $phpWord = new PhpWord();
         $section = $phpWord->addSection();
 
         // Generate a dummy PNG and embed it to simulate the issue

--- a/tests/PhpWordTests/Writer/PDF/MPDFTest.php
+++ b/tests/PhpWordTests/Writer/PDF/MPDFTest.php
@@ -11,9 +11,9 @@
  * file that was distributed with this source code. For the full list of
  * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
  *
- * @see         https://github.com/PHPOffice/PHPWord
+ * @see        https://github.com/PHPOffice/PHPWord
  *
- * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ * @license    http://www.gnu.org/licenses/lgpl.txt LGPL version 3
  */
 
 namespace PhpOffice\PhpWordTests\Writer\PDF;
@@ -112,5 +112,39 @@ class MPDFTest extends \PHPUnit\Framework\TestCase
         ]);
         $writer = new PDF(new PhpWord());
         self::assertEquals('Arial', $writer->getFont());
+    }
+
+    /**
+     * @covers \PhpOffice\PhpWord\Writer\PDF\MPDF
+     *
+     * Regression test for #2876: large inline Base64 images used to exhaust
+     * pcre.backtrack_limit when the Mpdf writer split the HTML line-by-line.
+     */
+    public function testWriteLargeEmbeddedImageDoesNotExhaustBacktrackLimit(): void
+    {
+        Settings::setPdfRendererName(Settings::PDF_RENDERER_MPDF);
+        Settings::setPdfRendererPath('');
+
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+
+        // Generate a dummy PNG and embed it to simulate the issue
+        $imagePath = tempnam(sys_get_temp_dir(), 'phpword_') . '.png';
+        $gd = imagecreatetruecolor(100, 100);
+        imagepng($gd, $imagePath);
+        imagedestroy($gd);
+
+        $section->addImage($imagePath);
+
+        $writer = \PhpOffice\PhpWord\IOFactory::createWriter($phpWord, 'PDF');
+        $outputPath = tempnam(sys_get_temp_dir(), 'phpword_') . '.pdf';
+
+        $writer->save($outputPath);
+
+        self::assertFileExists($outputPath);
+        self::assertGreaterThan(0, filesize($outputPath));
+
+        unlink($imagePath);
+        unlink($outputPath);
     }
 }


### PR DESCRIPTION
Fixes #2876.

As noted by @oleibman in #2876, PhpSpreadsheet gave up chunking to prevent pcre.backtrack_limit exhaustion when parsing large inline Base64 images.

This PR removes the line-by-line explode("\n", $html) loop in the Mpdf writer and passes the full $html string directly to $pdf->WriteHTML(). This aligns the behavior with PhpSpreadsheet and resolves the backtracking crash without forcing ini_set changes inside the library.

Changes
src/PhpWord/Writer/PDF/MPDF.php: replaced the foreach loop with a single $pdf->WriteHTML($html) call.

tests/PhpWordTests/Writer/PDF/MPDFTest.php: added a regression test to ensure large embedded images do not cause issues.

Why not ini_set?
Mutating global PHP runtime settings from inside a library produces hard-to-debug side effects for downstream consumers. The cleaner fix—and the one already adopted by PhpSpreadsheet—is to stop splitting the HTML in the first place, since the split provides no benefit when the offending content (e.g. a single long Base64 image string) contains no newlines anyway.