### PR TITLE
Fix #2882 Fixed errors from CS Fixer in CI

### DIFF
--- a/src/PhpWord/Element/Image.php
+++ b/src/PhpWord/Element/Image.php
@@ -208,18 +208,14 @@ class Image extends AbstractElement
 
     /**
      * Get image alt text.
-     *
-     * @return null|string
      */
-    public function getAltText(): ?string 
+    public function getAltText(): ?string
     {
         return $this->altText;
     }
 
     /**
      * Sets the image alt text.
-     *
-     * @param null|string $value
      */
     public function setAltText(?string $value): void
     {

--- a/tests/PhpWordTests/Element/ImageTest.php
+++ b/tests/PhpWordTests/Element/ImageTest.php
@@ -115,7 +115,8 @@ class ImageTest extends AbstractWebServerEmbedded
     /**
      * Get alt text.
      */
-    public function testAltText(): void {
+    public function testAltText(): void
+    {
         $source = __DIR__ . '/../_files/images/earth.jpg';
         $altText = 'Picture of the earth from space';
         $image = new Image($source, null, false, null, $altText);


### PR DESCRIPTION
### Description

On CI errors in CS Fixer

````
1) src/PhpWord/Element/Image.php
      ---------- begin diff ----------
--- /home/runner/work/PHPWord/PHPWord/src/PhpWord/Element/Image.php
+++ /home/runner/work/PHPWord/PHPWord/src/PhpWord/Element/Image.php
@@ -208,10 +208,8 @@
 
     /**
      * Get image alt text.
-     *
-     * @return null|string
      */
-    public function getAltText(): ?string 
+    public function getAltText(): ?string
     {
         return $this->altText;
     }
@@ -218,8 +216,6 @@
 
     /**
      * Sets the image alt text.
-     *
-     * @param null|string $value
      */
     public function setAltText(?string $value): void
     {

      ----------- end diff -----------

   2) tests/PhpWordTests/Element/ImageTest.php
      ---------- begin diff ----------
--- /home/runner/work/PHPWord/PHPWord/tests/PhpWordTests/Element/ImageTest.php
+++ /home/runner/work/PHPWord/PHPWord/tests/PhpWordTests/Element/ImageTest.php
@@ -115,7 +115,8 @@
     /**
      * Get alt text.
      */
-    public function testAltText(): void {
+    public function testAltText(): void
+    {
         $source = __DIR__ . '/../_files/images/earth.jpg';
         $altText = 'Picture of the earth from space';
         $image = new Image($source, null, false, null, $altText);

      ----------- end diff -----------


Found 2 of 552 files that can be fixed in 9.6[38](https://github.com/PHPOffice/PHPWord/actions/runs/27883107154/job/82513926848?pr=2881#step:7:39) seconds, 80.00 MB memory used

````

Fixes #2882  

### Checklist:

- [ ] My CI is :green_circle: