### PR TITLE
Fix #2886: Reset Settings values to default for PDF tests

### DIFF
--- a/tests/PhpWordTests/Writer/PDF/TCPDFTest.php
+++ b/tests/PhpWordTests/Writer/PDF/TCPDFTest.php
@@ -29,6 +29,14 @@ use PhpOffice\PhpWord\Writer\PDF;
  */
 class TCPDFTest extends \PHPUnit\Framework\TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        //Reset setting for default
+        Settings::setPdfRenderer(null, null);
+        Settings::setPdfRendererOptions([]);
+    }
+
     /**
      * Test construct.
      */

--- a/tests/PhpWordTests/Writer/PDF/TCPDFTest.php
+++ b/tests/PhpWordTests/Writer/PDF/TCPDFTest.php
@@ -33,7 +33,7 @@ class TCPDFTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
         //Reset setting for default
-        Settings::setPdfRenderer(null, null);
+        Settings::setPdfRenderer('', '');
         Settings::setPdfRendererOptions([]);
     }
 

--- a/tests/PhpWordTests/Writer/PDFTest.php
+++ b/tests/PhpWordTests/Writer/PDFTest.php
@@ -33,7 +33,7 @@ class PDFTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
         //Reset setting for default
-        Settings::setPdfRenderer(null, null);
+        Settings::setPdfRenderer('', '');
         Settings::setPdfRendererOptions([]);
     }
 

--- a/tests/PhpWordTests/Writer/PDFTest.php
+++ b/tests/PhpWordTests/Writer/PDFTest.php
@@ -29,6 +29,14 @@ use PhpOffice\PhpWord\Writer\PDF;
  */
 class PDFTest extends \PHPUnit\Framework\TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        //Reset setting for default
+        Settings::setPdfRenderer(null, null);
+        Settings::setPdfRendererOptions([]);
+    }
+
     /**
      * Test normal construct.
      */


### PR DESCRIPTION
### Description

Static variables in Settings class storing data from previous test. So it are way  fatal error in test. 

I added ``::setUp`` method for two test class where resets variables to default values.

Fixes #2886 

### Checklist:

- [ ] My CI is :green_circle:

