### PR TITLE
Use one directory as temp folder for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ phpword.ini
 /.php_cs.cache
 /.phpunit.result.cache
 /public
+tests/PhpWordTests/_files/tmp

--- a/tests/PhpWordTests/AbstractTestReader.php
+++ b/tests/PhpWordTests/AbstractTestReader.php
@@ -41,7 +41,7 @@ abstract class AbstractTestReader extends \PHPUnit\Framework\TestCase
      */
     protected function getDocumentFromString(array $partXmls = [])
     {
-        $file = __DIR__ . '/_files/temp.docx';
+        $file = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'temp.docx';
         $zip = new ZipArchive();
         $zip->open($file, ZipArchive::CREATE | ZipArchive::OVERWRITE);
         foreach ($this->parts as $partName => $part) {

--- a/tests/PhpWordTests/TemplateProcessorTest.php
+++ b/tests/PhpWordTests/TemplateProcessorTest.php
@@ -228,7 +228,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
             $templateProcessor->getVariables()
         );
 
-        $docName = 'delete-row-test-result.docx';
+        $docName = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'delete-row-test-result.docx';
         $templateProcessor->deleteRow('deleteMe');
         self::assertEquals(
             [],
@@ -254,7 +254,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
             $templateProcessor->getVariables()
         );
 
-        $docName = 'clone-test-result.docx';
+        $docName = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'clone-test-result.docx';
         $templateProcessor->setValue('tableHeader', 'ééé');
         $templateProcessor->cloneRow('userId', 1);
         $templateProcessor->setValue('userId#1', 'Test');
@@ -281,7 +281,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
             $templateProcessor->getVariables()
         );
 
-        $docName = 'clone-test-result.docx';
+        $docName = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'clone-test-result.docx';
         $templateProcessor->setValue('tableHeader', 'ééé');
         $templateProcessor->cloneRow('userId', 1);
         $templateProcessor->setValue('userId#1', 'Test');
@@ -436,7 +436,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
         $macroValues = ['Header Value', 'Document text.', 'Footer Value'];
         $templateProcessor->setValue($macroNames, $macroValues);
 
-        $docName = 'header-footer-test-result.docx';
+        $docName = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'header-footer-test-result.docx';
         $templateProcessor->saveAs($docName);
         $docFound = file_exists($docName);
         unlink($docName);
@@ -459,7 +459,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
         $macroValues = ['Header Value', 'Document text.', 'Footer Value'];
         $templateProcessor->setValue($macroNames, $macroValues);
 
-        $docName = 'header-footer-test-result.docx';
+        $docName = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'header-footer-test-result.docx';
         $templateProcessor->saveAs($docName);
         $docFound = file_exists($docName);
         unlink($docName);
@@ -870,7 +870,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
         ];
         $templateProcessor->setImageValue(array_keys($variablesReplace), $variablesReplace);
 
-        $docName = 'header-footer-images-test-result.docx';
+        $docName = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'header-footer-images-test-result.docx';
         $templateProcessor->saveAs($docName);
 
         self::assertFileExists($docName, "Generated file '{$docName}' not found!");
@@ -903,7 +903,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
         unlink($docName);
 
         // dynamic generated doc
-        $testFileName = 'images-test-sample.docx';
+        $testFileName = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'images-test-sample.docx';
         $phpWord = new PhpWord();
         $section = $phpWord->addSection();
         $section->addText('${Test:width=100:ratio=true}');
@@ -911,7 +911,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
         $objWriter->save($testFileName);
         self::assertFileExists($testFileName, "Generated file '{$testFileName}' not found!");
 
-        $resultFileName = 'images-test-result.docx';
+        $resultFileName = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'images-test-result.docx';
         $templateProcessor = new TemplateProcessor($testFileName);
         unlink($testFileName);
         $templateProcessor->setImageValue('Test', $imagePath);
@@ -945,7 +945,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
             $templateProcessor->getVariables()
         );
 
-        $docName = 'clone-delete-block-result.docx';
+        $docName = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'clone-delete-block-result.docx';
         $templateProcessor->cloneBlock('CLONEME', 3);
         $templateProcessor->deleteBlock('DELETEME');
         $templateProcessor->setValue('blockVariable#3', 'Test');
@@ -975,7 +975,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
                    ${a_field_that_is_present_three_times}
         ');
         $objWriter = IOFactory::createWriter($phpWord);
-        $templatePath = 'test.docx';
+        $templatePath = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'test.docx';
         $objWriter->save($templatePath);
 
         $templateProcessor = $this->getTemplateProcessor($templatePath);
@@ -1012,7 +1012,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
                    {{a_field_that_is_present_three_times}}
         ');
         $objWriter = IOFactory::createWriter($phpWord);
-        $templatePath = 'test.docx';
+        $templatePath = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'test.docx';
         $objWriter->save($templatePath);
 
         $templateProcessor = $this->getTemplateProcessor($templatePath);
@@ -1049,7 +1049,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
         }
 
         $objWriter = IOFactory::createWriter($phpWord);
-        $templatePath = 'test.docx';
+        $templatePath = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'test.docx';
         $objWriter->save($templatePath);
 
         // replace placeholders and save the file
@@ -1102,7 +1102,7 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
         }
 
         $objWriter = IOFactory::createWriter($phpWord);
-        $templatePath = 'test.docx';
+        $templatePath = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'test.docx';
         $objWriter->save($templatePath);
 
         // replace placeholders and save the file

--- a/tests/PhpWordTests/WriteReadback/Word2007Test.php
+++ b/tests/PhpWordTests/WriteReadback/Word2007Test.php
@@ -43,7 +43,7 @@ class Word2007Test extends \PHPUnit\Framework\TestCase
         $phpWordWriter->setDefaultFontName($testDefaultFontName);
 
         $writer = new Word2007($phpWordWriter);
-        $file = __DIR__ . '/../_files/temp.docx';
+        $file = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'temp.docx';
         $writer->save($file);
 
         self::assertFileExists($file);
@@ -65,7 +65,7 @@ class Word2007Test extends \PHPUnit\Framework\TestCase
         $phpWordWriter->setDefaultAsianFontName($testDefaultFontName);
 
         $writer = new Word2007($phpWordWriter);
-        $file = __DIR__ . '/../_files/temp.docx';
+        $file = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'temp.docx';
         $writer->save($file);
 
         self::assertFileExists($file);
@@ -87,7 +87,7 @@ class Word2007Test extends \PHPUnit\Framework\TestCase
         $phpWordWriter->setDefaultFontSize($testDefaultFontSize);
 
         $writer = new Word2007($phpWordWriter);
-        $file = __DIR__ . '/../_files/temp.docx';
+        $file = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'temp.docx';
         $writer->save($file);
 
         self::assertFileExists($file);
@@ -109,7 +109,7 @@ class Word2007Test extends \PHPUnit\Framework\TestCase
         $phpWordWriter->setDefaultFontColor($testDefaultFontColor);
 
         $writer = new Word2007($phpWordWriter);
-        $file = __DIR__ . '/../_files/temp.docx';
+        $file = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'temp.docx';
         $writer->save($file);
 
         self::assertFileExists($file);
@@ -131,7 +131,7 @@ class Word2007Test extends \PHPUnit\Framework\TestCase
         $phpWordWriter->getSettings()->setZoom($zoomLevel);
 
         $writer = new Word2007($phpWordWriter);
-        $file = __DIR__ . '/../_files/temp.docx';
+        $file = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'temp.docx';
         $writer->save($file);
 
         self::assertFileExists($file);
@@ -154,7 +154,7 @@ class Word2007Test extends \PHPUnit\Framework\TestCase
         $sectionWriter->addText($testText);
 
         $writer = new Word2007($phpWordWriter);
-        $file = __DIR__ . '/../_files/temp.docx';
+        $file = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'temp.docx';
         $writer->save($file);
 
         self::assertFileExists($file);

--- a/tests/PhpWordTests/Writer/EPub3Test.php
+++ b/tests/PhpWordTests/Writer/EPub3Test.php
@@ -68,7 +68,7 @@ class EPub3Test extends \PHPUnit\Framework\TestCase
     public function testSave(): void
     {
         $imageSrc = __DIR__ . '/../_files/images/PhpWord.png';
-        $file = __DIR__ . '/../_files/temp.epub';
+        $file = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'temp.epub';
 
         $phpWord = new PhpWord();
         $section = $phpWord->addSection();

--- a/tests/PhpWordTests/Writer/PDF/TCPDFTest.php
+++ b/tests/PhpWordTests/Writer/PDF/TCPDFTest.php
@@ -42,7 +42,7 @@ class TCPDFTest extends \PHPUnit\Framework\TestCase
      */
     public function testConstruct(): void
     {
-        $file = __DIR__ . '/../../_files/tcpdf.pdf';
+        $file = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'tcpdf.pdf';
 
         $phpWord = new PhpWord();
         $phpWord->setDefaultParagraphStyle(['spaceBefore' => 0, 'spaceAfter' => 0]);

--- a/tests/PhpWordTests/Writer/PDFTest.php
+++ b/tests/PhpWordTests/Writer/PDFTest.php
@@ -43,7 +43,7 @@ class PDFTest extends \PHPUnit\Framework\TestCase
     public function testConstruct(): void
     {
         define('DOMPDF_ENABLE_AUTOLOAD', false);
-        $file = __DIR__ . '/../_files/temp.pdf';
+        $file = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'temp.pdf';
 
         $rendererName = Settings::PDF_RENDERER_DOMPDF;
         $rendererLibraryPath = realpath(PHPWORD_TESTS_BASE_DIR . '/../vendor/dompdf/dompdf');
@@ -61,9 +61,16 @@ class PDFTest extends \PHPUnit\Framework\TestCase
      */
     public function testConstructException(): void
     {
+        $file = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'unknown.file';
+
         $this->expectException(\PhpOffice\PhpWord\Exception\Exception::class);
         $this->expectExceptionMessage('PDF rendering library or library path has not been defined.');
         $writer = new PDF(new PhpWord());
-        $writer->save('unknown.file');
+        $writer->save($file);
+
+        //If no exception and file created
+        if (file_exists($file)) {
+            unlink($file);
+        }
     }
 }

--- a/tests/PhpWordTests/Writer/Word2007Test.php
+++ b/tests/PhpWordTests/Writer/Word2007Test.php
@@ -99,7 +99,7 @@ class Word2007Test extends AbstractWebServerEmbedded
         $footer->addImage($remoteImage);
 
         $writer = new Word2007($phpWord);
-        $file = __DIR__ . '/../_files/temp.docx';
+        $file = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'temp.docx';
         $writer->save($file);
 
         self::assertFileExists($file);
@@ -124,7 +124,7 @@ class Word2007Test extends AbstractWebServerEmbedded
             self::fail('Unable to create temp directory');
         }
         $writer->setUseDiskCaching(true, $dir);
-        $file = __DIR__ . '/../_files/temp.docx';
+        $file = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'temp.docx';
         $writer->save($file);
 
         self::assertFileExists($file);
@@ -212,7 +212,7 @@ class Word2007Test extends AbstractWebServerEmbedded
         $section->addText('Test 1');
 
         $writer = new Word2007($phpWord);
-        $file = __DIR__ . '/../_files/temp.docx';
+        $file = PHPWORD_TEST_TEMP_DIR . DIRECTORY_SEPARATOR . 'temp.docx';
         $writer->save($file);
 
         $finfo = new finfo(FILEINFO_MIME_TYPE);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,7 +28,7 @@ if (!defined('PHPWORD_TESTS_BASE_DIR')) {
 if (!defined('PHPWORD_TESTS_TEMP_DIR')) {
     define('PHPWORD_TEST_TEMP_DIR', PHPWORD_TESTS_BASE_DIR . DIRECTORY_SEPARATOR . 'PhpWordTests' . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'tmp');
 }
-if (!mkdir(PHPWORD_TEST_TEMP_DIR) && !is_dir(PHPWORD_TEST_TEMP_DIR)) {
+if (!is_dir(PHPWORD_TEST_TEMP_DIR) && !mkdir(PHPWORD_TEST_TEMP_DIR)) {
     printf("Error: Not exists temp directory: %s\n", PHPWORD_TEST_TEMP_DIR);
     exit(1);
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,6 +25,14 @@ if (!defined('PHPWORD_TESTS_BASE_DIR')) {
     define('PHPWORD_TESTS_BASE_DIR', realpath(__DIR__));
 }
 
+if (!defined('PHPWORD_TESTS_TEMP_DIR')) {
+    define('PHPWORD_TEST_TEMP_DIR', PHPWORD_TESTS_BASE_DIR . DIRECTORY_SEPARATOR . 'PhpWordTests' . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'tmp');
+}
+if (!mkdir(PHPWORD_TEST_TEMP_DIR) && !is_dir(PHPWORD_TEST_TEMP_DIR)) {
+    printf("Error: Not exists temp directory: %s\n", PHPWORD_TEST_TEMP_DIR);
+    exit(1);
+}
+
 function phpunit10ErrorHandler(int $errno, string $errstr, string $filename, int $lineno): bool
 {
     $x = error_reporting() & $errno;


### PR DESCRIPTION
### Description

Defined constant for temp folder path. If directory not exists then create it.  
Added this directory to .gitignore.
Changed some tests method for use this constant when define path to temp file.

In result after test not leaved untracked files.


Fixes #2885 

### Checklist:

- [ ] My CI is :green_circle:
