### PR TITLE
Restrict phpunit/phpunit to < 12 to fix unit tests on PHP 8.3/8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -122,7 +122,7 @@
         "phpmd/phpmd": "^2.13",
         "phpstan/phpstan": "^0.12.88 || ^1.0.0 || ^2.0.0",
         "phpstan/phpstan-phpunit": "^1.0 || ^2.0",
-        "phpunit/phpunit": ">=7.0",
+        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
         "symfony/process": "^4.4 || ^5.0",
         "tecnickcom/tcpdf": "^6.5"
     },

--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -12,6 +12,7 @@
 ### Miscellaneous
 
 - Update phpstan/phpstan requirement from ^0.12.88 || ^1.0.0 to ^0.12.88 || ^1.0.0 || ^2.0.0 by [@dependabot](https://github.com/dependabot) & [@Progi1984](https://github.com/Progi1984) in [#2736](https://github.com/PHPOffice/PHPWord/pull/2736)
+- Restrict phpunit/phpunit to `< 12` to fix unit tests on PHP 8.3/8.4 by [@slayerfx](https://github.com/slayerfx) fixing [#2842](https://github.com/PHPOffice/PHPWord/issues/2842) in [#2889](https://github.com/PHPOffice/PHPWord/pull/2889)
 
 ### Deprecations
 


### PR DESCRIPTION
### Description

The `phpunit/phpunit` constraint was unbounded (`>=7.0`), so PHP 8.3/8.4 installed
PHPUnit 12 which the test suite doesn't support yet. This caps it to `< 12`.

Fixes #2842
