### PR TITLE
Fixed errors by phpstan

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -24,8 +24,6 @@ parameters:
         ## <=PHP7.3
         -
             identifier: nullCoalesce.offset
-        -
-            identifier: assignOp.invalid
 
         ## <=PHP7.4
         -

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,6 +21,12 @@ parameters:
         -
             identifier: missingType.iterableValue
         
+        ## <=PHP7.3
+        -
+            identifier: nullCoalesce.offset
+        -
+            identifier: assignOp.invalid
+
         ## <=PHP7.4
         -
             message: '#Parameter \#1 \$argument of class ReflectionClass constructor expects class-string<T of object>\|T of object, string given.#'

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -369,6 +369,7 @@ abstract class AbstractPart
                     }
                     $formField->setEntries($listEntries);
                     if (null !== $formField->getValue()) {
+                        /** @phpstan-ignore offsetAccess.notFound */
                         $formField->setText($listEntries[$formField->getValue()]);
                     }
 

--- a/src/PhpWord/Shared/Text.php
+++ b/src/PhpWord/Shared/Text.php
@@ -94,6 +94,9 @@ class Text
      */
     public static function chr($dec)
     {
+        if ($dec < 0) {
+            return '';
+        }
         if ($dec <= 0x7F) {
             return chr($dec);
         }

--- a/tests/PhpWordTests/Style/FontTest.php
+++ b/tests/PhpWordTests/Style/FontTest.php
@@ -52,87 +52,97 @@ class FontTest extends \PHPUnit\Framework\TestCase
         self::assertIsArray($object->getStyleValues());
     }
 
+    public static function providerStyleValueEmpty(): array
+    {
+        return [
+            ['name', null],
+            ['size', null],
+            ['hint', null],
+            ['color', null],
+            ['bold', false],
+            ['italic', false],
+            ['underline', Font::UNDERLINE_NONE],
+            ['superScript', false],
+            ['subScript', false],
+            ['strikethrough', false],
+            ['doubleStrikethrough', false],
+            ['smallCaps', false],
+            ['allCaps', false],
+            ['rtl', false],
+            ['fgColor', null],
+            ['bgColor', null],
+            ['scale', null],
+            ['spacing', null],
+            ['kerning', null],
+            ['lang', null],
+            ['hidden', false],
+            ['whiteSpace', ''],
+            ['fallbackFont', ''],
+        ];
+    }
+
     /**
      * Test setting style values with null or empty value.
+     *
+     * @dataProvider providerStyleValueEmpty
+     *
+     * @phpstan-ignore missingType.parameter
      */
-    public function testSetStyleValueWithNullOrEmpty(): void
+    public function testSetStyleValueWithNullOrEmpty(string $key, $default): void
     {
         $object = new Font();
+        $get = is_bool($default) ? "is{$key}" : "get{$key}";
+        self::assertEquals($default, $object->$get());
+        $object->setStyleValue($key, null);
+        self::assertEquals($default, $object->$get());
+        $object->setStyleValue($key, '');
+        self::assertEquals($default, $object->$get());
+    }
 
-        $attributes = [
-            'name' => null,
-            'size' => null,
-            'hint' => null,
-            'color' => null,
-            'bold' => false,
-            'italic' => false,
-            'underline' => Font::UNDERLINE_NONE,
-            'superScript' => false,
-            'subScript' => false,
-            'strikethrough' => false,
-            'doubleStrikethrough' => false,
-            'smallCaps' => false,
-            'allCaps' => false,
-            'rtl' => false,
-            'fgColor' => null,
-            'bgColor' => null,
-            'scale' => null,
-            'spacing' => null,
-            'kerning' => null,
-            'lang' => null,
-            'hidden' => false,
-            'whiteSpace' => '',
-            'fallbackFont' => '',
+    public static function providerStyleValueNormal(): array
+    {
+        return [
+            ['name', 'Times New Roman'],
+            ['size', 9],
+            ['color', '999999'],
+            ['hint', 'eastAsia'],
+            ['bold', true],
+            ['italic', true],
+            ['underline', Font::UNDERLINE_HEAVY],
+            ['superScript', true],
+            ['subScript', false],
+            ['strikethrough', true],
+            ['doubleStrikethrough', false],
+            ['smallCaps', true],
+            ['allCaps', false],
+            ['fgColor', Font::FGCOLOR_YELLOW],
+            ['bgColor', 'FFFF00'],
+            ['lineHeight', 2],
+            ['scale', 150],
+            ['spacing', 240],
+            ['kerning', 10],
+            ['rtl', true],
+            ['noProof', true],
+            ['lang', new Language(Language::EN_US)],
+            ['hidden', true],
+            ['whiteSpace', 'pre-wrap'],
+            ['fallbackFont', 'serif'],
         ];
-        foreach ($attributes as $key => $default) {
-            $get = is_bool($default) ? "is{$key}" : "get{$key}";
-            self::assertEquals($default, $object->$get());
-            $object->setStyleValue($key, null);
-            self::assertEquals($default, $object->$get());
-            $object->setStyleValue($key, '');
-            self::assertEquals($default, $object->$get());
-        }
     }
 
     /**
      * Test setting style values with normal value.
+     *
+     * @dataProvider providerStyleValueNormal
+     *
+     * @phpstan-ignore missingType.parameter
      */
-    public function testSetStyleValueNormal(): void
+    public function testSetStyleValueNormal(string $key, $value): void
     {
         $object = new Font();
-
-        $attributes = [
-            'name' => 'Times New Roman',
-            'size' => 9,
-            'color' => '999999',
-            'hint' => 'eastAsia',
-            'bold' => true,
-            'italic' => true,
-            'underline' => Font::UNDERLINE_HEAVY,
-            'superScript' => true,
-            'subScript' => false,
-            'strikethrough' => true,
-            'doubleStrikethrough' => false,
-            'smallCaps' => true,
-            'allCaps' => false,
-            'fgColor' => Font::FGCOLOR_YELLOW,
-            'bgColor' => 'FFFF00',
-            'lineHeight' => 2,
-            'scale' => 150,
-            'spacing' => 240,
-            'kerning' => 10,
-            'rtl' => true,
-            'noProof' => true,
-            'lang' => new Language(Language::EN_US),
-            'hidden' => true,
-            'whiteSpace' => 'pre-wrap',
-            'fallbackFont' => 'serif',
-        ];
-        $object->setStyleByArray($attributes);
-        foreach ($attributes as $key => $value) {
-            $get = is_bool($value) ? "is{$key}" : "get{$key}";
-            self::assertEquals($value, $object->$get());
-        }
+        $object->setStyleValue($key, $value);
+        $get = is_bool($value) ? "is{$key}" : "get{$key}";
+        self::assertEquals($value, $object->$get());
     }
 
     /**

--- a/tests/PhpWordTests/Style/ParagraphTest.php
+++ b/tests/PhpWordTests/Style/ParagraphTest.php
@@ -94,7 +94,7 @@ class ParagraphTest extends \PHPUnit\Framework\TestCase
             $get = $this->findGetter($key, $value, $object);
             $object->setStyleValue("$key", $value);
             if (('indent' == $key || 'hanging' == $key)) {
-                $value = $value * 720;
+                $value = (int)$value * 720;
             }
             self::assertEquals($value, $object->$get());
         }

--- a/tests/PhpWordTests/Style/ParagraphTest.php
+++ b/tests/PhpWordTests/Style/ParagraphTest.php
@@ -93,7 +93,7 @@ class ParagraphTest extends \PHPUnit\Framework\TestCase
         foreach ($attributes as $key => $value) {
             $get = $this->findGetter($key, $value, $object);
             $object->setStyleValue("$key", $value);
-            if (('indent' == $key || 'hanging' == $key) && is_numeric($value)) {
+            if (('indent' == $key || 'hanging' == $key)) {
                 $value = $value * 720;
             }
             self::assertEquals($value, $object->$get());

--- a/tests/PhpWordTests/Style/ParagraphTest.php
+++ b/tests/PhpWordTests/Style/ParagraphTest.php
@@ -94,7 +94,7 @@ class ParagraphTest extends \PHPUnit\Framework\TestCase
             $get = $this->findGetter($key, $value, $object);
             $object->setStyleValue("$key", $value);
             if (('indent' == $key || 'hanging' == $key)) {
-                $value = (int)$value * 720;
+                $value = 720 * (int) $value;
             }
             self::assertEquals($value, $object->$get());
         }

--- a/tests/PhpWordTests/Style/TableTest.php
+++ b/tests/PhpWordTests/Style/TableTest.php
@@ -65,42 +65,48 @@ class TableTest extends \PHPUnit\Framework\TestCase
         self::assertNull($object->getIndent());
     }
 
+    public static function providerSetGetNormal(): array
+    {
+        return [
+            ['bgColor', 'FF0000'],
+            ['borderTopSize', 4],
+            ['borderTopColor', 'FF0000'],
+            ['borderLeftSize', 4],
+            ['borderLeftColor', 'FF0000'],
+            ['borderRightSize', 4],
+            ['borderRightColor', 'FF0000'],
+            ['borderBottomSize', 4],
+            ['borderBottomColor', 'FF0000'],
+            ['borderInsideHSize', 4],
+            ['borderInsideHColor', 'FF0000'],
+            ['borderInsideVSize', 4],
+            ['borderInsideVColor', 'FF0000'],
+            ['cellMarginTop', 240],
+            ['cellMarginLeft', 240],
+            ['cellMarginRight', 240],
+            ['cellMarginBottom', 240],
+            ['alignment', JcTable::CENTER],
+            ['width', 100],
+            ['unit', 'pct'],
+            ['layout', Table::LAYOUT_FIXED],
+        ];
+    }
+
     /**
      * Test setting style with normal value.
+     *
+     * @dataProvider providerSetGetNormal
+     *
+     * @phpstan-ignore missingType.parameter
      */
-    public function testSetGetNormal(): void
+    public function testSetGetNormal(string $key, $value): void
     {
         $object = new Table();
 
-        $attributes = [
-            'bgColor' => 'FF0000',
-            'borderTopSize' => 4,
-            'borderTopColor' => 'FF0000',
-            'borderLeftSize' => 4,
-            'borderLeftColor' => 'FF0000',
-            'borderRightSize' => 4,
-            'borderRightColor' => 'FF0000',
-            'borderBottomSize' => 4,
-            'borderBottomColor' => 'FF0000',
-            'borderInsideHSize' => 4,
-            'borderInsideHColor' => 'FF0000',
-            'borderInsideVSize' => 4,
-            'borderInsideVColor' => 'FF0000',
-            'cellMarginTop' => 240,
-            'cellMarginLeft' => 240,
-            'cellMarginRight' => 240,
-            'cellMarginBottom' => 240,
-            'alignment' => JcTable::CENTER,
-            'width' => 100,
-            'unit' => 'pct',
-            'layout' => Table::LAYOUT_FIXED,
-        ];
-        foreach ($attributes as $key => $value) {
-            $set = "set{$key}";
-            $get = "get{$key}";
-            $object->$set($value);
-            self::assertEquals($value, $object->$get());
-        }
+        $set = "set{$key}";
+        $get = "get{$key}";
+        $object->$set($value);
+        self::assertEquals($value, $object->$get());
     }
 
     public function testBidiVisual(): void

--- a/tests/PhpWordTests/Style/TextBoxTest.php
+++ b/tests/PhpWordTests/Style/TextBoxTest.php
@@ -30,39 +30,44 @@ use PHPUnit\Framework\TestCase;
  */
 class TextBoxTest extends TestCase
 {
+    public static function providerSetGetNormal(): array
+    {
+        return [
+            ['width', 200],
+            ['height', 200],
+            ['alignment', Jc::START],
+            ['marginTop', 240],
+            ['marginLeft', 240],
+            ['wrappingStyle', 'inline'],
+            ['positioning', 'absolute'],
+            ['posHorizontal', 'center'],
+            ['posVertical', 'top'],
+            ['posHorizontalRel', 'margin'],
+            ['posVerticalRel', 'page'],
+            ['innerMarginTop', '5'],
+            ['innerMarginRight', '5'],
+            ['innerMarginBottom', '5'],
+            ['innerMarginLeft', '5'],
+            ['borderSize', '2'],
+            ['borderColor', 'red'],
+            ['bgColor', 'blue'],
+        ];
+    }
+
     /**
      * Test setting style with normal value.
+     *
+     * @dataProvider providerSetGetNormal
+     *
+     * @phpstan-ignore missingType.parameter
      */
-    public function testSetGetNormal(): void
+    public function testSetGetNormal(string $key, $value): void
     {
         $object = new TextBox();
-
-        $properties = [
-            'width' => 200,
-            'height' => 200,
-            'alignment' => Jc::START,
-            'marginTop' => 240,
-            'marginLeft' => 240,
-            'wrappingStyle' => 'inline',
-            'positioning' => 'absolute',
-            'posHorizontal' => 'center',
-            'posVertical' => 'top',
-            'posHorizontalRel' => 'margin',
-            'posVerticalRel' => 'page',
-            'innerMarginTop' => '5',
-            'innerMarginRight' => '5',
-            'innerMarginBottom' => '5',
-            'innerMarginLeft' => '5',
-            'borderSize' => '2',
-            'borderColor' => 'red',
-            'bgColor' => 'blue',
-        ];
-        foreach ($properties as $key => $value) {
-            $set = "set{$key}";
-            $get = "get{$key}";
-            $object->$set($value);
-            self::assertEquals($value, $object->$get());
-        }
+        $set = "set{$key}";
+        $get = "get{$key}";
+        $object->$set($value);
+        self::assertEquals($value, $object->$get());
     }
 
     /**

--- a/tests/PhpWordTests/Writer/HTML/Element/RubyTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/RubyTest.php
@@ -49,7 +49,8 @@ class RubyTest extends TestCase
 
         $dom = Helper::getAsHTML($phpWord, '', '', ['ruby', 'rt', 'rp']);
         $xpath = new DOMXPath($dom);
-        self::assertEquals(1, $xpath->query('/html/body/div/ruby')->length);
+        $element = $xpath->query('/html/body/div/ruby');
+        self::assertEquals(1, $element === false ? 0 : $element->length);
         // ensure text is right
         $rubyElement = $dom->getElementsByTagName('ruby')->item(0);
         $rtElement = $dom->getElementsByTagName('rt')->item(0);
@@ -84,7 +85,8 @@ class RubyTest extends TestCase
 
         $dom = Helper::getAsHTML($phpWord, '', '', ['ruby', 'rt', 'rp']);
         $xpath = new DOMXPath($dom);
-        self::assertEquals(1, $xpath->query('/html/body/div/ruby')->length);
+        $element = $xpath->query('/html/body/div/ruby');
+        self::assertEquals(1, $element === false ? 0 : $element->length);
         // ensure text is right
         $rubyElement = $dom->getElementsByTagName('ruby')->item(0);
         $rtElement = $dom->getElementsByTagName('rt')->item(0);

--- a/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
+++ b/tests/PhpWordTests/Writer/HTML/Element/TableTest.php
@@ -162,7 +162,7 @@ class TableTest extends TestCase
         self::assertEquals('tstyle', Helper::getTextContent($xpath, '/html/body/div/table[6]', 'class'));
         $style = Helper::getTextContent($xpath, '/html/head/style');
         self::assertNotFalse(preg_match('/^[.]tstyle[^\\r\\n]*/m', $style, $matches));
-        self::assertEquals(".tstyle {table-layout: auto; $cssnone}", $matches[0]);
+        self::assertEquals(".tstyle {table-layout: auto; $cssnone}", $matches[0] ?? '');
     }
 
     public function testWriteTableCellVAlign(): void
@@ -198,6 +198,7 @@ class TableTest extends TestCase
         self::assertNotFalse($cell3Query);
         self::assertCount(1, $cell3Query);
 
+        /** @phpstan-ignore property.notFound */
         $cell3Style = $cell3Query->item(0)->attributes->getNamedItem('style');
         self::assertNull($cell3Style);
     }
@@ -230,6 +231,7 @@ class TableTest extends TestCase
         $cell3Query = $xpath->query('//table/tr[3]/td[1]');
         self::assertNotFalse($cell3Query);
         self::assertCount(1, $cell3Query);
+        /** @phpstan-ignore property.notFound */
         self::assertNull($cell3Query->item(0)->attributes->getNamedItem('rowspan'));
     }
 }

--- a/tests/PhpWordTests/Writer/HTML/ElementTest.php
+++ b/tests/PhpWordTests/Writer/HTML/ElementTest.php
@@ -77,8 +77,10 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $dom = Helper::getAsHTML($phpWord);
         $xpath = new DOMXPath($dom);
 
-        self::assertEquals(1, $xpath->query('/html/body/div/p[1]/ins')->length);
-        self::assertEquals(1, $xpath->query('/html/body/div/p[2]/del')->length);
+        $element1 = $xpath->query('/html/body/div/p[1]/ins');
+        $element2 = $xpath->query('/html/body/div/p[2]/del');
+        self::assertEquals(1, is_object($element1) ? $element1->length : 0);
+        self::assertEquals(1, is_object($element2) ? $element2->length : 0);
     }
 
     /**

--- a/tests/PhpWordTests/Writer/HTML/ElementTest.php
+++ b/tests/PhpWordTests/Writer/HTML/ElementTest.php
@@ -103,13 +103,24 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $dom = Helper::getAsHTML($phpWord);
         $xpath = new DOMXPath($dom);
 
-        self::assertEquals(1, $xpath->query('/html/body/div/table/tr[1]/td')->length);
+        $element1 = $xpath->query('/html/body/div/table/tr[1]/td');
+        self::assertEquals(1, is_object($element1) ? $element1->length : 0);
+        /** @phpstan-ignore-next-line  */
         self::assertEquals('2', $xpath->query('/html/body/div/table/tr/td[1]')->item(0)->attributes->getNamedItem('colspan')->textContent);
-        self::assertEquals(2, $xpath->query('/html/body/div/table/tr[2]/td')->length);
 
+        $element2 = $xpath->query('/html/body/div/table/tr[2]/td');
+        self::assertEquals(2, is_object($element2) ? $element2->length : 0);
+
+        /** @phpstan-ignore-next-line  */
         self::assertEquals('#6086B8', $xpath->query('/html/body/div/table/tr[1]/td')->item(0)->attributes->getNamedItem('bgcolor')->textContent);
+
+        /** @phpstan-ignore-next-line  */
         self::assertEquals('#ffffff', $xpath->query('/html/body/div/table/tr[1]/td')->item(0)->attributes->getNamedItem('color')->textContent);
+
+        /** @phpstan-ignore-next-line  */
         self::assertEquals('#ffffff', $xpath->query('/html/body/div/table/tr[2]/td')->item(0)->attributes->getNamedItem('bgcolor')->textContent);
+
+        /** @phpstan-ignore-next-line  */
         self::assertNull($xpath->query('/html/body/div/table/tr[2]/td')->item(0)->attributes->getNamedItem('color'));
     }
 
@@ -137,9 +148,14 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $dom = Helper::getAsHTML($phpWord);
         $xpath = new DOMXPath($dom);
 
-        self::assertEquals(2, $xpath->query('/html/body/div/table/tr[1]/td')->length);
+        $element1 = $xpath->query('/html/body/div/table/tr[1]/td');
+        self::assertEquals(2, is_object($element1) ? $element1->length : 0);
+
+        /** @phpstan-ignore-next-line  */
         self::assertEquals('3', $xpath->query('/html/body/div/table/tr[1]/td[1]')->item(0)->attributes->getNamedItem('rowspan')->textContent);
-        self::assertEquals(1, $xpath->query('/html/body/div/table/tr[2]/td')->length);
+
+        $element2 = $xpath->query('/html/body/div/table/tr[2]/td');
+        self::assertEquals(1, is_object($element2) ? $element2->length : 0);
     }
 
     /**
@@ -169,14 +185,23 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $dom = Helper::getAsHTML($phpWord);
         $xpath = new DOMXPath($dom);
 
-        self::assertEquals(3, $xpath->query('/html/body/div/table/tr[1]/td')->length);
+        $element1 = $xpath->query('/html/body/div/table/tr[1]/td');
+        self::assertEquals(3, is_object($element1) ? $element1->length : 0);
+
+        /** @phpstan-ignore-next-line  */
         self::assertEquals('2', $xpath->query('/html/body/div/table/tr[1]/td[2]')->item(0)->attributes->getNamedItem('colspan')->textContent);
+
+        /** @phpstan-ignore-next-line  */
         self::assertEquals('3', $xpath->query('/html/body/div/table/tr[1]/td[3]')->item(0)->attributes->getNamedItem('rowspan')->textContent);
 
-        self::assertEquals(1, $xpath->query('/html/body/div/table/tr[2]/td')->length);
+        $element2 = $xpath->query('/html/body/div/table/tr[2]/td');
+        self::assertEquals(1, is_object($element2) ? $element2->length : 0);
+
+        /** @phpstan-ignore-next-line  */
         self::assertEquals('3', $xpath->query('/html/body/div/table/tr[2]/td[1]')->item(0)->attributes->getNamedItem('colspan')->textContent);
 
-        self::assertEquals(3, $xpath->query('/html/body/div/table/tr[3]/td')->length);
+        $element3 = $xpath->query('/html/body/div/table/tr[3]/td');
+        self::assertEquals(3, is_object($element3) ? $element3->length : 0);
     }
 
     public function testWriteTitleTextRun(): void
@@ -242,7 +267,10 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $dom = Helper::getAsHTML($phpWord);
         $xpath = new DOMXPath($dom);
 
+        /** @phpstan-ignore-next-line  */
         self::assertEquals('table-layout: fixed;', $xpath->query('/html/body/div/table[1]')->item(0)->attributes->getNamedItem('style')->textContent);
+
+        /** @phpstan-ignore-next-line  */
         self::assertEquals('table-layout: auto;', $xpath->query('/html/body/div/table[2]')->item(0)->attributes->getNamedItem('style')->textContent);
     }
 }

--- a/tests/PhpWordTests/Writer/HTML/FontTest.php
+++ b/tests/PhpWordTests/Writer/HTML/FontTest.php
@@ -275,7 +275,7 @@ class FontTest extends \PHPUnit\Framework\TestCase
 
         $style = Helper::getTextContent($xpath, '/html/head/style');
         self::assertNotFalse(preg_match('/^[*][^\\r\\n]*/m', $style, $matches));
-        self::assertEquals('* {font-family: \'Arial\'; font-size: 12pt; color: #000000; white-space: pre-wrap;}', $matches[0]);
+        self::assertEquals('* {font-family: \'Arial\'; font-size: 12pt; color: #000000; white-space: pre-wrap;}', $matches[0] ?? '');
         $prg = preg_match('/^[.]style1[^\\r\\n]*/m', $style, $matches);
         self::assertNotEmpty($matches);
         self::assertNotFalse($prg);

--- a/tests/PhpWordTests/Writer/HTML/Helper.php
+++ b/tests/PhpWordTests/Writer/HTML/Helper.php
@@ -41,6 +41,7 @@ class Helper extends \PHPUnit\Framework\TestCase
             if ($item2 === null) {
                 self::fail('Unexpected null return requesting item');
             } elseif ($namedItem !== '') {
+                /** @phpstan-ignore property.notFound */
                 $item3 = $item2->attributes->getNamedItem($namedItem);
                 if ($item3 === null) {
                     self::fail('Unexpected null return requesting namedItem');
@@ -48,6 +49,7 @@ class Helper extends \PHPUnit\Framework\TestCase
                     $returnVal = $item3->textContent;
                 }
             } else {
+                /** @phpstan-ignore property.notFound */
                 $returnVal = $item2->textContent;
             }
         }
@@ -67,7 +69,8 @@ class Helper extends \PHPUnit\Framework\TestCase
             if ($item2 === null) {
                 self::fail('Unexpected null return requesting item');
             } else {
-                $returnValue = $item2->attributes->getNamedItem($namedItem);
+                /** @phpstan-ignore property.notFound */
+                $returnVal = $item2->attributes->getNamedItem($namedItem);
             }
         }
 

--- a/tests/PhpWordTests/Writer/HTML/ParagraphTest.php
+++ b/tests/PhpWordTests/Writer/HTML/ParagraphTest.php
@@ -55,7 +55,7 @@ class ParagraphTest extends \PHPUnit\Framework\TestCase
 
         $style = Helper::getTextContent($xpath, '/html/head/style');
         self::assertNotFalse(preg_match('/^[.]indented[^\\r\\n]*/m', $style, $matches));
-        self::assertEquals('.indented {margin-left: 0.5in; margin-right: 0.6in;}', $matches[0]);
+        self::assertEquals('.indented {margin-left: 0.5in; margin-right: 0.6in;}', $matches[0] ?? '');
     }
 
     /**
@@ -88,9 +88,9 @@ class ParagraphTest extends \PHPUnit\Framework\TestCase
 
         $style = Helper::getTextContent($xpath, '/html/head/style');
         self::assertNotFalse(preg_match('/^[.]indented[^\\r\\n]*/m', $style, $matches));
-        self::assertEquals('.indented {margin-left: 0.5in; margin-right: 0.6in;}', $matches[0]);
+        self::assertEquals('.indented {margin-left: 0.5in; margin-right: 0.6in;}', $matches[0] ?? '');
         self::assertNotFalse(preg_match('/^[.]style1[^\\r\\n]*/m', $style, $matches));
-        self::assertEquals('.style1 {font-family: \'Courier New\', monospace; font-size: 10pt; white-space: pre-wrap;}', $matches[0]);
+        self::assertEquals('.style1 {font-family: \'Courier New\', monospace; font-size: 10pt; white-space: pre-wrap;}', $matches[0] ?? '');
     }
 
     /**

--- a/tests/PhpWordTests/XmlDocument.php
+++ b/tests/PhpWordTests/XmlDocument.php
@@ -157,6 +157,7 @@ class XmlDocument
             $this->xpath->registerNamespace('w14', 'http://schemas.microsoft.com/office/word/2010/wordml');
         }
 
+        /** @phpstan-ignore return.type */
         return $this->xpath->query($path);
     }
 


### PR DESCRIPTION
### Description

Fixed errors from phpstan

Now in draft. Fixed some error in tests. 
To tests added dataProviders insted foreach in test methods.

Used directive @runTestsInSeparateProcesses for back compatible. Because mixed type definition is on PHP >= 8.0


### Checklist:

- [x] My CI is :green_circle:
