### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         # Disabled PHPStan in '7.1'
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
         -   name: Setup PHP
             uses: shivammathur/setup-php@v2
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       -   name: Setup PHP
           uses: shivammathur/setup-php@v2
@@ -106,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       -   name: Setup PHP
           uses: shivammathur/setup-php@v2

--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -8,11 +8,13 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
+- Fix "Using null as an array offset" deprecation in Style::getStyle() on PHP 8.5 by [@pwsdotru](https://github.com/pwsdotru) & [@slayerfx](https://github.com/slayerfx) fixing [#2863](https://github.com/PHPOffice/PHPWord/issues/2863) in [#2890](https://github.com/PHPOffice/PHPWord/pull/2890)
 
 ### Miscellaneous
 
 - Update phpstan/phpstan requirement from ^0.12.88 || ^1.0.0 to ^0.12.88 || ^1.0.0 || ^2.0.0 by [@dependabot](https://github.com/dependabot) & [@Progi1984](https://github.com/Progi1984) in [#2736](https://github.com/PHPOffice/PHPWord/pull/2736)
 - Restrict phpunit/phpunit to `< 12` to fix unit tests on PHP 8.3/8.4 by [@slayerfx](https://github.com/slayerfx) fixing [#2842](https://github.com/PHPOffice/PHPWord/issues/2842) in [#2889](https://github.com/PHPOffice/PHPWord/pull/2889)
+- Add PHP 8.5 to the CI matrix and fix chr()/ReflectionMethod::setAccessible() deprecations by [@slayerfx](https://github.com/slayerfx) in [#2890](https://github.com/PHPOffice/PHPWord/pull/2890)
 
 ### Deprecations
 

--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -8,13 +8,13 @@
 ### Bug fixes
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
-- Fix "Using null as an array offset" deprecation in Style::getStyle() on PHP 8.5 by [@pwsdotru](https://github.com/pwsdotru) & [@slayerfx](https://github.com/slayerfx) fixing [#2863](https://github.com/PHPOffice/PHPWord/issues/2863) in [#2890](https://github.com/PHPOffice/PHPWord/pull/2890)
+- Fix "Using null as an array offset" deprecation in Style::getStyle() on PHP 8.5 by [@pwsdotru](https://github.com/pwsdotru) & [@slayerfx](https://github.com/slayerfx) fixing [#2863](https://github.com/PHPOffice/PHPWord/issues/2863) in [#2892](https://github.com/PHPOffice/PHPWord/pull/2892)
 
 ### Miscellaneous
 
 - Update phpstan/phpstan requirement from ^0.12.88 || ^1.0.0 to ^0.12.88 || ^1.0.0 || ^2.0.0 by [@dependabot](https://github.com/dependabot) & [@Progi1984](https://github.com/Progi1984) in [#2736](https://github.com/PHPOffice/PHPWord/pull/2736)
 - Restrict phpunit/phpunit to `< 12` to fix unit tests on PHP 8.3/8.4 by [@slayerfx](https://github.com/slayerfx) fixing [#2842](https://github.com/PHPOffice/PHPWord/issues/2842) in [#2889](https://github.com/PHPOffice/PHPWord/pull/2889)
-- Add PHP 8.5 to the CI matrix and fix chr()/ReflectionMethod::setAccessible() deprecations by [@slayerfx](https://github.com/slayerfx) in [#2890](https://github.com/PHPOffice/PHPWord/pull/2890)
+- Add PHP 8.5 to the CI matrix and fix chr()/ReflectionMethod::setAccessible() deprecations by [@slayerfx](https://github.com/slayerfx) in [#2892](https://github.com/PHPOffice/PHPWord/pull/2892)
 
 ### Deprecations
 

--- a/src/PhpWord/Reader/MsDoc.php
+++ b/src/PhpWord/Reader/MsDoc.php
@@ -1218,7 +1218,7 @@ class MsDoc extends AbstractReader implements ReaderInterface
                     $char = self::getInt2d($this->data1Table, $posMem);
                     $posMem += 2;
                     if ($char > 0) {
-                        $xszFfn .= chr($char);
+                        $xszFfn .= chr($char & 0xFF);
                     }
                 } while ($char != 0);
                 // xszAlt
@@ -1230,7 +1230,7 @@ class MsDoc extends AbstractReader implements ReaderInterface
                         if ($char == 0) {
                             break;
                         }
-                        $xszAlt .= chr($char);
+                        $xszAlt .= chr($char & 0xFF);
                     } while ($char != 0);
                 }
                 $this->arrayFonts[] = [

--- a/src/PhpWord/Style.php
+++ b/src/PhpWord/Style.php
@@ -178,7 +178,7 @@ class Style
      */
     public static function getStyle($styleName)
     {
-        if (isset(self::$styles[$styleName])) {
+        if (!empty($styleName) && array_key_exists($styleName, self::$styles) && isset(self::$styles[$styleName])) {
             return self::$styles[$styleName];
         }
 

--- a/src/PhpWord/Style.php
+++ b/src/PhpWord/Style.php
@@ -178,7 +178,7 @@ class Style
      */
     public static function getStyle($styleName)
     {
-        if (!empty($styleName) && array_key_exists($styleName, self::$styles) && isset(self::$styles[$styleName])) {
+        if ($styleName !== null && isset(self::$styles[$styleName])) {
             return self::$styles[$styleName];
         }
 

--- a/tests/PhpWordTests/Style/AbstractStyleTest.php
+++ b/tests/PhpWordTests/Style/AbstractStyleTest.php
@@ -134,7 +134,6 @@ class AbstractStyleTest extends \PHPUnit\Framework\TestCase
     {
         $class = new ReflectionClass(get_class($object));
         $method = $class->getMethod($method);
-        $method->setAccessible(true);
 
         return $method->invokeArgs($object, $args);
     }

--- a/tests/PhpWordTests/Style/AbstractStyleTest.php
+++ b/tests/PhpWordTests/Style/AbstractStyleTest.php
@@ -134,6 +134,9 @@ class AbstractStyleTest extends \PHPUnit\Framework\TestCase
     {
         $class = new ReflectionClass(get_class($object));
         $method = $class->getMethod($method);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         return $method->invokeArgs($object, $args);
     }


### PR DESCRIPTION
### Description

Adds PHP 8.5 support: fixes the deprecations that break the test suite on 8.5, and adds 8.5 to the CI matrix.

- `Style::getStyle()`: using `null` as an array offset (takes over #2881 by @pwsdotru, simplified)
- `MsDoc` reader: `chr()` called with a value above 255
- tests: `ReflectionMethod::setAccessible()` is deprecated since 8.5, but still required
  before 8.1, so it is now guarded by a version check

All PHPUnit and samples jobs are green from 7.1 to 8.5.

Notes:
- the PHPStan jobs are red, but this is pre-existing and unrelated to this PR
- PHPUnit 7.3 fails only when uploading to coveralls.io (their service is returning 504s);
  the tests themselves pass

Fixes #2863
