### PR TITLE
MPDF Writer: make the mPDF temporary directory configurable

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -4,6 +4,7 @@
 
 ## Enhancements
 - Added support for image alt text by [@jwoodhead](https://github.com/jwoodhead) in [#2873](https://github.com/PHPOffice/PHPWord/pull/2873)
+- MPDF Writer : Make the mPDF temporary directory configurable via the `tempDir` PDF renderer option, defaulting to the system temporary directory by [@danielwirz](https://github.com/danielwirz) in [#2898](https://github.com/PHPOffice/PHPWord/pull/2898)
 
 ### Bug fixes
 

--- a/docs/usage/writers.md
+++ b/docs/usage/writers.md
@@ -71,6 +71,7 @@ function cbEditHTML(string $inputHTML): string
 
 You can define options like :
 * `font`: default font
+* `tempDir`: writable directory for mPDF's temporary files (MPDF renderer only, defaults to the system temporary directory)
 
 Options must be defined before creating the writer.
 

--- a/src/PhpWord/Writer/PDF/MPDF.php
+++ b/src/PhpWord/Writer/PDF/MPDF.php
@@ -61,6 +61,8 @@ class MPDF extends AbstractRenderer implements WriterInterface
             $options['default_font'] = $this->getFont();
         }
 
+        $options['tempDir'] = Settings::getPdfRendererOptions()['tempDir'] ?? sys_get_temp_dir() . '/mpdf';
+
         return new $mPdfClass($options);
     }
 

--- a/tests/PhpWordTests/Writer/PDF/MPDFTest.php
+++ b/tests/PhpWordTests/Writer/PDF/MPDFTest.php
@@ -22,6 +22,7 @@ use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\Writer\PDF;
 use PhpOffice\PhpWord\Writer\PDF\MPDF;
+use ReflectionMethod;
 
 /**
  * Test class for PhpOffice\PhpWord\Writer\PDF\MPDF.
@@ -112,5 +113,30 @@ class MPDFTest extends \PHPUnit\Framework\TestCase
         ]);
         $writer = new PDF(new PhpWord());
         self::assertEquals('Arial', $writer->getFont());
+    }
+
+    /**
+     * Test that the mPDF temporary directory can be set via the renderer options.
+     */
+    public function testSetTempDir(): void
+    {
+        $rendererName = Settings::PDF_RENDERER_MPDF;
+        $rendererLibraryPath = (string) realpath(PHPWORD_TESTS_BASE_DIR . '/../vendor/mpdf/mpdf');
+        Settings::setPdfRenderer($rendererName, $rendererLibraryPath);
+
+        $writer = new MPDF(new PhpWord());
+        $method = new ReflectionMethod(MPDF::class, 'createExternalWriterInstance');
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        // Defaults to the system temporary directory.
+        self::assertSame(sys_get_temp_dir() . '/mpdf', $method->invoke($writer)->tempDir);
+
+        // Can be overridden via the PDF renderer options.
+        Settings::setPdfRendererOptions([
+            'tempDir' => sys_get_temp_dir() . '/phpword-mpdf',
+        ]);
+        self::assertSame(sys_get_temp_dir() . '/phpword-mpdf', $method->invoke($writer)->tempDir);
     }
 }


### PR DESCRIPTION
## Description

When rendering a PDF through the MPDF writer, the `Mpdf` instance is created without a `tempDir`, so mPDF falls back to its default temporary directory **inside its own package folder** (`vendor/mpdf/mpdf/tmp`). On hosts with an immutable/read-only application filesystem (Platform.sh, some Docker setups, …) that directory is not writable and PDF generation fails with:

> Temporary files directory "…/vendor/mpdf/mpdf/tmp" is not writable

This PR forwards a `tempDir` set via `Settings::setPdfRendererOptions(['tempDir' => …])` to the `Mpdf` constructor, and defaults to `sys_get_temp_dir() . '/mpdf'` when the option is not set.

```php
\PhpOffice\PhpWord\Settings::setPdfRendererOptions([
    'tempDir' => '/path/to/writable/dir',
]);
```

This mirrors PhpSpreadsheet, which always passes a temp dir below the system temporary directory to `Mpdf` ([Writer/Pdf/Mpdf.php](https://github.com/PHPOffice/PhpSpreadsheet/blob/65b080eef4d9fd11a5796135ab145883e5c3d6a6/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php#L42)). mPDF creates the directory itself if it does not exist.

Note the (deliberate) behavior change when the option is not set: mPDF's font/image cache moves from `vendor/mpdf/mpdf/tmp` to the system temporary directory — writing cache files into an installed Composer package is what breaks read-only deployments in the first place.

## Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (`testSetTempDir` in `MPDFTest`)
- [x] I have updated the documentation to describe the changes