### PR TITLE
Fix: <p> wrapping a block element throws "Cannot add ListItemRun in TextRun"

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -304,13 +304,20 @@ class Html
      * @param AbstractContainer $element
      * @param array &$styles
      *
-     * @return \PhpOffice\PhpWord\Element\PageBreak|TextRun
+     * @return AbstractContainer|\PhpOffice\PhpWord\Element\PageBreak|TextRun
      */
     protected static function parseParagraph($node, $element, &$styles)
     {
         $styles['paragraph'] = self::recursiveParseStylesInHierarchy($node, $styles['paragraph']);
         if (isset($styles['paragraph']['isPageBreak']) && $styles['paragraph']['isPageBreak']) {
             return $element->addPageBreak();
+        }
+
+        // A <p> wrapping a block element (e.g. <ul>, <table>) cannot become a TextRun,
+        // since a TextRun cannot contain a ListItemRun or a Table. Leave it transparent
+        // so its children are added directly to the parent container instead.
+        if (!self::shouldAddTextRun($node)) {
+            return $element;
         }
 
         return $element->addTextRun($styles['paragraph']);

--- a/tests/PhpWordTests/Shared/HtmlTest.php
+++ b/tests/PhpWordTests/Shared/HtmlTest.php
@@ -506,6 +506,22 @@ class HtmlTest extends AbstractWebServerEmbedded
     }
 
     /**
+     * A <p> wrapping a block element (e.g. <ul>) must not be turned into a TextRun,
+     * since a TextRun cannot contain a ListItemRun.
+     */
+    public function testParseParagraphWrappingList(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        Html::addHtml($section, '<p><ul><li>Item 1</li><li>Item 2</li></ul></p>');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p[1]/w:pPr/w:numPr'));
+        self::assertEquals('Item 1', $doc->getElement('/w:document/w:body/w:p[1]/w:r/w:t')->textContent);
+        self::assertEquals('Item 2', $doc->getElement('/w:document/w:body/w:p[2]/w:r/w:t')->textContent);
+    }
+
+    /**
      * Test parsing table.
      */
     public function testParseTable(): void


### PR DESCRIPTION
## Summary
`Html::parseParagraph()` always converts a `<p>` into a `TextRun`, but a `TextRun`
cannot contain block-level elements such as `ListItemRun` or `Table`. HTML that
wraps a `<ul>`/`<ol>`/`<table>`/heading in a `<p>` — common output from rich text
editors like TinyMCE — throws `Cannot add ListItemRun in TextRun` and aborts the
whole conversion, rather than just rendering incorrectly.

`parseCell()` already has a `shouldAddTextRun()` guard for this exact constraint;
`parseParagraph()` now reuses it and stays transparent when the paragraph contains
a block element, so its children are added directly to the parent container instead.

## Test plan
- [x] Added `testParseParagraphWrappingList()` covering `<p><ul>...</ul></p>`
- [x] `composer test-no-coverage` — full suite passes
- [x] `composer phpstan` — clean
- [x] `composer phpmd` — clean
- [x] PHP CS Fixer — no violations