### PR TITLE
Add TemplateProcessor::macroExists() to check macro presence (#2895)

### DIFF
--- a/src/PhpWord/TemplateProcessor.php
+++ b/src/PhpWord/TemplateProcessor.php
@@ -1357,6 +1357,21 @@ class TemplateProcessor
     }
 
     /**
+     * Check whether a macro exists in the document.
+     *
+     * Useful to branch logic on the presence of a placeholder before
+     * setting or cloning it.
+     *
+     * @param string $macro Name of the macro
+     *
+     * @return bool True if the macro is present, false otherwise
+     */
+    public function macroExists($macro)
+    {
+        return $this->findMacro($macro) >= 0;
+    }
+
+    /**
      * Find start and end of XML block containing the given macro
      * e.g. <w:p>...${macro}...</w:p>.
      *

--- a/tests/PhpWordTests/TemplateProcessorTest.php
+++ b/tests/PhpWordTests/TemplateProcessorTest.php
@@ -482,6 +482,18 @@ final class TemplateProcessorTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers ::macroExists
+     */
+    public function testMacroExists(): void
+    {
+        $templateProcessor = $this->getTemplateProcessor(__DIR__ . '/_files/templates/clone-merge.docx');
+
+        self::assertTrue($templateProcessor->macroExists('tableHeader'));
+        self::assertTrue($templateProcessor->macroExists('userId'));
+        self::assertFalse($templateProcessor->macroExists('nonexistentMacro'));
+    }
+
+    /**
      * @covers ::setValue
      */
     public function testSetValueWithCustomMacro(): void


### PR DESCRIPTION
Adds `TemplateProcessor::macroExists($macro)` so callers can branch on whether a placeholder exists before setting or cloning it. Builds on the existing protected `findMacro()` helper (returns -1 when absent).

Regression test added in `TemplateProcessorTest::testMacroExists`.

Closes #2895.

---
**Algora bounty:** PHPWord issue #2895 (https://github.com/PHPOffice/PHPWord/issues/2895). Submitted for the Algora-funded feature request.