### PR TITLE
feat: make GD extension optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,6 @@
     "require": {
         "php": "^7.1|^8.0",
         "ext-dom": "*",
-        "ext-gd": "*",  
         "ext-zip": "*",
         "ext-json": "*",
         "ext-xml": "*",
@@ -127,6 +126,7 @@
         "tecnickcom/tcpdf": "^6.5"
     },
     "suggest": {
+        "ext-gd": "Allows adding images from remote HTTP URLs and GD-generated images",
         "ext-xmlwriter": "Allows writing OOXML and ODF",
         "ext-xsl": "Allows applying XSL style sheet to headers, to main document part, and to footers of an OOXML template",
         "dompdf/dompdf": "Allows writing PDF"

--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -5,6 +5,7 @@
 ## Enhancements
 - Added support for image alt text by [@jwoodhead](https://github.com/jwoodhead) in [#2873](https://github.com/PHPOffice/PHPWord/pull/2873)
 - MPDF Writer : Make the mPDF temporary directory configurable via the `tempDir` PDF renderer option, defaulting to the system temporary directory by [@danielwirz](https://github.com/danielwirz) in [#2898](https://github.com/PHPOffice/PHPWord/pull/2898)
+- GD extension is now optional by [@andrew-demb](https://github.com/andrew-demb) fixing [#2789] in [#2902](https://github.com/PHPOffice/PHPWord/pull/2902)
 
 ### Bug fixes
 

--- a/src/PhpWord/Element/Image.php
+++ b/src/PhpWord/Element/Image.php
@@ -24,6 +24,7 @@ use PhpOffice\PhpWord\Exception\UnsupportedImageTypeException;
 use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\Shared\ZipArchive;
 use PhpOffice\PhpWord\Style\Image as ImageStyle;
+use RuntimeException;
 
 /**
  * Image element.
@@ -398,6 +399,9 @@ class Image extends AbstractElement
 
         // Read image binary data and convert to hex/base64 string
         if ($this->sourceType == self::SOURCE_GD) {
+            if (!extension_loaded('gd')) {
+                throw new RuntimeException('The GD extension is required to process GD images.');
+            }
             $imageResource = call_user_func($this->imageCreateFunc, $actualSource);
             if ($this->imageType === 'image/png') {
                 // PNG images need to preserve alpha channel information


### PR DESCRIPTION
Fixes #2789

### Description

Make the GD extension optional for consumers who don't want to deal with images overall and want to keep the number of PHP extensions installed minimal.

Fixes #2789

### Checklist:

- [x] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
