### PR TITLE
Fix various CSS border parsing and rendering bugs in HTML-to-Word conversion

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -28,6 +28,7 @@ use PhpOffice\PhpWord\Element\Row;
 use PhpOffice\PhpWord\Element\Table;
 use PhpOffice\PhpWord\Element\TextRun;
 use PhpOffice\PhpWord\Settings;
+use PhpOffice\PhpWord\SimpleType\Border as BorderType;
 use PhpOffice\PhpWord\SimpleType\Jc;
 use PhpOffice\PhpWord\SimpleType\NumberFormat;
 use PhpOffice\PhpWord\Style\Paragraph;
@@ -40,6 +41,31 @@ use PhpOffice\PhpWord\Style\Paragraph;
 class Html
 {
     private const RGB_REGEXP = '/^\s*rgb\s*[(]\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*[)]\s*$/';
+
+    /**
+     * CSS border-style keywords mapped to their Word/OOXML equivalent.
+     *
+     * @see http://www.datypic.com/sc/ooxml/t-w_ST_Border.html
+     */
+    private const BORDER_STYLE_MAP = [
+        'none' => BorderType::NONE,
+        'hidden' => BorderType::NONE,
+        'dotted' => BorderType::DOTTED,
+        'dashed' => BorderType::DASHED,
+        'solid' => BorderType::SINGLE,
+        'double' => BorderType::DOUBLE,
+        'groove' => BorderType::THREE_D_ENGRAVE,
+        'ridge' => BorderType::THREE_D_EMBOSS,
+        'inset' => BorderType::INSET,
+        'outset' => BorderType::OUTSET,
+    ];
+
+    /**
+     * Default border width applied when a border-style/-color is set without one. CSS itself
+     * defaults an unset border-width to "medium" whenever a border-style/-color is present;
+     * browsers commonly render "medium" as 3px, so that's what's used here.
+     */
+    private const DEFAULT_BORDER_WIDTH = '3px';
 
     protected static $listIndex = 0;
 
@@ -178,6 +204,8 @@ class Html
             if ($attributeStyle) {
                 $styles = self::parseStyle($attributeStyle, $styles);
             }
+
+            $styles = self::fillMissingBorderSize($styles);
         }
 
         return $styles;
@@ -861,7 +889,7 @@ class Html
 
                     break;
                 case 'border-width':
-                    $styles['borderSize'] = Converter::cssToPoint($value);
+                    $styles['borderSize'] = self::mapBorderWidth($value);
 
                     break;
                 case 'border-style':
@@ -891,29 +919,7 @@ class Html
                 case 'border-bottom':
                 case 'border-right':
                 case 'border-left':
-                    // must have exact order [width color style], e.g. "1px #0011CC solid" or "2pt green solid"
-                    // Word does not accept shortened hex colors e.g. #CCC, only full e.g. #CCCCCC
-                    if (preg_match('/([0-9]+[^0-9]*)\s+(\#[a-fA-F0-9]+|[a-zA-Z]+)\s+([a-z]+)/', $value, $matches)) {
-                        if (false !== strpos($property, '-')) {
-                            $tmp = explode('-', $property);
-                            $which = $tmp[1];
-                            $which = ucfirst($which); // e.g. bottom -> Bottom
-                        } else {
-                            $which = '';
-                        }
-                        // Note - border width normalization:
-                        // Width of border in Word is calculated differently than HTML borders, usually showing up too bold.
-                        // Smallest 1px (or 1pt) appears in Word like 2-3px/pt in HTML once converted to twips.
-                        // Therefore we need to normalize converted twip value to cca 1/2 of value.
-                        // This may be adjusted, if better ratio or formula found.
-                        // BC change: up to ver. 0.17.0 was $size converted to points - Converter::cssToPoint($size)
-                        $size = Converter::cssToTwip($matches[1]);
-                        $size = (int) ($size / 2);
-                        // valid variants may be e.g. borderSize, borderTopSize, borderLeftColor, etc ..
-                        $styles["border{$which}Size"] = $size; // twips
-                        $styles["border{$which}Color"] = trim($matches[2], '#');
-                        $styles["border{$which}Style"] = self::mapBorderStyle($matches[3]);
-                    }
+                    self::mapBorderShorthand($styles, $property, $value);
 
                     break;
                 case 'vertical-align':
@@ -1057,33 +1063,113 @@ class Html
      *
      * @param string $cssBorderStyle
      *
-     * @return null|string
+     * @return string
      */
     protected static function mapBorderStyle($cssBorderStyle)
     {
-        switch ($cssBorderStyle) {
-            case 'none':
-            case 'dashed':
-            case 'dotted':
-            case 'double':
-                return $cssBorderStyle;
-            default:
-                return 'single';
-        }
+        return self::BORDER_STYLE_MAP[strtolower($cssBorderStyle)] ?? BorderType::SINGLE;
+    }
+
+    /**
+     * Transforms a CSS border-width into the border size unit used internally.
+     *
+     * Note - border width normalization:
+     * Width of border in Word is calculated differently than HTML borders, usually showing up too bold.
+     * Smallest 1px (or 1pt) appears in Word like 2-3px/pt in HTML once converted to twips.
+     * Therefore we need to normalize converted twip value to cca 1/2 of value.
+     * This may be adjusted, if better ratio or formula found.
+     *
+     * @param string $cssBorderWidth
+     *
+     * @return int
+     */
+    protected static function mapBorderWidth($cssBorderWidth)
+    {
+        return (int) (Converter::cssToTwip($cssBorderWidth) / 2);
     }
 
     protected static function mapBorderColor(&$styles, $cssBorderColor): void
     {
-        $numColors = substr_count($cssBorderColor, '#');
-        if ($numColors === 1) {
-            $styles['borderColor'] = trim($cssBorderColor, '#');
-        } elseif ($numColors > 1) {
-            $colors = explode(' ', $cssBorderColor);
+        $colors = preg_split('/\s+/', trim($cssBorderColor)) ?: [];
+        if (count($colors) === 1) {
+            $styles['borderColor'] = trim($colors[0], '#');
+        } else {
             $borders = ['borderTopColor', 'borderRightColor', 'borderBottomColor', 'borderLeftColor'];
-            for ($i = 0; $i < min(4, $numColors, count($colors)); ++$i) {
+            for ($i = 0; $i < min(4, count($colors)); ++$i) {
                 $styles[$borders[$i]] = trim($colors[$i], '#');
             }
         }
+    }
+
+    /**
+     * Parses the `border`/`border-top`/`border-right`/`border-bottom`/`border-left` shorthand.
+     *
+     * CSS does not fix a token order for this shorthand - width, style and color may appear in
+     * any order (e.g. "1px solid #0011CC" or "2pt green solid" are both valid CSS). Each
+     * whitespace-separated token is classified by shape instead of by position: a number with a
+     * unit is the width, a recognized border-style keyword is the style, and anything else is
+     * the color.
+     * Word does not accept shortened hex colors e.g. #CCC, only full e.g. #CCCCCC.
+     *
+     * @param array &$styles
+     * @param string $property
+     * @param string $value
+     */
+    protected static function mapBorderShorthand(&$styles, $property, $value): void
+    {
+        $which = false !== strpos($property, '-') ? ucfirst(explode('-', $property)[1]) : '';
+
+        $width = null;
+        $borderStyle = null;
+        $color = null;
+        foreach (preg_split('/\s+/', trim($value)) ?: [] as $token) {
+            if ($token === '') {
+                continue;
+            }
+            if ($width === null && preg_match('/^[0-9]+\.?[0-9]*(px|pt|em|ex|%|in|cm|mm|pc)$/i', $token)) {
+                $width = $token;
+            } elseif ($borderStyle === null && array_key_exists(strtolower($token), self::BORDER_STYLE_MAP)) {
+                $borderStyle = $token;
+            } elseif ($color === null) {
+                $color = $token;
+            }
+        }
+
+        if ($width !== null) {
+            // valid variants may be e.g. borderSize, borderTopSize, borderLeftColor, etc ..
+            $styles["border{$which}Size"] = self::mapBorderWidth($width);
+        }
+        if ($borderStyle !== null) {
+            $styles["border{$which}Style"] = self::mapBorderStyle($borderStyle);
+        }
+        if ($color !== null) {
+            $styles["border{$which}Color"] = trim($color, '#');
+        }
+    }
+
+    /**
+     * Backfills a default border width for any side whose border-style or border-color was set
+     * but border-width was not.
+     *
+     * CSS itself defaults an unset border-width to "medium" whenever a border-style or
+     * border-color is present. PHPWord doesn't apply that default on its own -
+     * Style\Border::hasBorder(), which the writers check before emitting a border at all, gates
+     * purely on border size being set - so a bare `border-style`/`border-color` declaration
+     * would otherwise be silently dropped instead of rendering with a default width.
+     *
+     * @return array
+     */
+    protected static function fillMissingBorderSize(array $styles)
+    {
+        foreach (['', 'Top', 'Right', 'Bottom', 'Left'] as $side) {
+            $sizeKey = "border{$side}Size";
+            $hasStyleOrColor = isset($styles["border{$side}Style"]) || isset($styles["border{$side}Color"]);
+            if ($hasStyleOrColor && !isset($styles[$sizeKey])) {
+                $styles[$sizeKey] = self::mapBorderWidth(self::DEFAULT_BORDER_WIDTH);
+            }
+        }
+
+        return $styles;
     }
 
     /**

--- a/src/PhpWord/Writer/Word2007/Style/Table.php
+++ b/src/PhpWord/Writer/Word2007/Style/Table.php
@@ -140,6 +140,7 @@ class Table extends AbstractStyle
             $styleWriter = new MarginBorder($xmlWriter);
             $styleWriter->setSizes($style->getBorderSize());
             $styleWriter->setColors($style->getBorderColor());
+            $styleWriter->setStyles($style->getBorderStyle());
             $styleWriter->write();
 
             $xmlWriter->endElement(); // w:tblBorders

--- a/tests/PhpWordTests/Shared/HtmlTest.php
+++ b/tests/PhpWordTests/Shared/HtmlTest.php
@@ -552,6 +552,131 @@ class HtmlTest extends AbstractWebServerEmbedded
     }
 
     /**
+     * The `border` shorthand does not have a fixed CSS token order - width, style and color may
+     * appear in any order. Real-world CSS (and every browser/editor) emits "width style color",
+     * not the "width color style" order the parser used to assume.
+     */
+    public function testParseBorderShorthandOrderIndependent(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<table>
+                <tr>
+                    <td style="border: 2px dashed #FF00FF">hex color</td>
+                    <td style="border: 2px dashed magenta">named color</td>
+                </tr>
+            </table>';
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        // 2px = 30 twips (2 / 96 * 1440), halved for Word's bolder rendering = 15
+        self::assertEquals('dashed', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc[1]/w:tcPr/w:tcBorders/w:top', 'w:val'));
+        self::assertEquals('FF00FF', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc[1]/w:tcPr/w:tcBorders/w:top', 'w:color'));
+        self::assertEquals(15, $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc[1]/w:tcPr/w:tcBorders/w:top', 'w:sz'));
+
+        self::assertEquals('dashed', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc[2]/w:tcPr/w:tcBorders/w:top', 'w:val'));
+        self::assertEquals('magenta', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc[2]/w:tcPr/w:tcBorders/w:top', 'w:color'));
+        self::assertEquals(15, $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc[2]/w:tcPr/w:tcBorders/w:top', 'w:sz'));
+    }
+
+    /**
+     * `border-color` used to be dropped entirely for named colors, because the parser decided
+     * single- vs. multi-color by counting "#" characters in the value.
+     */
+    public function testParseBorderColorNamedColor(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        Html::addHtml($section, '<table><tr><td style="border-color: red; border-width: 1px;">cell</td></tr></table>');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        self::assertEquals('red', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc/w:tcPr/w:tcBorders/w:top', 'w:color'));
+    }
+
+    /**
+     * The `border-width` longhand used to be stored in points but read back everywhere else as
+     * twips, rendering roughly 20x thinner than intended. It should produce the same size as the
+     * equivalent `border` shorthand.
+     */
+    public function testParseBorderWidthLonghandUnit(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<table>
+                <tr>
+                    <td style="border-width: 1px; border-style: solid; border-color: #000000;">longhand</td>
+                    <td style="border: 1px solid #000000;">shorthand</td>
+                </tr>
+            </table>';
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        // 1px = 15 twips (1 / 96 * 1440), halved for Word's bolder rendering = 7
+        self::assertEquals(7, $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc[1]/w:tcPr/w:tcBorders/w:top', 'w:sz'));
+        self::assertEquals(7, $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc[2]/w:tcPr/w:tcBorders/w:top', 'w:sz'));
+    }
+
+    /**
+     * CSS border-style keywords beyond none/dashed/dotted/double used to silently fall back to
+     * "single" (solid).
+     */
+    public function testParseBorderStyleExtendedKeywords(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<table>
+                <tr>
+                    <td style="border-style: groove; border-width: 1px;">groove</td>
+                    <td style="border-style: ridge; border-width: 1px;">ridge</td>
+                    <td style="border-style: inset; border-width: 1px;">inset</td>
+                    <td style="border-style: outset; border-width: 1px;">outset</td>
+                </tr>
+            </table>';
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        self::assertEquals('threeDEngrave', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc[1]/w:tcPr/w:tcBorders/w:top', 'w:val'));
+        self::assertEquals('threeDEmboss', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc[2]/w:tcPr/w:tcBorders/w:top', 'w:val'));
+        self::assertEquals('inset', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc[3]/w:tcPr/w:tcBorders/w:top', 'w:val'));
+        self::assertEquals('outset', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc[4]/w:tcPr/w:tcBorders/w:top', 'w:val'));
+    }
+
+    /**
+     * `Style\Border::hasBorder()` gates purely on border size being set, so a bare
+     * `border-style`/`border-color` declaration without a width used to be silently dropped
+     * entirely, even though CSS itself defaults an unset border-width to "medium" whenever a
+     * style/color is present.
+     */
+    public function testParseBorderStyleWithoutWidthStillRenders(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        Html::addHtml($section, '<table><tr><td style="border-style: dashed;">cell</td></tr></table>');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:tbl/w:tr/w:tc/w:tcPr/w:tcBorders/w:top'));
+        self::assertEquals('dashed', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc/w:tcPr/w:tcBorders/w:top', 'w:val'));
+        self::assertNotNull($doc->getElementAttribute('/w:document/w:body/w:tbl/w:tr/w:tc/w:tcPr/w:tcBorders/w:top', 'w:sz'));
+    }
+
+    /**
+     * Writer\Word2007\Style\Table::writeBorder() used to never pass border style through to its
+     * XML writer (only size and color), so a table's own <w:tblBorders> always rendered every
+     * side as "single" no matter what border-style was configured.
+     */
+    public function testParseTableLevelBorderStyleIsWritten(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        Html::addHtml($section, '<table style="border: 1px double #000000;"><tr><td>cell</td></tr></table>');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        self::assertEquals('double', $doc->getElementAttribute('/w:document/w:body/w:tbl/w:tblPr/w:tblBorders/w:top', 'w:val'));
+    }
+
+    /**
      * Parse widths in tables and cells, which also allows for controlling column width.
      */
     public function testParseTableAndCellWidth(): void


### PR DESCRIPTION
## Summary
Several related bugs in `Html::parseStyleDeclarations()` and the Word2007 table
border writer meant CSS borders frequently rendered wrong, or not at all:

- The `border`/`border-top`/`border-right`/`border-bottom`/`border-left`
  shorthand assumed a fixed `width color style` token order, but real CSS
  (and every browser/editor) emits `width style color`. Tokens are now
  classified by shape (a number+unit is the width, a recognized keyword is
  the style, anything else is the color) instead of by position, so either
  order parses correctly.
- `border-color` decided single- vs. multi-color by counting `#` characters
  in the value, so named colors (e.g. `red`) had zero and were silently
  dropped entirely, for both the single- and multi-value cases.
- `border-width` was converted with `Converter::cssToPoint()` but stored
  and read back everywhere else in the file as twips, rendering roughly
  20x thinner than intended.
- `border-style` only recognized `none`/`dashed`/`dotted`/`double`, silently
  falling back to `single` (solid) for `groove`/`ridge`/`inset`/`outset`.
- `Style\Border::hasBorder()` - which every writer checks before emitting a
  border at all - gates purely on border size being set. So a bare
  `border-style`/`border-color` declaration without an explicit width was
  dropped entirely, even though CSS itself defaults an unset border-width
  to "medium" (~3px) whenever a style/color is present. The HTML parser now
  backfills that same default so it isn't dropped.
- `Writer\Word2007\Style\Table::writeBorder()` never passed border *style*
  through to its `MarginBorder` XML writer (only size and color), even
  though `MarginBorder` supports it and the cell writer
  (`Writer\Word2007\Style\Cell`) already does. So a table's own
  `<w:tblBorders>` always rendered every side as `single`, regardless of
  what `border-style` was configured - only cell-level borders (`<w:tcBorders>`)
  ever showed the right style.

These are grouped into one PR because they're all in the same small area of
code (the border cases in `parseStyleDeclarations()`, plus `mapBorderStyle()`/
`mapBorderColor()`) and only become fully visible together - e.g. a plain
`border-style: dashed` only round-trips to Word once both the backfill and
the table writer fix are in place.

## Test plan
- [x] Added 6 new tests to `HtmlTest.php` covering: order-independent shorthand
      parsing (hex + named color), named `border-color`, `border-width`
      longhand/shorthand unit consistency, extended `border-style` keywords,
      style-without-width backfill, and table-level `border-style` writing
- [x] `composer test-no-coverage` - full suite passes (1119 tests)
- [x] `composer phpstan` - clean
- [x] `composer phpmd` - clean
- [x] PHP CS Fixer - no violations
- [x] Manually generated a `.docx` exercising every fix and visually confirmed
      correct rendering in Word