### PR TITLE
Writer ODText: Support table row heights

### DIFF
--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -14,6 +14,7 @@
 - Add Default font color for Word by [@Collie-IT](https://github.com/Collie-IT) in [#2700](https://github.com/PHPOffice/PHPWord/pull/2700)
 - Writer HTML: Support Default font color by [@MichaelPFrey](https://github.com/MichaelPFrey) in [#2731](https://github.com/PHPOffice/PHPWord/pull/2731)
 - Writer ODText: Support Default font color by [@MichaelPFrey](https://github.com/MichaelPFrey) in [#2735](https://github.com/PHPOffice/PHPWord/pull/2735)
+- Writer ODText: Support table row heights and exact-height semantics by [@potofcoffee](https://github.com/potofcoffee) in [#2904](https://github.com/PHPOffice/PHPWord/pull/2904)
 - Add basic ruby text (phonetic guide) support for Word2007 and HTML Reader/Writer, RTF Writer, basic support for ODT writing by [@Deadpikle](https://github.com/Deadpikle) in [#2727](https://github.com/PHPOffice/PHPWord/pull/2727)
 - Reader HTML: Support font styles for h1/h6 by [@Progi1984](https://github.com/Progi1984) fixing [#2619](https://github.com/PHPOffice/PHPWord/issues/2619) in [#2737](https://github.com/PHPOffice/PHPWord/pull/2737)
 - Writer EPub3: Basic support by [@Sambit003](https://github.com/Sambit003) fixing [#55](https://github.com/PHPOffice/PHPWord/issues/55) in [#2724](https://github.com/PHPOffice/PHPWord/pull/2724)

--- a/docs/usage/styles/table.md
+++ b/docs/usage/styles/table.md
@@ -35,6 +35,10 @@ Available Row style options:
 - ``exactHeight``. Row height is exact or at least.
 - ``tblHeader``. Repeat table row on every new page, *true* or *false*.
 
+The ODText writer serializes row heights as native ODF table-row styles. An
+exact height uses ``style:row-height``; an at-least height uses
+``style:min-row-height``.
+
 Available Cell style options:
 
 - ``bgColor``. Background color, e.g. '9966CC'.

--- a/src/PhpWord/Writer/ODText/Element/Table.php
+++ b/src/PhpWord/Writer/ODText/Element/Table.php
@@ -78,6 +78,9 @@ class Table extends AbstractElement
     private function writeRow(XMLWriter $xmlWriter, RowElement $row): void
     {
         $xmlWriter->startElement('table:table-row');
+        if ($row->getHeight() !== null) {
+            $xmlWriter->writeAttribute('table:style-name', $row->getElementId());
+        }
         /** @var RowElement $row Type hint */
         foreach ($row->getCells() as $cell) {
             $xmlWriter->startElement('table:table-cell');

--- a/src/PhpWord/Writer/ODText/Part/Content.php
+++ b/src/PhpWord/Writer/ODText/Part/Content.php
@@ -21,6 +21,7 @@ namespace PhpOffice\PhpWord\Writer\ODText\Part;
 use PhpOffice\PhpWord\Element\AbstractContainer;
 use PhpOffice\PhpWord\Element\Field;
 use PhpOffice\PhpWord\Element\Image;
+use PhpOffice\PhpWord\Element\Row as RowElement;
 use PhpOffice\PhpWord\Element\Table;
 use PhpOffice\PhpWord\Element\Text;
 use PhpOffice\PhpWord\Element\TextRun;
@@ -48,7 +49,7 @@ class Content extends AbstractPart
      *
      * @var array
      */
-    private $autoStyles = ['Section' => [], 'Image' => [], 'Table' => []];
+    private $autoStyles = ['Section' => [], 'Image' => [], 'Table' => [], 'Row' => []];
 
     private $imageParagraphStyles = [];
 
@@ -295,6 +296,15 @@ class Content extends AbstractPart
                 $style->setStyleName($element->getElementId());
                 $style->setColumnWidths($element->findFirstDefinedCellWidths());
                 $this->autoStyles['Table'][] = $style;
+                foreach ($element->getRows() as $row) {
+                    if ($row instanceof RowElement && $row->getHeight() !== null) {
+                        if (!$row->getElementId()) {
+                            $row->setElementId();
+                        }
+                        $row->getStyle()->setStyleName($row->getElementId());
+                        $this->autoStyles['Row'][] = $row;
+                    }
+                }
             }
         }
     }

--- a/src/PhpWord/Writer/ODText/Style/Row.php
+++ b/src/PhpWord/Writer/ODText/Style/Row.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PhpOffice\PhpWord\Writer\ODText\Style;
+
+use PhpOffice\PhpWord\Shared\Converter;
+
+/**
+ * Table row style writer.
+ */
+class Row extends AbstractStyle
+{
+    public function write(): void
+    {
+        $style = $this->getStyle();
+        if ($style instanceof \PhpOffice\PhpWord\Element\Row) {
+            $height = $style->getHeight();
+            $style = $style->getStyle();
+        } else {
+            $height = null;
+        }
+        if (!$style instanceof \PhpOffice\PhpWord\Style\Row) {
+            return;
+        }
+
+        $xmlWriter = $this->getXmlWriter();
+        $xmlWriter->startElement('style:style');
+        $xmlWriter->writeAttribute('style:name', $style->getStyleName());
+        $xmlWriter->writeAttribute('style:family', 'table-row');
+        $xmlWriter->startElement('style:table-row-properties');
+
+        if ($height !== null) {
+            $attribute = $style->isExactHeight() ? 'style:row-height' : 'style:min-row-height';
+            $xmlWriter->writeAttribute($attribute, $this->convertHeight($height));
+            if ($style->isExactHeight()) {
+                $xmlWriter->writeAttribute('style:use-optimal-row-height', 'false');
+            }
+        }
+
+        $xmlWriter->endElement(); // style:table-row-properties
+        $xmlWriter->endElement(); // style:style
+    }
+
+    private function convertHeight(int $height): string
+    {
+        $inches = (string) ($height / Converter::INCH_TO_TWIP) . 'in';
+        $centimeters = (string) ($height * Converter::INCH_TO_CM / Converter::INCH_TO_TWIP) . 'cm';
+
+        return strlen($inches) < strlen($centimeters) ? $inches : $centimeters;
+    }
+}

--- a/tests/PhpWordTests/Writer/ODText/Element/TableTest.php
+++ b/tests/PhpWordTests/Writer/ODText/Element/TableTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace PhpOffice\PhpWordTests\Writer\ODText\Element;
+
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWordTests\TestHelperDOCX;
+
+class TableTest extends \PHPUnit\Framework\TestCase
+{
+    protected function tearDown(): void
+    {
+        TestHelperDOCX::clear();
+    }
+
+    public function testWritesRowHeightsAndExactHeightAsAutomaticStyles(): void
+    {
+        $phpWord = new PhpWord();
+        $table = $phpWord->addSection()->addTable();
+
+        $table->addRow(720)->addCell()->addText('minimum');
+        $table->addRow(1440, ['exactHeight' => true])->addCell()->addText('exact');
+        $table->addRow(2880)->addCell()->addText('minimum');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+
+        $rows = [
+            [
+                'height' => '0.5in',
+                'exact' => null,
+            ],
+            [
+                'height' => '1in',
+                'exact' => 'false',
+            ],
+            [
+                'height' => '2in',
+                'exact' => null,
+            ],
+        ];
+
+        foreach ($rows as $index => $expected) {
+            $row = '/office:document-content/office:body/office:text/text:section/table:table/table:table-row[' . ($index + 1) . ']';
+            self::assertTrue($doc->hasElementAttribute($row, 'table:style-name'));
+
+            $styleName = $doc->getElementAttribute($row, 'table:style-name');
+            $style = "/office:document-content/office:automatic-styles/style:style[@style:name='{$styleName}']";
+            self::assertTrue($doc->elementExists($style));
+            self::assertEquals('table-row', $doc->getElementAttribute($style, 'style:family'));
+
+            $properties = $style . '/style:table-row-properties';
+            self::assertTrue($doc->elementExists($properties));
+            if ($expected['exact'] === null) {
+                self::assertEquals($expected['height'], $doc->getElementAttribute($properties, 'style:min-row-height'));
+                self::assertFalse($doc->hasElementAttribute($properties, 'style:row-height'));
+            } else {
+                self::assertEquals($expected['height'], $doc->getElementAttribute($properties, 'style:row-height'));
+                self::assertEquals($expected['exact'], $doc->getElementAttribute($properties, 'style:use-optimal-row-height'));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description

Adds native ODF serialization for existing PHPWord table row heights and exact-height semantics. Exact heights use style:row-height with style:use-optimal-row-height="false"; at-least heights use style:min-row-height.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code.
- [x] I have updated the documentation.
- [x] I have updated the changelog.

### Verification

- Focused ODText tests: 74 passed, 643 assertions.
- PHP CS Fixer sequential dry-run: passed.
- PHPMD: no violations reported.
- PHPStan with --debug --memory-limit=512M: passed.
