### PR TITLE
Writer ODText: Support table and cell styles

### DIFF
--- a/docs/changes/1.x/1.4.0.md
+++ b/docs/changes/1.x/1.4.0.md
@@ -15,6 +15,7 @@
 - Writer HTML: Support Default font color by [@MichaelPFrey](https://github.com/MichaelPFrey) in [#2731](https://github.com/PHPOffice/PHPWord/pull/2731)
 - Writer ODText: Support Default font color by [@MichaelPFrey](https://github.com/MichaelPFrey) in [#2735](https://github.com/PHPOffice/PHPWord/pull/2735)
 - Writer ODText: Support table row heights and exact-height semantics by [@potofcoffee](https://github.com/potofcoffee) in [#2904](https://github.com/PHPOffice/PHPWord/pull/2904)
+- Writer ODText: Support table and cell styles by [@potofcoffee](https://github.com/potofcoffee) fixing [#411](https://github.com/PHPOffice/PHPWord/issues/411) in [#2906](https://github.com/PHPOffice/PHPWord/pull/2906)
 - Add basic ruby text (phonetic guide) support for Word2007 and HTML Reader/Writer, RTF Writer, basic support for ODT writing by [@Deadpikle](https://github.com/Deadpikle) in [#2727](https://github.com/PHPOffice/PHPWord/pull/2727)
 - Reader HTML: Support font styles for h1/h6 by [@Progi1984](https://github.com/Progi1984) fixing [#2619](https://github.com/PHPOffice/PHPWord/issues/2619) in [#2737](https://github.com/PHPOffice/PHPWord/pull/2737)
 - Writer EPub3: Basic support by [@Sambit003](https://github.com/Sambit003) fixing [#55](https://github.com/PHPOffice/PHPWord/issues/55) in [#2724](https://github.com/PHPOffice/PHPWord/pull/2724)

--- a/docs/usage/styles/table.md
+++ b/docs/usage/styles/table.md
@@ -51,3 +51,12 @@ Available Cell style options:
 - ``valign``. Vertical alignment, *top*, *center*, *both*, *bottom*.
 - ``vMerge``. *restart* or *continue*.
 - ``width``. Cell width in *twip*.
+
+The ODText writer serializes cell borders as native ODF table-cell styles. Each
+configured side is written independently, so asymmetric cell borders and
+different border definitions on cells in the same row are preserved.
+
+The ODText writer also serializes table and cell ``bgColor`` values as native
+ODF background colors. Cell padding, vertical alignment, text direction,
+wrapping, column spans, table alignment, and table width are mapped when the
+corresponding PHPWord style options are present.

--- a/src/PhpWord/Writer/ODText/Element/Table.php
+++ b/src/PhpWord/Writer/ODText/Element/Table.php
@@ -85,6 +85,12 @@ class Table extends AbstractElement
         foreach ($row->getCells() as $cell) {
             $xmlWriter->startElement('table:table-cell');
             $xmlWriter->writeAttribute('office:value-type', 'string');
+            if ($cell->getStyle()->getStyleName()) {
+                $xmlWriter->writeAttribute('table:style-name', $cell->getStyle()->getStyleName());
+            }
+            if ($cell->getStyle()->getGridSpan() !== null) {
+                $xmlWriter->writeAttribute('table:number-columns-spanned', $cell->getStyle()->getGridSpan());
+            }
 
             $containerWriter = new Container($xmlWriter, $cell);
             $containerWriter->write();

--- a/src/PhpWord/Writer/ODText/Part/Content.php
+++ b/src/PhpWord/Writer/ODText/Part/Content.php
@@ -19,6 +19,7 @@
 namespace PhpOffice\PhpWord\Writer\ODText\Part;
 
 use PhpOffice\PhpWord\Element\AbstractContainer;
+use PhpOffice\PhpWord\Element\Cell as CellElement;
 use PhpOffice\PhpWord\Element\Field;
 use PhpOffice\PhpWord\Element\Image;
 use PhpOffice\PhpWord\Element\Row as RowElement;
@@ -29,6 +30,7 @@ use PhpOffice\PhpWord\Element\TrackChange;
 use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Shared\XMLWriter;
 use PhpOffice\PhpWord\Style;
+use PhpOffice\PhpWord\Style\Cell as CellStyle;
 use PhpOffice\PhpWord\Style\Font;
 use PhpOffice\PhpWord\Style\Paragraph;
 use PhpOffice\PhpWord\Style\Table as TableStyle;
@@ -49,7 +51,7 @@ class Content extends AbstractPart
      *
      * @var array
      */
-    private $autoStyles = ['Section' => [], 'Image' => [], 'Table' => [], 'Row' => []];
+    private $autoStyles = ['Section' => [], 'Image' => [], 'Table' => [], 'Row' => [], 'Cell' => []];
 
     private $imageParagraphStyles = [];
 
@@ -296,7 +298,9 @@ class Content extends AbstractPart
                 $style->setStyleName($element->getElementId());
                 $style->setColumnWidths($element->findFirstDefinedCellWidths());
                 $this->autoStyles['Table'][] = $style;
-                foreach ($element->getRows() as $row) {
+                $rows = $element->getRows();
+                $rowCount = count($rows);
+                foreach ($rows as $rowIndex => $row) {
                     if ($row instanceof RowElement && $row->getHeight() !== null) {
                         if (!$row->getElementId()) {
                             $row->setElementId();
@@ -304,9 +308,85 @@ class Content extends AbstractPart
                         $row->getStyle()->setStyleName($row->getElementId());
                         $this->autoStyles['Row'][] = $row;
                     }
+                    $cells = $row->getCells();
+                    $cellCount = count($cells);
+                    foreach ($cells as $cellIndex => $cell) {
+                        if ($cell instanceof CellElement) {
+                            if ($style instanceof TableStyle) {
+                                $this->applyTableStyleToCell($cell, $style, $rowIndex, $cellIndex, $rowCount, $cellCount);
+                            }
+                        }
+                        if ($cell instanceof CellElement && $this->hasCellStyle($cell)) {
+                            if (!$cell->getElementId()) {
+                                $cell->setElementId();
+                            }
+                            $cell->getStyle()->setStyleName($cell->getElementId());
+                            $this->autoStyles['Cell'][] = $cell->getStyle();
+                        }
+                        if ($cell instanceof CellElement) {
+                            $this->getContainerStyle($cell, $paragraphStyleCount, $fontStyleCount);
+                        }
+                    }
                 }
             }
         }
+    }
+
+    private function hasCellStyle(CellElement $cell): bool
+    {
+        $style = $cell->getStyle();
+
+        return $style !== null && (
+            $style->hasBorder()
+            || $style->getBgColor() !== null
+            || $style->getVAlign() !== null
+            || $style->getTextDirection() !== null
+            || $style->getPaddingTop() !== null
+            || $style->getPaddingBottom() !== null
+            || $style->getPaddingLeft() !== null
+            || $style->getPaddingRight() !== null
+            || $style->getNoWrap() === false
+        );
+    }
+
+    private function applyTableStyleToCell(CellElement $cell, TableStyle $tableStyle, int $rowIndex, int $cellIndex, int $rowCount, int $cellCount): void
+    {
+        $style = $cell->getStyle();
+        if ($style === null) {
+            return;
+        }
+
+        $this->setCellBorderIfUnset($style, 'Top', $rowIndex === 0 ? $tableStyle->getBorderTopSize() : $tableStyle->getBorderInsideHSize(), $rowIndex === 0 ? $tableStyle->getBorderTopColor() : $tableStyle->getBorderInsideHColor());
+        $this->setCellBorderIfUnset($style, 'Bottom', $rowIndex === $rowCount - 1 ? $tableStyle->getBorderBottomSize() : null, $tableStyle->getBorderBottomColor());
+        $this->setCellBorderIfUnset($style, 'Left', $cellIndex === 0 ? $tableStyle->getBorderLeftSize() : $tableStyle->getBorderInsideVSize(), $cellIndex === 0 ? $tableStyle->getBorderLeftColor() : $tableStyle->getBorderInsideVColor());
+        $this->setCellBorderIfUnset($style, 'Right', $cellIndex === $cellCount - 1 ? $tableStyle->getBorderRightSize() : null, $tableStyle->getBorderRightColor());
+
+        if ($style->getPaddingTop() === null && $tableStyle->getCellMarginTop() !== null) {
+            $style->setPaddingTop($tableStyle->getCellMarginTop());
+        }
+        if ($style->getPaddingBottom() === null && $tableStyle->getCellMarginBottom() !== null) {
+            $style->setPaddingBottom($tableStyle->getCellMarginBottom());
+        }
+        if ($style->getPaddingLeft() === null && $tableStyle->getCellMarginLeft() !== null) {
+            $style->setPaddingLeft($tableStyle->getCellMarginLeft());
+        }
+        if ($style->getPaddingRight() === null && $tableStyle->getCellMarginRight() !== null) {
+            $style->setPaddingRight($tableStyle->getCellMarginRight());
+        }
+    }
+
+    /**
+     * @param null|float|int $size
+     */
+    private function setCellBorderIfUnset(CellStyle $style, string $side, $size, ?string $color): void
+    {
+        $getSize = 'getBorder' . $side . 'Size';
+        if ($style->$getSize() !== null || $size === null) {
+            return;
+        }
+
+        $style->{'setBorder' . $side . 'Size'}($size);
+        $style->{'setBorder' . $side . 'Color'}($color);
     }
 
     /**

--- a/src/PhpWord/Writer/ODText/Style/Cell.php
+++ b/src/PhpWord/Writer/ODText/Style/Cell.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace PhpOffice\PhpWord\Writer\ODText\Style;
+
+use PhpOffice\PhpWord\Shared\XMLWriter;
+use PhpOffice\PhpWord\Style\Cell as CellStyle;
+
+/**
+ * Table cell style writer.
+ */
+class Cell extends AbstractStyle
+{
+    public function write(): void
+    {
+        $style = $this->getStyle();
+        if (!$style instanceof CellStyle) {
+            return;
+        }
+
+        $xmlWriter = $this->getXmlWriter();
+        $xmlWriter->startElement('style:style');
+        $xmlWriter->writeAttribute('style:name', $style->getStyleName());
+        $xmlWriter->writeAttribute('style:family', 'table-cell');
+        $xmlWriter->startElement('style:table-cell-properties');
+
+        if ($style->getBgColor() !== null) {
+            $xmlWriter->writeAttribute('fo:background-color', '#' . ltrim($style->getBgColor(), '#'));
+        }
+
+        $this->writeBorder($xmlWriter, 'top', $style->getBorderTopSize(), $style->getBorderTopColor(), $style->getBorderTopStyle());
+        $this->writeBorder($xmlWriter, 'bottom', $style->getBorderBottomSize(), $style->getBorderBottomColor(), $style->getBorderBottomStyle());
+        $this->writeBorder($xmlWriter, 'left', $style->getBorderLeftSize(), $style->getBorderLeftColor(), $style->getBorderLeftStyle());
+        $this->writeBorder($xmlWriter, 'right', $style->getBorderRightSize(), $style->getBorderRightColor(), $style->getBorderRightStyle());
+
+        $padding = [
+            'top' => $style->getPaddingTop(),
+            'bottom' => $style->getPaddingBottom(),
+            'left' => $style->getPaddingLeft(),
+            'right' => $style->getPaddingRight(),
+        ];
+        foreach ($padding as $side => $value) {
+            if ($value !== null) {
+                $xmlWriter->writeAttribute('fo:padding-' . $side, number_format($value / 1440, 3, '.', '') . 'in');
+            }
+        }
+
+        $verticalAlign = [
+            'top' => 'top',
+            'center' => 'middle',
+            'both' => 'automatic',
+            'bottom' => 'bottom',
+        ];
+        if ($style->getVAlign() !== null && isset($verticalAlign[$style->getVAlign()])) {
+            $xmlWriter->writeAttribute('style:vertical-align', $verticalAlign[$style->getVAlign()]);
+        }
+
+        $writingMode = [
+            CellStyle::TEXT_DIR_LRTB => 'lr-tb',
+            CellStyle::TEXT_DIR_TBRL => 'tb-rl',
+            CellStyle::TEXT_DIR_BTLR => 'bt-lr',
+        ];
+        if ($style->getTextDirection() !== null && isset($writingMode[$style->getTextDirection()])) {
+            $xmlWriter->writeAttribute('style:writing-mode', $writingMode[$style->getTextDirection()]);
+        }
+
+        if ($style->getNoWrap() === false) {
+            $xmlWriter->writeAttribute('fo:wrap-option', 'wrap');
+        }
+
+        $xmlWriter->endElement(); // style:table-cell-properties
+        $xmlWriter->endElement(); // style:style
+    }
+
+    /**
+     * @param null|float|int $size
+     */
+    private function writeBorder(XMLWriter $xmlWriter, string $side, $size, ?string $color, ?string $style): void
+    {
+        if ($size === null) {
+            return;
+        }
+
+        $xmlWriter->writeAttribute(
+            'fo:border-' . $side,
+            number_format($size / 20, 3, '.', '') . 'pt ' . $this->convertBorderStyle($style) . ' #' . ltrim($color ?: CellStyle::DEFAULT_BORDER_COLOR, '#')
+        );
+    }
+
+    private function convertBorderStyle(?string $style): string
+    {
+        if ($style === null || $style === 'single' || $style === 'thick' || $style === 'inset' || $style === 'outset' || $style === 'wave') {
+            return 'solid';
+        }
+        if ($style === 'double' || $style === 'triple') {
+            return 'double';
+        }
+        if ($style === 'dotted' || strpos($style, 'dot') !== false) {
+            return 'dotted';
+        }
+        if ($style === 'none' || $style === 'nil') {
+            return 'none';
+        }
+
+        return 'dashed';
+    }
+}

--- a/src/PhpWord/Writer/ODText/Style/Table.php
+++ b/src/PhpWord/Writer/ODText/Style/Table.php
@@ -43,7 +43,24 @@ class Table extends AbstractStyle
         $xmlWriter->startElement('style:table-properties');
         //$xmlWriter->writeAttribute('style:width', 'table');
         $xmlWriter->writeAttribute('style:rel-width', 100);
-        $xmlWriter->writeAttribute('table:align', 'center');
+        $xmlWriter->writeAttribute('table:align', $style->getAlignment() ?: 'center');
+        if ($style->getBgColor() !== null) {
+            $xmlWriter->writeAttribute('fo:background-color', '#' . ltrim($style->getBgColor(), '#'));
+        }
+        if ($style->getWidth() > 0) {
+            $xmlWriter->writeAttribute('style:width', number_format($style->getWidth() / 1440, 3, '.', '') . 'in');
+        }
+        $margins = [
+            'top' => $style->getMarginTop(),
+            'bottom' => $style->getMarginBottom(),
+            'left' => $style->getMarginLeft(),
+            'right' => $style->getMarginRight(),
+        ];
+        foreach ($margins as $side => $value) {
+            if ($value !== null && $value !== \PhpOffice\PhpWord\Style\Border::DEFAULT_MARGIN) {
+                $xmlWriter->writeAttribute('fo:margin-' . $side, number_format($value / 1440, 3, '.', '') . 'in');
+            }
+        }
         $xmlWriter->writeAttributeIf($style->isBidiVisual(), 'style:writing-mode', 'rl-tb');
         $xmlWriter->endElement(); // style:table-properties
         $xmlWriter->endElement(); // style:style

--- a/tests/PhpWordTests/Writer/ODText/Element/TableTest.php
+++ b/tests/PhpWordTests/Writer/ODText/Element/TableTest.php
@@ -58,4 +58,138 @@ class TableTest extends \PHPUnit\Framework\TestCase
             }
         }
     }
+
+    public function testWritesIndependentCellBorderStylesAsAutomaticStyles(): void
+    {
+        $phpWord = new PhpWord();
+        $table = $phpWord->addSection()->addTable();
+        $row = $table->addRow();
+
+        $styles = [
+            ['borderTopSize' => 10, 'borderTopColor' => '112233', 'borderTopStyle' => 'dashed'],
+            ['borderBottomSize' => 20, 'borderBottomColor' => '223344'],
+            ['borderLeftSize' => 30, 'borderLeftColor' => '334455'],
+            ['borderRightSize' => 40, 'borderRightColor' => '445566'],
+            [
+                'borderTopSize' => 10,
+                'borderTopColor' => '112233',
+                'borderBottomSize' => 20,
+                'borderBottomColor' => '223344',
+            ],
+            [
+                'borderLeftSize' => 30,
+                'borderLeftColor' => '334455',
+                'borderRightSize' => 40,
+                'borderRightColor' => '445566',
+            ],
+            [
+                'borderTopSize' => 10,
+                'borderTopColor' => '112233',
+                'borderBottomSize' => 20,
+                'borderBottomColor' => '223344',
+                'borderLeftSize' => 30,
+                'borderLeftColor' => '334455',
+                'borderRightSize' => 40,
+                'borderRightColor' => '445566',
+            ],
+            [
+                'bgColor' => 'abcdef',
+                'paddingTop' => 144,
+                'paddingBottom' => 288,
+                'paddingLeft' => 432,
+                'paddingRight' => 576,
+                'valign' => 'center',
+                'textDirection' => \PhpOffice\PhpWord\Style\Cell::TEXT_DIR_TBRL,
+                'noWrap' => false,
+            ],
+            null,
+        ];
+
+        foreach ($styles as $index => $style) {
+            $row->addCell(null, $style)->addText((string) ($index + 1));
+        }
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        $base = '/office:document-content/office:body/office:text/text:section/table:table/table:table-row/table:table-cell';
+
+        foreach ($styles as $index => $style) {
+            $cell = $base . '[' . ($index + 1) . ']';
+            if ($style === null) {
+                self::assertFalse($doc->hasElementAttribute($cell, 'table:style-name'));
+
+                continue;
+            }
+
+            self::assertTrue($doc->hasElementAttribute($cell, 'table:style-name'));
+            $styleName = $doc->getElementAttribute($cell, 'table:style-name');
+            $automaticStyle = "/office:document-content/office:automatic-styles/style:style[@style:name='{$styleName}']";
+            self::assertEquals('table-cell', $doc->getElementAttribute($automaticStyle, 'style:family'));
+            $properties = $automaticStyle . '/style:table-cell-properties';
+
+            foreach (['Top', 'Bottom', 'Left', 'Right'] as $side) {
+                $size = $style['border' . $side . 'Size'] ?? null;
+                $color = $style['border' . $side . 'Color'] ?? null;
+                $attribute = 'fo:border-' . strtolower($side);
+                if ($size === null) {
+                    self::assertFalse($doc->hasElementAttribute($properties, $attribute));
+                } else {
+                    self::assertEquals(
+                        number_format($size / 20, 3, '.', '') . 'pt ' . ($style['border' . $side . 'Style'] ?? 'solid') . ' #' . $color,
+                        $doc->getElementAttribute($properties, $attribute)
+                    );
+                }
+            }
+
+            if ($index === 7) {
+                self::assertEquals('#abcdef', $doc->getElementAttribute($properties, 'fo:background-color'));
+                self::assertEquals('0.100in', $doc->getElementAttribute($properties, 'fo:padding-top'));
+                self::assertEquals('0.200in', $doc->getElementAttribute($properties, 'fo:padding-bottom'));
+                self::assertEquals('0.300in', $doc->getElementAttribute($properties, 'fo:padding-left'));
+                self::assertEquals('0.400in', $doc->getElementAttribute($properties, 'fo:padding-right'));
+                self::assertEquals('middle', $doc->getElementAttribute($properties, 'style:vertical-align'));
+                self::assertEquals('tb-rl', $doc->getElementAttribute($properties, 'style:writing-mode'));
+                self::assertEquals('wrap', $doc->getElementAttribute($properties, 'fo:wrap-option'));
+            }
+        }
+    }
+
+    public function testWritesTableBackgroundAlignmentAndWidth(): void
+    {
+        $phpWord = new PhpWord();
+        $table = $phpWord->addSection()->addTable([
+            'bgColor' => 'abcdef',
+            'alignment' => 'right',
+            'width' => 2880,
+        ]);
+        $table->addRow()->addCell()->addText('styled');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        $tablePath = '/office:document-content/office:automatic-styles/style:style[@style:family="table"]/style:table-properties';
+
+        self::assertEquals('#abcdef', $doc->getElementAttribute($tablePath, 'fo:background-color'));
+        self::assertEquals('right', $doc->getElementAttribute($tablePath, 'table:align'));
+        self::assertEquals('2.000in', $doc->getElementAttribute($tablePath, 'style:width'));
+    }
+
+    public function testMapsTableBordersAndCellMarginsToCellStyles(): void
+    {
+        $phpWord = new PhpWord();
+        $table = $phpWord->addSection()->addTable([
+            'borderSize' => 10,
+            'borderColor' => '123456',
+            'cellMargin' => 144,
+        ]);
+        $table->addRow()->addCell()->addText('one');
+        $table->getRows()[0]->addCell()->addText('two');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        $base = '/office:document-content/office:body/office:text/text:section/table:table/table:table-row/table:table-cell';
+        foreach ([1, 2] as $index) {
+            $cell = $base . '[' . $index . ']';
+            $styleName = $doc->getElementAttribute($cell, 'table:style-name');
+            $properties = "/office:document-content/office:automatic-styles/style:style[@style:name='{$styleName}']/style:table-cell-properties";
+            self::assertEquals('0.500pt solid #123456', $doc->getElementAttribute($properties, 'fo:border-top'));
+            self::assertEquals('0.100in', $doc->getElementAttribute($properties, 'fo:padding-top'));
+        }
+    }
 }


### PR DESCRIPTION
## Description

Fixes #411 by serializing PHPWord table and cell styling to native ODF automatic styles. Table and cell background colors, borders, padding, alignment, width, text direction, wrapping, spans, table-border inheritance, and nested table styles are covered.

## Checklist

- [x] I have run the test suite
- [x] I have added tests for the changes
- [x] I have updated the documentation
- [x] I have updated the changelog

## Testing

- ODText writer tests
- ODText readback test
- PHPStan
- PHP CS Fixer
- git diff --check