### PR TITLE
Writer ODText: Support native line drawings

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -9,6 +9,7 @@
 - Writer ODText: Serialize comments as native ODF annotations by [@potofcoffee](https://github.com/potofcoffee) fixing [#2921](https://github.com/PHPOffice/PHPWord/issues/2921) in [#2922](https://github.com/PHPOffice/PHPWord/pull/2922)
 - Writer ODText: Support native shapes, text boxes, and watermarks by [@potofcoffee](https://github.com/potofcoffee) fixing [#2909](https://github.com/PHPOffice/PHPWord/issues/2909) in [#2910](https://github.com/PHPOffice/PHPWord/pull/2910)
 - Writer ODText: Support native form controls by [@potofcoffee](https://github.com/potofcoffee) fixing [#2925](https://github.com/PHPOffice/PHPWord/issues/2925) in [#2926](https://github.com/PHPOffice/PHPWord/pull/2926)
+- Writer ODText: Support native line drawings by [@potofcoffee](https://github.com/potofcoffee) fixing [#2907](https://github.com/PHPOffice/PHPWord/issues/2907) in [#2908](https://github.com/PHPOffice/PHPWord/pull/2908)
 
 ### Bug fixes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ Below are the supported features for each file formats.
 |                           | List                 | :material-check: | :material-check: |       |        |       |
 |                           | Table                | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
 |                           | Image                | :material-check: | :material-check: | :material-check: | :material-check: |       |
+|                           | Line                 | :material-check: | :material-check: |       |        |       |
 |                           | Object               | :material-check: |       |       |        |       |
 |                           | Watermark            | :material-check: | :material-check: |       |        |       |
 |                           | Table of Contents    | :material-check: |       |       |        |       |

--- a/src/PhpWord/Writer/ODText/Element/Line.php
+++ b/src/PhpWord/Writer/ODText/Element/Line.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @license http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\ODText\Element;
+
+use PhpOffice\PhpWord\Element\Line as LineElement;
+use PhpOffice\PhpWord\Shared\Converter;
+use PhpOffice\PhpWord\Style\Line as LineStyle;
+
+/**
+ * Line element writer.
+ */
+class Line extends AbstractElement
+{
+    public function write(): void
+    {
+        $element = $this->getElement();
+        if (!$element instanceof LineElement) {
+            return;
+        }
+
+        $style = $element->getStyle() ?: new LineStyle();
+        if (!$style->getStyleName()) {
+            $style->setStyleName($element->getElementId());
+        }
+        $width = $style->getWidth() ?? 0;
+        $height = $style->getHeight() ?? 0;
+        $left = $style->getMarginLeft();
+        $top = $style->getMarginTop();
+        $x1 = $left;
+        $y1 = $top;
+        $x2 = $left + $width;
+        $y2 = $top + $height;
+        if ($style->isFlip()) {
+            [$x1, $x2] = [$x2, $x1];
+            [$y1, $y2] = [$y2, $y1];
+        }
+
+        $xmlWriter = $this->getXmlWriter();
+        if (!$this->withoutP) {
+            $xmlWriter->startElement('text:p');
+        }
+        $xmlWriter->startElement('draw:line');
+        $xmlWriter->writeAttribute('draw:style-name', $style->getStyleName());
+        $xmlWriter->writeAttribute('svg:x1', Converter::pointToCm($x1) . 'cm');
+        $xmlWriter->writeAttribute('svg:y1', Converter::pointToCm($y1) . 'cm');
+        $xmlWriter->writeAttribute('svg:x2', Converter::pointToCm($x2) . 'cm');
+        $xmlWriter->writeAttribute('svg:y2', Converter::pointToCm($y2) . 'cm');
+        $xmlWriter->endElement(); // draw:line
+        if (!$this->withoutP) {
+            $xmlWriter->endElement(); // text:p
+        }
+    }
+}

--- a/src/PhpWord/Writer/ODText/Part/Content.php
+++ b/src/PhpWord/Writer/ODText/Part/Content.php
@@ -24,6 +24,7 @@ use PhpOffice\PhpWord\Element\CheckBox;
 use PhpOffice\PhpWord\Element\Field;
 use PhpOffice\PhpWord\Element\FormField;
 use PhpOffice\PhpWord\Element\Image;
+use PhpOffice\PhpWord\Element\Line;
 use PhpOffice\PhpWord\Element\Row as RowElement;
 use PhpOffice\PhpWord\Element\Shape;
 use PhpOffice\PhpWord\Element\Table;
@@ -36,6 +37,7 @@ use PhpOffice\PhpWord\Shared\XMLWriter;
 use PhpOffice\PhpWord\Style;
 use PhpOffice\PhpWord\Style\Cell as CellStyle;
 use PhpOffice\PhpWord\Style\Font;
+use PhpOffice\PhpWord\Style\Line as LineStyle;
 use PhpOffice\PhpWord\Style\Paragraph;
 use PhpOffice\PhpWord\Style\Table as TableStyle;
 use PhpOffice\PhpWord\Writer\ODText\Element\Container;
@@ -43,6 +45,8 @@ use PhpOffice\PhpWord\Writer\ODText\Style\Paragraph as ParagraphStyleWriter;
 
 /**
  * ODText content part writer: content.xml.
+ *
+ * @SuppressWarnings("PHPMD.CouplingBetweenObjects")
  */
 class Content extends AbstractPart
 {
@@ -55,7 +59,7 @@ class Content extends AbstractPart
      *
      * @var array
      */
-    private $autoStyles = ['Section' => [], 'Image' => [], 'Table' => [], 'Row' => [], 'Cell' => [], 'Shape' => [], 'TextBox' => []];
+    private $autoStyles = ['Section' => [], 'Image' => [], 'Line' => [], 'Table' => [], 'Row' => [], 'Cell' => [], 'Shape' => [], 'TextBox' => []];
 
     private $imageParagraphStyles = [];
 
@@ -306,6 +310,13 @@ class Content extends AbstractPart
                 $style->setStyleName('tb' . $element->getElementId());
                 $this->autoStyles['TextBox'][] = $style;
                 $this->getContainerStyle($element, $paragraphStyleCount, $fontStyleCount);
+            } elseif ($element instanceof Line) {
+                if (!$element->getElementId()) {
+                    $element->setElementId();
+                }
+                $style = $element->getStyle() ?: new LineStyle();
+                $style->setStyleName($element->getElementId());
+                $this->autoStyles['Line'][] = $style;
             } elseif ($element instanceof Table) {
                 $style = $element->getStyle();
                 if (is_string($style)) {

--- a/src/PhpWord/Writer/ODText/Style/Line.php
+++ b/src/PhpWord/Writer/ODText/Style/Line.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @license http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\ODText\Style;
+
+use PhpOffice\PhpWord\Style\Line as LineStyle;
+
+/**
+ * Line style writer.
+ */
+class Line extends AbstractStyle
+{
+    public function write(): void
+    {
+        $style = $this->getStyle();
+        if (!$style instanceof LineStyle) {
+            return;
+        }
+
+        $xmlWriter = $this->getXmlWriter();
+        $xmlWriter->startElement('style:style');
+        $xmlWriter->writeAttribute('style:name', $style->getStyleName());
+        $xmlWriter->writeAttribute('style:family', 'graphic');
+        $xmlWriter->writeAttribute('style:parent-style-name', 'Graphics');
+        $xmlWriter->startElement('style:graphic-properties');
+        $xmlWriter->writeAttribute('draw:stroke', 'solid');
+        if ($style->getColor() !== null) {
+            $xmlWriter->writeAttribute('svg:stroke-color', '#' . ltrim($style->getColor(), '#'));
+        }
+        $xmlWriter->writeAttributeIf($style->getWeight() !== null, 'svg:stroke-width', $style->getWeight() . 'pt');
+        $xmlWriter->endElement(); // style:graphic-properties
+        $xmlWriter->endElement(); // style:style
+    }
+}

--- a/tests/PhpWordTests/Writer/ODText/Element/LineTest.php
+++ b/tests/PhpWordTests/Writer/ODText/Element/LineTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @license http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWordTests\Writer\ODText\Element;
+
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Shared\Converter;
+use PhpOffice\PhpWordTests\TestHelperDOCX;
+
+/**
+ * Test class for PhpOffice\PhpWord\Writer\ODText\Element\Line.
+ */
+class LineTest extends \PHPUnit\Framework\TestCase
+{
+    protected function tearDown(): void
+    {
+        TestHelperDOCX::clear();
+    }
+
+    public function testLineIsWrittenAsNativeOdfDrawing(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $section->addLine([
+            'width' => 100,
+            'height' => 20,
+            'marginLeft' => 10,
+            'marginTop' => 5,
+            'color' => '336699',
+            'weight' => 2,
+        ]);
+        $section->addLine([
+            'width' => 40,
+            'height' => 0,
+            'color' => '993300',
+            'weight' => 1,
+        ]);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        $line = '/office:document-content/office:body/office:text/text:section/text:p[2]/draw:line';
+
+        self::assertTrue($doc->elementExists($line));
+        self::assertEquals(Converter::pointToCm(10) . 'cm', $doc->getElementAttribute($line, 'svg:x1'));
+        self::assertEquals(Converter::pointToCm(5) . 'cm', $doc->getElementAttribute($line, 'svg:y1'));
+        self::assertEquals(Converter::pointToCm(110) . 'cm', $doc->getElementAttribute($line, 'svg:x2'));
+        self::assertEquals(Converter::pointToCm(25) . 'cm', $doc->getElementAttribute($line, 'svg:y2'));
+
+        $styleName = $doc->getElementAttribute($line, 'draw:style-name');
+        self::assertNotEmpty($styleName);
+        $style = "/office:document-content/office:automatic-styles/style:style[@style:name='{$styleName}']";
+        self::assertEquals('graphic', $doc->getElementAttribute($style, 'style:family'));
+        self::assertEquals('solid', $doc->getElementAttribute($style . '/style:graphic-properties', 'draw:stroke'));
+        self::assertEquals('#336699', $doc->getElementAttribute($style . '/style:graphic-properties', 'svg:stroke-color'));
+        self::assertEquals('2pt', $doc->getElementAttribute($style . '/style:graphic-properties', 'svg:stroke-width'));
+
+        $secondLine = '/office:document-content/office:body/office:text/text:section/text:p[3]/draw:line';
+        $secondStyleName = $doc->getElementAttribute($secondLine, 'draw:style-name');
+        self::assertNotSame($styleName, $secondStyleName);
+        $secondStyle = "/office:document-content/office:automatic-styles/style:style[@style:name='{$secondStyleName}']";
+        self::assertEquals('#993300', $doc->getElementAttribute($secondStyle . '/style:graphic-properties', 'svg:stroke-color'));
+        self::assertEquals('1pt', $doc->getElementAttribute($secondStyle . '/style:graphic-properties', 'svg:stroke-width'));
+    }
+
+    public function testDefaultLineIsWritten(): void
+    {
+        $phpWord = new PhpWord();
+        $phpWord->addSection()->addLine();
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+
+        self::assertTrue($doc->elementExists('/office:document-content/office:body/office:text/text:section/text:p[2]/draw:line'));
+    }
+}

--- a/tests/PhpWordTests/Writer/ODText/ElementTest.php
+++ b/tests/PhpWordTests/Writer/ODText/ElementTest.php
@@ -44,7 +44,7 @@ class ElementTest extends \PHPUnit\Framework\TestCase
      */
     public function testUnmatchedElements(): void
     {
-        $elements = ['Image', 'Link', 'Table', 'Text', 'Title', 'Field'];
+        $elements = ['Image', 'Line', 'Link', 'Table', 'Text', 'Title', 'Field'];
         foreach ($elements as $element) {
             $objectClass = 'PhpOffice\\PhpWord\\Writer\\ODText\\Element\\' . $element;
             $xmlWriter = new XMLWriter();


### PR DESCRIPTION
Fixes #2907

## Summary

PHPWord\Element\Line was silently dropped by the ODText writer. This PR serializes lines as native ODF `draw:line` elements.

## Native ODF mapping

- line coordinates use `svg:x1`, `svg:y1`, `svg:x2`, and `svg:y2` in centimetres;
- stroke settings use an automatic `style:family="graphic"` style;
- color and width map to `svg:stroke-color` and `svg:stroke-width`;
- unsupported generic shape semantics remain out of scope.

## Tests

- generated `content.xml` tests cover default lines, coordinates, multiple styles, color, and width;
- ODText test suite passes.

## Documentation

- ODF writer feature matrix and changelog updated.

## Checklist

- [x] CI is green
- [x] Unit tests cover the new code
- [x] Documentation updated
- [x] Changelog updated,