### PR TITLE
Writer ODText: support native drawing elements

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -7,6 +7,7 @@
 - MPDF Writer : Make the mPDF temporary directory configurable via the `tempDir` PDF renderer option, defaulting to the system temporary directory by [@danielwirz](https://github.com/danielwirz) in [#2898](https://github.com/PHPOffice/PHPWord/pull/2898)
 - GD extension is now optional by [@andrew-demb](https://github.com/andrew-demb) fixing [#2789] in [#2902](https://github.com/PHPOffice/PHPWord/pull/2902)
 - Writer ODText: Serialize comments as native ODF annotations by [@potofcoffee](https://github.com/potofcoffee) fixing [#2921](https://github.com/PHPOffice/PHPWord/issues/2921) in [#2922](https://github.com/PHPOffice/PHPWord/pull/2922)
+- Writer ODText: Support native shapes, text boxes, and watermarks by [@potofcoffee](https://github.com/potofcoffee) fixing [#2909](https://github.com/PHPOffice/PHPWord/issues/2909) in [#2910](https://github.com/PHPOffice/PHPWord/pull/2910)
 
 ### Bug fixes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ Below are the supported features for each file formats.
 |                           | Table                | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
 |                           | Image                | :material-check: | :material-check: | :material-check: | :material-check: |       |
 |                           | Object               | :material-check: |       |       |        |       |
-|                           | Watermark            | :material-check: |       |       |        |       |
+|                           | Watermark            | :material-check: | :material-check: |       |        |       |
 |                           | Table of Contents    | :material-check: |       |       |        |       |
 |                           | Header               | :material-check: |       |       |        |       |
 |                           | Footer               | :material-check: |       |       |        |       |

--- a/docs/usage/elements/textbox.md
+++ b/docs/usage/elements/textbox.md
@@ -1,3 +1,19 @@
 # TextBox
 
-To Be Completed... 
+The ODText writer serializes text boxes as native ODF drawing frames. The
+frame preserves supported dimensions, background and border colors, inner
+margins, and rich text content:
+
+```php
+$textBox = $section->addTextBox([
+    'width' => 400,
+    'height' => 150,
+    'bgColor' => '#eeeeee',
+    'borderSize' => 1,
+    'borderColor' => '#333333',
+]);
+$textBox->addText('Text box content.');
+```
+
+The generated ODF uses `draw:frame` with a nested `draw:text-box`. Positioning
+options that have no direct standard ODF equivalent are not approximated.

--- a/docs/usage/elements/watermark.md
+++ b/docs/usage/elements/watermark.md
@@ -11,3 +11,8 @@ $section = $phpWord->addSection();
 $header = $section->addHeader();
 $header->addWatermark('resources/_earth.jpg', array('marginTop' => 200, 'marginLeft' => 55));
 ```
+
+The ODText writer preserves the watermark image in the section's ODF master
+page header as a page-anchored drawing frame, including its size and margins.
+ODF master-page headers provide the native background-like placement; exact
+WordprocessingML layering semantics are not portable across ODF consumers.

--- a/src/PhpWord/Writer/ODText/Element/Image.php
+++ b/src/PhpWord/Writer/ODText/Element/Image.php
@@ -56,10 +56,16 @@ class Image extends AbstractElement
         $xmlWriter->writeAttribute('draw:style-name', 'fr' . $mediaIndex);
         $xmlWriter->writeAttributeIf($this->withoutP, 'draw:text-style-name', 'IM' . $mediaIndex);
         $xmlWriter->writeAttribute('draw:name', $element->getElementId());
-        $xmlWriter->writeAttribute('text:anchor-type', 'as-char');
+        $xmlWriter->writeAttribute('text:anchor-type', $element->isWatermark() ? 'at-page' : 'as-char');
         $xmlWriter->writeAttribute('svg:width', $width . 'cm');
         $xmlWriter->writeAttribute('svg:height', $height . 'cm');
-        $xmlWriter->writeAttribute('draw:z-index', $mediaIndex);
+        if ($element->isWatermark()) {
+            $xmlWriter->writeAttributeIf($style->getLeft() != 0, 'svg:x', Converter::pixelToCm($style->getLeft()) . 'cm');
+            $xmlWriter->writeAttributeIf($style->getTop() != 0, 'svg:y', Converter::pixelToCm($style->getTop()) . 'cm');
+            $xmlWriter->writeAttribute('draw:z-index', '-1');
+        } else {
+            $xmlWriter->writeAttribute('draw:z-index', $mediaIndex);
+        }
 
         $xmlWriter->startElement('draw:image');
         $xmlWriter->writeAttribute('xlink:href', $target);

--- a/src/PhpWord/Writer/ODText/Element/Shape.php
+++ b/src/PhpWord/Writer/ODText/Element/Shape.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\ODText\Element;
+
+use PhpOffice\PhpWord\Element\Shape as ShapeElement;
+use PhpOffice\PhpWord\Writer\ODText\Style\Graphic;
+
+/**
+ * Basic ODF shape element writer.
+ */
+class Shape extends AbstractElement
+{
+    public function write(): void
+    {
+        $element = $this->getElement();
+        if (!$element instanceof ShapeElement || !in_array($element->getType(), ['rect', 'oval', 'polyline'], true)) {
+            return;
+        }
+
+        $xmlWriter = $this->getXmlWriter();
+        $style = $element->getStyle();
+        $name = $element->getType() === 'oval' ? 'draw:ellipse' : 'draw:' . $element->getType();
+        $xmlWriter->startElement($name);
+        $xmlWriter->writeAttribute('draw:style-name', $style->getStyleName());
+        $xmlWriter->writeAttribute('text:anchor-type', 'as-char');
+        if ($style->getFrame() !== null) {
+            Graphic::writeFrameProperties($xmlWriter, $style->getFrame());
+        }
+        if ($element->getType() === 'polyline') {
+            $xmlWriter->writeAttributeIf($style->getPoints() !== null, 'draw:points', $style->getPoints());
+        }
+        $xmlWriter->endElement();
+    }
+}

--- a/src/PhpWord/Writer/ODText/Element/TextBox.php
+++ b/src/PhpWord/Writer/ODText/Element/TextBox.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\ODText\Element;
+
+use PhpOffice\PhpWord\Element\TextBox as TextBoxElement;
+use PhpOffice\PhpWord\Writer\ODText\Style\Graphic;
+
+/**
+ * ODF text box element writer.
+ */
+class TextBox extends AbstractElement
+{
+    public function write(): void
+    {
+        $element = $this->getElement();
+        if (!$element instanceof TextBoxElement) {
+            return;
+        }
+
+        $xmlWriter = $this->getXmlWriter();
+        $style = $element->getStyle();
+        $xmlWriter->startElement('draw:frame');
+        $xmlWriter->writeAttribute('draw:style-name', $style->getStyleName());
+        $xmlWriter->writeAttribute('draw:name', $element->getElementId());
+        $xmlWriter->writeAttribute('text:anchor-type', 'as-char');
+        Graphic::writeFrameProperties($xmlWriter, $style);
+        $xmlWriter->startElement('draw:text-box');
+        $container = new Container($xmlWriter, $element);
+        $container->setPart($this->getPart());
+        $container->write();
+        $xmlWriter->endElement();
+        $xmlWriter->endElement();
+    }
+}

--- a/src/PhpWord/Writer/ODText/Part/Content.php
+++ b/src/PhpWord/Writer/ODText/Part/Content.php
@@ -23,8 +23,10 @@ use PhpOffice\PhpWord\Element\Cell as CellElement;
 use PhpOffice\PhpWord\Element\Field;
 use PhpOffice\PhpWord\Element\Image;
 use PhpOffice\PhpWord\Element\Row as RowElement;
+use PhpOffice\PhpWord\Element\Shape;
 use PhpOffice\PhpWord\Element\Table;
 use PhpOffice\PhpWord\Element\Text;
+use PhpOffice\PhpWord\Element\TextBox;
 use PhpOffice\PhpWord\Element\TextRun;
 use PhpOffice\PhpWord\Element\TrackChange;
 use PhpOffice\PhpWord\PhpWord;
@@ -51,7 +53,7 @@ class Content extends AbstractPart
      *
      * @var array
      */
-    private $autoStyles = ['Section' => [], 'Image' => [], 'Table' => [], 'Row' => [], 'Cell' => []];
+    private $autoStyles = ['Section' => [], 'Image' => [], 'Table' => [], 'Row' => [], 'Cell' => [], 'Shape' => [], 'TextBox' => []];
 
     private $imageParagraphStyles = [];
 
@@ -287,6 +289,15 @@ class Content extends AbstractPart
                 $sty->setAuto();
                 $sty->setAlignment($style->getAlignment());
                 $this->imageParagraphStyles[] = $sty;
+            } elseif ($element instanceof Shape) {
+                $style = $element->getStyle();
+                $style->setStyleName('sh' . $element->getElementId());
+                $this->autoStyles['Shape'][] = $style;
+            } elseif ($element instanceof TextBox) {
+                $style = $element->getStyle();
+                $style->setStyleName('tb' . $element->getElementId());
+                $this->autoStyles['TextBox'][] = $style;
+                $this->getContainerStyle($element, $paragraphStyleCount, $fontStyleCount);
             } elseif ($element instanceof Table) {
                 $style = $element->getStyle();
                 if (is_string($style)) {

--- a/src/PhpWord/Writer/ODText/Style/Graphic.php
+++ b/src/PhpWord/Writer/ODText/Style/Graphic.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation.
+ */
+
+namespace PhpOffice\PhpWord\Writer\ODText\Style;
+
+use PhpOffice\PhpWord\Shared\Converter;
+use PhpOffice\PhpWord\Shared\XMLWriter;
+use PhpOffice\PhpWord\Style\Fill;
+use PhpOffice\PhpWord\Style\Frame;
+use PhpOffice\PhpWord\Style\Outline;
+
+/**
+ * Shared ODF graphic property helpers.
+ */
+class Graphic
+{
+    /**
+     * Write the ODF geometry for a frame-like element.
+     */
+    public static function writeFrameProperties(XMLWriter $xmlWriter, Frame $style): void
+    {
+        $unit = $style->getUnit();
+        $convert = $unit === Frame::UNIT_PX ? 'pixelToCm' : 'pointToCm';
+        $xmlWriter->writeAttributeIf($style->getWidth() !== null, 'svg:width', Converter::$convert($style->getWidth()) . 'cm');
+        $xmlWriter->writeAttributeIf($style->getHeight() !== null, 'svg:height', Converter::$convert($style->getHeight()) . 'cm');
+        $xmlWriter->writeAttributeIf($style->getLeft() !== null && $style->getLeft() != 0, 'svg:x', Converter::$convert($style->getLeft()) . 'cm');
+        $xmlWriter->writeAttributeIf($style->getTop() !== null && $style->getTop() != 0, 'svg:y', Converter::$convert($style->getTop()) . 'cm');
+    }
+
+    /**
+     * Write standard ODF fill and stroke properties.
+     */
+    public static function writeFillAndStroke(XMLWriter $xmlWriter, ?Fill $fill = null, ?Outline $outline = null): void
+    {
+        if ($fill !== null && $fill->getColor() !== null) {
+            $xmlWriter->writeAttribute('draw:fill', 'solid');
+            $xmlWriter->writeAttribute('draw:fill-color', '#' . ltrim($fill->getColor(), '#'));
+        } else {
+            $xmlWriter->writeAttribute('draw:fill', 'none');
+        }
+
+        if ($outline !== null && $outline->getColor() !== null) {
+            $xmlWriter->writeAttribute('draw:stroke', 'solid');
+            $xmlWriter->writeAttribute('svg:stroke-color', '#' . ltrim($outline->getColor(), '#'));
+            $xmlWriter->writeAttributeIf($outline->getWeight() !== null, 'svg:stroke-width', $outline->getWeight() . $outline->getUnit());
+        } else {
+            $xmlWriter->writeAttribute('draw:stroke', 'none');
+        }
+    }
+}

--- a/src/PhpWord/Writer/ODText/Style/Shape.php
+++ b/src/PhpWord/Writer/ODText/Style/Shape.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\ODText\Style;
+
+/**
+ * Shape graphic style writer.
+ */
+class Shape extends AbstractStyle
+{
+    public function write(): void
+    {
+        $style = $this->getStyle();
+        if (!$style instanceof \PhpOffice\PhpWord\Style\Shape) {
+            return;
+        }
+
+        $xmlWriter = $this->getXmlWriter();
+        $xmlWriter->startElement('style:style');
+        $xmlWriter->writeAttribute('style:name', $style->getStyleName());
+        $xmlWriter->writeAttribute('style:family', 'graphic');
+        $xmlWriter->startElement('style:graphic-properties');
+        Graphic::writeFillAndStroke($xmlWriter, $style->getFill(), $style->getOutline());
+        $xmlWriter->endElement();
+        $xmlWriter->endElement();
+    }
+}

--- a/src/PhpWord/Writer/ODText/Style/TextBox.php
+++ b/src/PhpWord/Writer/ODText/Style/TextBox.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\ODText\Style;
+
+use PhpOffice\PhpWord\Shared\Converter;
+
+/**
+ * Text box graphic style writer.
+ */
+class TextBox extends AbstractStyle
+{
+    public function write(): void
+    {
+        $style = $this->getStyle();
+        if (!$style instanceof \PhpOffice\PhpWord\Style\TextBox) {
+            return;
+        }
+
+        $xmlWriter = $this->getXmlWriter();
+        $xmlWriter->startElement('style:style');
+        $xmlWriter->writeAttribute('style:name', $style->getStyleName());
+        $xmlWriter->writeAttribute('style:family', 'graphic');
+        $xmlWriter->startElement('style:graphic-properties');
+        Graphic::writeFillAndStroke($xmlWriter, $style->getBgColor() === null ? null : new \PhpOffice\PhpWord\Style\Fill(['color' => $style->getBgColor()]), $style->getBorderColor() === null ? null : new \PhpOffice\PhpWord\Style\Outline(['weight' => $style->getBorderSize(), 'color' => $style->getBorderColor()]));
+        if ($style->hasInnerMargins()) {
+            $margins = $style->getInnerMargin();
+            $padding = [];
+            foreach ([$margins[1], $margins[2], $margins[3], $margins[0]] as $margin) {
+                $padding[] = Converter::pointToCm($margin / 20) . 'cm';
+            }
+            $xmlWriter->writeAttribute('fo:padding', implode(' ', $padding));
+        }
+        $xmlWriter->endElement();
+        $xmlWriter->endElement();
+    }
+}

--- a/tests/PhpWordTests/Writer/ODText/Element/ShapeTest.php
+++ b/tests/PhpWordTests/Writer/ODText/Element/ShapeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PhpOffice\PhpWordTests\Writer\ODText\Element;
+
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Shared\Converter;
+use PhpOffice\PhpWordTests\TestHelperDOCX;
+
+class ShapeTest extends \PHPUnit\Framework\TestCase
+{
+    protected function tearDown(): void
+    {
+        TestHelperDOCX::clear();
+    }
+
+    public function testBasicShapesUseNativeOdfElementsAndGraphicStyles(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $section->addShape('rect', [
+            'frame' => ['width' => 100, 'height' => 50, 'left' => 4, 'top' => 6],
+            'fill' => ['color' => '#ffcc33'],
+            'outline' => ['color' => '#990000', 'weight' => 2],
+        ]);
+        $section->addShape('oval', ['frame' => ['width' => 80, 'height' => 40]]);
+        $section->addShape('polyline', ['points' => '1,2 3,4']);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        $root = '/office:document-content/office:body/office:text/text:section';
+
+        $rect = $root . '/draw:rect[1]';
+        self::assertTrue($doc->elementExists($rect));
+        self::assertEquals(Converter::pointToCm(100) . 'cm', $doc->getElementAttribute($rect, 'svg:width'));
+        self::assertEquals(Converter::pointToCm(50) . 'cm', $doc->getElementAttribute($rect, 'svg:height'));
+        self::assertEquals(Converter::pointToCm(4) . 'cm', $doc->getElementAttribute($rect, 'svg:x'));
+        self::assertEquals(Converter::pointToCm(6) . 'cm', $doc->getElementAttribute($rect, 'svg:y'));
+
+        $styleName = $doc->getElementAttribute($rect, 'draw:style-name');
+        $style = "/office:document-content/office:automatic-styles/style:style[@style:name='{$styleName}']/style:graphic-properties";
+        self::assertEquals('solid', $doc->getElementAttribute($style, 'draw:fill'));
+        self::assertEquals('#ffcc33', $doc->getElementAttribute($style, 'draw:fill-color'));
+        self::assertEquals('solid', $doc->getElementAttribute($style, 'draw:stroke'));
+        self::assertEquals('#990000', $doc->getElementAttribute($style, 'svg:stroke-color'));
+        self::assertEquals('2pt', $doc->getElementAttribute($style, 'svg:stroke-width'));
+
+        self::assertTrue($doc->elementExists($root . '/draw:ellipse[1]'));
+        $polyline = $root . '/draw:polyline[1]';
+        self::assertEquals('1,2 3,4', $doc->getElementAttribute($polyline, 'draw:points'));
+    }
+}

--- a/tests/PhpWordTests/Writer/ODText/Element/TextBoxTest.php
+++ b/tests/PhpWordTests/Writer/ODText/Element/TextBoxTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace PhpOffice\PhpWordTests\Writer\ODText\Element;
+
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWordTests\TestHelperDOCX;
+
+class TextBoxTest extends \PHPUnit\Framework\TestCase
+{
+    protected function tearDown(): void
+    {
+        TestHelperDOCX::clear();
+    }
+
+    public function testTextBoxContainsNativeRichTextContentAndGraphicProperties(): void
+    {
+        $phpWord = new PhpWord();
+        $textBox = $phpWord->addSection()->addTextBox([
+            'width' => 200,
+            'height' => 100,
+            'bgColor' => '#eeeeee',
+            'borderSize' => 1,
+            'borderColor' => '#333333',
+            'innerMargin' => 100,
+        ]);
+        $textBox->addText('Plain text');
+        $run = $textBox->addTextRun();
+        $run->addText('Bold text', ['bold' => true]);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        $root = '/office:document-content/office:body/office:text/text:section';
+        $frame = $root . '/draw:frame[1]';
+
+        self::assertTrue($doc->elementExists($frame . '/draw:text-box/text:p[1]'));
+        self::assertEquals('Plain text', $doc->getElement($frame . '/draw:text-box/text:p[1]/text:span')->textContent);
+        self::assertEquals('Bold text', $doc->getElement($frame . '/draw:text-box/text:p[2]/text:span')->textContent);
+
+        $styleName = $doc->getElementAttribute($frame, 'draw:style-name');
+        $properties = "/office:document-content/office:automatic-styles/style:style[@style:name='{$styleName}']/style:graphic-properties";
+        self::assertEquals('solid', $doc->getElementAttribute($properties, 'draw:fill'));
+        self::assertEquals('#eeeeee', $doc->getElementAttribute($properties, 'draw:fill-color'));
+        self::assertEquals('#333333', $doc->getElementAttribute($properties, 'svg:stroke-color'));
+        self::assertNotEmpty($doc->getElementAttribute($properties, 'fo:padding'));
+    }
+}

--- a/tests/PhpWordTests/Writer/ODText/Element/WatermarkTest.php
+++ b/tests/PhpWordTests/Writer/ODText/Element/WatermarkTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PhpOffice\PhpWordTests\Writer\ODText\Element;
+
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWordTests\TestHelperDOCX;
+
+class WatermarkTest extends \PHPUnit\Framework\TestCase
+{
+    protected function tearDown(): void
+    {
+        TestHelperDOCX::clear();
+    }
+
+    public function testWatermarkUsesPageAnchoredHeaderImage(): void
+    {
+        $phpWord = new PhpWord();
+        $header = $phpWord->addSection()->addHeader();
+        $header->addWatermark(__DIR__ . '/../../../_files/images/earth.jpg', [
+            'width' => 100,
+            'height' => 80,
+            'marginLeft' => 12,
+            'marginTop' => 18,
+        ]);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        $doc->setDefaultFile('styles.xml');
+        $frame = '/office:document-styles/office:master-styles/style:master-page/style:header/text:p/draw:frame';
+
+        self::assertTrue($doc->elementExists($frame));
+        self::assertEquals('at-page', $doc->getElementAttribute($frame, 'text:anchor-type'));
+        self::assertEquals('0.3175cm', $doc->getElementAttribute($frame, 'svg:x'));
+        self::assertEquals('0.47625cm', $doc->getElementAttribute($frame, 'svg:y'));
+        self::assertEquals('Pictures/header1_image1.jpg', $doc->getElementAttribute($frame . '/draw:image', 'xlink:href'));
+    }
+}

--- a/tests/PhpWordTests/Writer/ODText/ElementTest.php
+++ b/tests/PhpWordTests/Writer/ODText/ElementTest.php
@@ -56,6 +56,23 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+    /**
+     * Test drawing elements are dispatched by the ODText container writer.
+     */
+    public function testDrawingElementsAreDispatched(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $section->addShape('rect', ['frame' => ['width' => 100, 'height' => 50]]);
+        $section->addTextBox(['width' => 100, 'height' => 50]);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+
+        $path = '/office:document-content/office:body/office:text/text:section';
+        self::assertTrue($doc->elementExists($path . '/draw:rect'));
+        self::assertTrue($doc->elementExists($path . '/draw:frame/draw:text-box'));
+    }
+
     // ODT Line Element not yet implemented
     // ODT Bookmark not yet implemented
     // ODT Table with style name not yet implemented (Word test defective)


### PR DESCRIPTION
## Description

PHPWord's ODText writer silently drops supported drawing features that already exist in the format-neutral model. This PR adds native ODF serialization for basic shapes, text boxes, and watermark images.

Fixes #2909

## Native ODF mapping

- Rectangles, ellipses, and polylines use native ODF drawing primitives and automatic graphic styles.
- Text boxes use draw:frame with nested draw:text-box content, preserving supported rich text, fill, border, and padding properties.
- Watermarks use page-anchored header drawing frames with preserved media, dimensions, and margins.
- Unsupported cross-format semantics remain documented instead of being approximated.

## Tests

- Added direct content.xml/styles.xml regression tests for shapes, text boxes, and watermarks.
- Ran focused ODText tests and the ODText suite.
- Ran PHP-CS-Fixer, PHPMD, and PHPStan.

## Checklist

- [x] Unit tests cover the new ODText behavior
- [x] Documentation and feature matrix updated
- [x] Full CI suite
