### PR TITLE
Writer ODText: support native footnotes and endnotes

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -11,6 +11,7 @@
 - Writer ODText: Support native form controls by [@potofcoffee](https://github.com/potofcoffee) fixing [#2925](https://github.com/PHPOffice/PHPWord/issues/2925) in [#2926](https://github.com/PHPOffice/PHPWord/pull/2926)
 - Writer ODText: Support native line drawings by [@potofcoffee](https://github.com/potofcoffee) fixing [#2907](https://github.com/PHPOffice/PHPWord/issues/2907) in [#2908](https://github.com/PHPOffice/PHPWord/pull/2908)
 - Writer ODText: Support native bookmarks by [@potofcoffee](https://github.com/potofcoffee) fixing [#2911](https://github.com/PHPOffice/PHPWord/issues/2911) in [#2912](https://github.com/PHPOffice/PHPWord/pull/2912)
+- Writer ODText: Support native footnotes and endnotes by [@potofcoffee](https://github.com/potofcoffee) fixing [#2913](https://github.com/PHPOffice/PHPWord/issues/2913) in [#2914](https://github.com/PHPOffice/PHPWord/pull/2914)
 
 ### Bug fixes
 

--- a/docs/usage/elements/note.md
+++ b/docs/usage/elements/note.md
@@ -1,6 +1,6 @@
 # Footnote & Endnote
 
-You can create footnotes with ``addFootnote`` and endnotes with``addEndnote`` in texts or textruns, but it's recommended to use textrun to have better layout. You can use ``addText``, ``addLink``,``addTextBreak``, ``addImage``, ``addOLEObject`` on footnotes and endnotes.
+You can create footnotes with ``addFootnote`` and endnotes with ``addEndnote`` in texts or textruns, but it's recommended to use textrun to have better layout. You can use ``addText``, ``addLink``, ``addTextBreak``, ``addImage``, ``addOLEObject`` on footnotes and endnotes. The ODText writer serializes both note types as native ODF notes.
 
 On textrun:
 

--- a/src/PhpWord/Writer/ODText/Element/Endnote.php
+++ b/src/PhpWord/Writer/ODText/Element/Endnote.php
@@ -5,7 +5,7 @@
  * word processing documents.
  *
  * PHPWord is free software distributed under the terms of the GNU Lesser
- * General Public License version 3 as published by the Free Software Foundation.
+ * General Public License as published by the Free Software Foundation.
  *
  * For the full copyright and license information, please read the LICENSE
  * file that was distributed with this source code. For the full list of
@@ -18,24 +18,22 @@
 
 namespace PhpOffice\PhpWord\Writer\ODText\Element;
 
-use PhpOffice\PhpWord\Writer\Word2007\Element\Container as Word2007Container;
-
 /**
- * Container element writer (section, textrun, header, footnote, cell, etc.).
- *
- * @since 0.11.0
+ * Endnote element writer.
  */
-class Container extends Word2007Container
+class Endnote extends Footnote
 {
     /**
-     * Namespace; Can't use __NAMESPACE__ in inherited class (ODText).
+     * ODF note class.
      *
      * @var string
      */
-    protected $namespace = 'PhpOffice\\PhpWord\\Writer\\ODText\\Element';
+    protected $noteClass = 'endnote';
 
     /**
-     * @var array<string>
+     * ODF note ID prefix.
+     *
+     * @var string
      */
-    protected $containerWithoutP = ['TextRun'];
+    protected $idPrefix = 'end';
 }

--- a/src/PhpWord/Writer/ODText/Element/Footnote.php
+++ b/src/PhpWord/Writer/ODText/Element/Footnote.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\ODText\Element;
+
+/**
+ * Footnote element writer.
+ */
+class Footnote extends AbstractElement
+{
+    /**
+     * ODF note class.
+     *
+     * @var string
+     */
+    protected $noteClass = 'footnote';
+
+    /**
+     * ODF note ID prefix.
+     *
+     * @var string
+     */
+    protected $idPrefix = 'ftn';
+
+    /**
+     * Write footnote element.
+     */
+    public function write(): void
+    {
+        $xmlWriter = $this->getXmlWriter();
+        $element = $this->getElement();
+        if (!$element instanceof \PhpOffice\PhpWord\Element\Footnote) {
+            return;
+        }
+
+        $number = $element->getRelationId() + 1;
+        if (!$this->withoutP) {
+            $xmlWriter->startElement('text:p');
+        }
+
+        $xmlWriter->startElement('text:note');
+        $xmlWriter->writeAttribute('text:note-class', $this->noteClass);
+        $xmlWriter->writeAttribute('text:id', $this->idPrefix . $number);
+
+        $xmlWriter->startElement('text:note-citation');
+        $xmlWriter->text((string) $number);
+        $xmlWriter->endElement();
+
+        $xmlWriter->startElement('text:note-body');
+        $containerWriter = new Container($xmlWriter, $element);
+        $containerWriter->write();
+        $xmlWriter->endElement();
+
+        $xmlWriter->endElement();
+
+        if (!$this->withoutP) {
+            $xmlWriter->endElement();
+        }
+    }
+}

--- a/tests/PhpWordTests/Writer/ODText/ElementTest.php
+++ b/tests/PhpWordTests/Writer/ODText/ElementTest.php
@@ -110,6 +110,58 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         self::assertEquals('nested_bookmark', $doc->getElementAttribute("($path)[3]", 'text:name'));
     }
 
+    /**
+     * Test footnote element.
+     */
+    public function testFootnoteElement(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $footnote = $section->addFootnote();
+        $footnote->addText('Footnote text.');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+
+        $path = '/office:document-content/office:body/office:text/text:section/text:p/text:note';
+        self::assertTrue($doc->elementExists($path));
+        self::assertEquals('footnote', $doc->getElementAttribute($path, 'text:note-class'));
+        self::assertEquals('ftn1', $doc->getElementAttribute($path, 'text:id'));
+        self::assertEquals('1', $doc->getElement($path . '/text:note-citation')->textContent);
+        self::assertEquals('Footnote text.', $doc->getElement($path . '/text:note-body/text:p')->textContent);
+    }
+
+    /**
+     * Test endnotes, multiple notes, and rich note content.
+     */
+    public function testEndnoteAndMultipleNotes(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $section->addFootnote()->addText('First footnote.');
+        $textRun = $section->addTextRun();
+        $footnote = $textRun->addFootnote();
+        $footnote->addText('Rich footnote with ');
+        $footnote->addLink('https://example.com', 'a link');
+        $endnote = $textRun->addEndnote();
+        $endnote->addText('Endnote text.');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+
+        $path = '/office:document-content/office:body/office:text/text:section//text:note';
+        self::assertTrue($doc->elementExists("($path)[3]"));
+        self::assertEquals('footnote', $doc->getElementAttribute("($path)[1]", 'text:note-class'));
+        self::assertEquals('ftn1', $doc->getElementAttribute("($path)[1]", 'text:id'));
+        self::assertEquals('1', $doc->getElement("($path)[1]/text:note-citation")->textContent);
+        self::assertEquals('footnote', $doc->getElementAttribute("($path)[2]", 'text:note-class'));
+        self::assertEquals('ftn2', $doc->getElementAttribute("($path)[2]", 'text:id'));
+        self::assertEquals('Rich footnote with', $doc->getElement("($path)[2]/text:note-body/text:p[1]")->textContent);
+        self::assertEquals('a link', $doc->getElement("($path)[2]/text:note-body/text:p[2]")->textContent);
+        self::assertEquals('endnote', $doc->getElementAttribute("($path)[3]", 'text:note-class'));
+        self::assertEquals('end1', $doc->getElementAttribute("($path)[3]", 'text:id'));
+        self::assertEquals('1', $doc->getElement("($path)[3]/text:note-citation")->textContent);
+        self::assertEquals('Endnote text.', $doc->getElement("($path)[3]/text:note-body/text:p")->textContent);
+    }
+
     // ODT Line Element not yet implemented
     // ODT Table with style name not yet implemented (Word test defective)
     // ODT Shape Elements not yet implemented


### PR DESCRIPTION
## Description

PHPWord's ODText writer silently drops footnote and endnote elements even though they are supported by the document model and Word2007 writer. This PR serializes both note types as native inline ODF notes.

Fixes #2913

## Native ODF mapping

- Footnotes use `text:note` with `text:note-class="footnote"`, an `ftnN` identifier, and a numeric citation.
- Endnotes use `text:note` with `text:note-class="endnote"`, an `endN` identifier, and a numeric citation.
- Note bodies reuse the ODText container writer and emit valid `text:p` children for supported content.
- No DOCX-style separate note parts are introduced.

## Tests

- Added direct `content.xml` regression coverage for footnotes and endnotes.
- Covered multiple notes, text-run placement, citations, IDs, and rich link content.
- Ran the focused ODText tests, the complete ODText suite, PHP-CS-Fixer, PHPMD, PHPStan, and `git diff --check`.

## Checklist

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code
- [x] I have updated the documentation
- [x] I have updated the changelog
