### PR TITLE
Writer ODText: support header and footer variants

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -4,6 +4,7 @@
 
 ## Enhancements
 - Add native ODF table-of-contents support to the ODText writer by [@potofcoffee](https://github.com/potofcoffee) fixing [#2917](https://github.com/PHPOffice/PHPWord/issues/2917) in [#2918](https://github.com/PHPOffice/PHPWord/pull/2918)
+- Add native ODF header and footer variants to the ODText writer by [@potofcoffee](https://github.com/potofcoffee) fixing [#2919](https://github.com/PHPOffice/PHPWord/issues/2919) in [#2920](https://github.com/PHPOffice/PHPWord/pull/2920)
 - Added support for image alt text by [@jwoodhead](https://github.com/jwoodhead) in [#2873](https://github.com/PHPOffice/PHPWord/pull/2873)
 - MPDF Writer : Make the mPDF temporary directory configurable via the `tempDir` PDF renderer option, defaulting to the system temporary directory by [@danielwirz](https://github.com/danielwirz) in [#2898](https://github.com/PHPOffice/PHPWord/pull/2898)
 - GD extension is now optional by [@andrew-demb](https://github.com/andrew-demb) fixing [#2789] in [#2902](https://github.com/PHPOffice/PHPWord/pull/2902)

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,8 +59,8 @@ Below are the supported features for each file formats.
 |                           | Object               | :material-check: |       |       |        |       |
 |                           | Watermark            | :material-check: | :material-check: |       |        |       |
 |                           | Table of Contents    | :material-check: | :material-check: |       |        |       |
-|                           | Header               | :material-check: |       |       |        |       |
-|                           | Footer               | :material-check: |       |       |        |       |
+|                           | Header               | :material-check: | :material-check: |       |        |       |
+|                           | Footer               | :material-check: | :material-check: |       |        |       |
 |                           | Footnote             | :material-check: |       |       | :material-check: |       |
 |                           | Endnote              | :material-check: |       |       | :material-check: |       |
 |                           | Comments             | :material-check: | :material-check: |       |        |       |

--- a/docs/usage/containers.md
+++ b/docs/usage/containers.md
@@ -103,6 +103,11 @@ You can pass an optional parameter to specify where the header/footer should be 
 -  ``Footer::FIRST`` each first page of the section
 -  ``Footer::EVEN`` each even page of the section. Will only be applied if the evenAndOddHeaders is set to true in phpWord->settings
 
+The ODText writer preserves these variants in the ODF master page: default
+containers use `style:header` or `style:footer`, first-page containers use
+`style:header-first` or `style:footer-first`, and even-page containers use
+`style:header-left` or `style:footer-left`.
+
 To change the evenAndOddHeaders use the ``getSettings`` method to return the Settings object, and then call the ``setEvenAndOddHeaders`` method:
 
 ``` php

--- a/src/PhpWord/Writer/ODText/Part/Styles.php
+++ b/src/PhpWord/Writer/ODText/Part/Styles.php
@@ -18,6 +18,7 @@
 
 namespace PhpOffice\PhpWord\Writer\ODText\Part;
 
+use PhpOffice\PhpWord\Element\Footer;
 use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\Shared\Converter;
 use PhpOffice\PhpWord\Shared\XMLWriter;
@@ -261,39 +262,38 @@ class Styles extends AbstractPart
             $xmlWriter->startElement('style:master-page');
             $xmlWriter->writeAttribute('style:name', "Standard$iplus1");
             $xmlWriter->writeAttribute('style:page-layout-name', "Mpm$iplus1");
-            // Multiple headers and footers probably not supported,
-            //   and, even if they are, I'm not sure how,
-            //   so quit after generating one.
             foreach ($sections[$i]->getHeaders() as $hdr) {
-                $xmlWriter->startElement('style:header');
-                foreach ($hdr->getElements() as $elem) {
-                    $cl1 = get_class($elem);
-                    $cl2 = str_replace('\\Element\\', '\\Writer\\ODText\\Element\\', $cl1);
-                    if (class_exists($cl2)) {
-                        $wtr = new $cl2($xmlWriter, $elem);
-                        $wtr->write();
-                    }
-                }
-                $xmlWriter->endElement(); // style:header
-
-                break;
+                $this->writeHeaderFooter($xmlWriter, $hdr, true);
             }
             foreach ($sections[$i]->getFooters() as $hdr) {
-                $xmlWriter->startElement('style:footer');
-                foreach ($hdr->getElements() as $elem) {
-                    $cl1 = get_class($elem);
-                    $cl2 = str_replace('\\Element\\', '\\Writer\\ODText\\Element\\', $cl1);
-                    if (class_exists($cl2)) {
-                        $wtr = new $cl2($xmlWriter, $elem);
-                        $wtr->write();
-                    }
-                }
-                $xmlWriter->endElement(); // style:footer
-
-                break;
+                $this->writeHeaderFooter($xmlWriter, $hdr, false);
             }
             $xmlWriter->endElement(); // style:master-page
         }
         $xmlWriter->endElement(); // office:master-styles
+    }
+
+    private function writeHeaderFooter(XMLWriter $xmlWriter, Footer $container, bool $header): void
+    {
+        $type = $container->getType();
+        $variants = [
+            'default' => $header ? 'style:header' : 'style:footer',
+            'first' => $header ? 'style:header-first' : 'style:footer-first',
+            'even' => $header ? 'style:header-left' : 'style:footer-left',
+        ];
+        $elementName = $variants[$type] ?? $variants['default'];
+
+        $xmlWriter->startElement($elementName);
+        foreach ($container->getElements() as $element) {
+            if (!$element instanceof \PhpOffice\PhpWord\Element\AbstractElement) {
+                continue;
+            }
+            $writerClass = str_replace('\\Element\\', '\\Writer\\ODText\\Element\\', get_class($element));
+            if (class_exists($writerClass)) {
+                $writer = new $writerClass($xmlWriter, $element);
+                $writer->write();
+            }
+        }
+        $xmlWriter->endElement();
     }
 }

--- a/tests/PhpWordTests/Writer/ODText/Style/SectionTest.php
+++ b/tests/PhpWordTests/Writer/ODText/Style/SectionTest.php
@@ -144,6 +144,56 @@ class SectionTest extends \PHPUnit\Framework\TestCase
         self::assertTrue($doc->elementExists($element));
     }
 
+    public function testHeaderFooterVariants(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+
+        $section->addHeader()->addText('Default header');
+        $section->addHeader(\PhpOffice\PhpWord\Element\Header::FIRST)->addText('First header');
+        $section->addHeader(\PhpOffice\PhpWord\Element\Header::EVEN)->addText('Even header');
+        $section->addFooter()->addText('Default footer');
+        $section->addFooter(\PhpOffice\PhpWord\Element\Footer::FIRST)->addText('First footer');
+        $section->addFooter(\PhpOffice\PhpWord\Element\Footer::EVEN)->addText('Even footer');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        $doc->setDefaultFile('styles.xml');
+        $master = '/office:document-styles/office:master-styles/style:master-page';
+
+        foreach ([
+            'style:header' => 'Default header',
+            'style:header-first' => 'First header',
+            'style:header-left' => 'Even header',
+            'style:footer' => 'Default footer',
+            'style:footer-first' => 'First footer',
+            'style:footer-left' => 'Even footer',
+        ] as $variant => $expected) {
+            $path = "$master/$variant/text:p";
+            self::assertTrue($doc->elementExists($path));
+            self::assertEquals($expected, $doc->getElement($path)->nodeValue);
+        }
+    }
+
+    public function testHeaderFooterVariantsAreWrittenForEachSection(): void
+    {
+        $phpWord = new PhpWord();
+        $firstSection = $phpWord->addSection();
+        $firstSection->addHeader(\PhpOffice\PhpWord\Element\Header::FIRST)->addText('First section header');
+        $secondSection = $phpWord->addSection();
+        $secondSection->addFooter(\PhpOffice\PhpWord\Element\Footer::EVEN)->addText('Second section footer');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        $doc->setDefaultFile('styles.xml');
+        $masters = '/office:document-styles/office:master-styles/style:master-page';
+
+        $firstHeader = "{$masters}[1]/style:header-first/text:p";
+        $secondFooter = "{$masters}[2]/style:footer-left/text:p";
+        self::assertTrue($doc->elementExists($firstHeader));
+        self::assertTrue($doc->elementExists($secondFooter));
+        self::assertEquals('First section header', $doc->getElement($firstHeader)->nodeValue);
+        self::assertEquals('Second section footer', $doc->getElement($secondFooter)->nodeValue);
+    }
+
     /**
      * Test HideErrors.
      */


### PR DESCRIPTION
### Description

Add native ODF serialization for PHPWord default, first-page, and even-page header and footer variants.

Fixes #2919

The ODText styles writer now maps default containers to `style:header` and `style:footer`, first-page containers to `style:header-first` and `style:footer-first`, and even-page containers to `style:header-left` and `style:footer-left`. All supported variants are emitted for every section master page while retaining the existing element writers.

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code
- [x] I have updated docs
- [x] I have updated changelog
