### PR TITLE
Writer ODText: support comments as native ODF annotations

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -6,6 +6,7 @@
 - Added support for image alt text by [@jwoodhead](https://github.com/jwoodhead) in [#2873](https://github.com/PHPOffice/PHPWord/pull/2873)
 - MPDF Writer : Make the mPDF temporary directory configurable via the `tempDir` PDF renderer option, defaulting to the system temporary directory by [@danielwirz](https://github.com/danielwirz) in [#2898](https://github.com/PHPOffice/PHPWord/pull/2898)
 - GD extension is now optional by [@andrew-demb](https://github.com/andrew-demb) fixing [#2789] in [#2902](https://github.com/PHPOffice/PHPWord/pull/2902)
+- Writer ODText: Serialize comments as native ODF annotations by [@potofcoffee](https://github.com/potofcoffee) fixing [#2921](https://github.com/PHPOffice/PHPWord/issues/2921) in [#2922](https://github.com/PHPOffice/PHPWord/pull/2922)
 
 ### Bug fixes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ Below are the supported features for each file formats.
 |                           | Footer               | :material-check: |       |       |        |       |
 |                           | Footnote             | :material-check: |       |       | :material-check: |       |
 |                           | Endnote              | :material-check: |       |       | :material-check: |       |
-|                           | Comments             | :material-check: |       |       |        |       |
+|                           | Comments             | :material-check: | :material-check: |       |        |       |
 | **Graphs**                | 2D basic graphs      | :material-check: |       |       |        |       |
 |                           | 2D advanced graphs   |        |       |       |        |       |
 |                           | 3D graphs            | :material-check: |       |       |        |       |

--- a/docs/usage/elements/comment.md
+++ b/docs/usage/elements/comment.md
@@ -22,3 +22,5 @@ $textrun->addText(' a test');
 ```
 
 If no end is set for a comment using the ``setCommentRangeEnd``, the comment will be ended automatically at the end of the element it is started on.
+
+The ODF writer serializes comments as native ODF annotations, including the author, date, formatted content, and comment range.

--- a/src/PhpWord/Writer/ODText/Element/AbstractElement.php
+++ b/src/PhpWord/Writer/ODText/Element/AbstractElement.php
@@ -18,6 +18,7 @@
 
 namespace PhpOffice\PhpWord\Writer\ODText\Element;
 
+use PhpOffice\PhpWord\Element\Comment;
 use PhpOffice\PhpWord\Writer\Word2007\Element\AbstractElement as Word2007AbstractElement;
 
 /**
@@ -27,6 +28,53 @@ use PhpOffice\PhpWord\Writer\Word2007\Element\AbstractElement as Word2007Abstrac
  */
 abstract class AbstractElement extends Word2007AbstractElement
 {
+    protected function writeCommentRangeStart(): void
+    {
+        if ($this->getElement()->getCommentsRangeStart() === null) {
+            return;
+        }
+
+        foreach ($this->getElement()->getCommentsRangeStart()->getItems() as $comment) {
+            $this->getXmlWriter()->startElement('office:annotation');
+            $this->getXmlWriter()->writeAttribute('office:name', $comment->getElementId());
+            $this->getXmlWriter()->writeElement('dc:creator', $comment->getAuthor());
+            if ($comment->getDate() !== null) {
+                $this->getXmlWriter()->writeElement('dc:date', $comment->getDate()->format('Y-m-d\\TH:i:s\\Z'));
+            }
+
+            $containerWriter = new Container($this->getXmlWriter(), $comment);
+            $containerWriter->write();
+            $this->getXmlWriter()->endElement();
+        }
+    }
+
+    protected function writeCommentRangeEnd(): void
+    {
+        $element = $this->getElement();
+        $comments = $element->getCommentsRangeEnd();
+        if ($comments !== null) {
+            foreach ($comments->getItems() as $comment) {
+                $this->writeCommentRangeEndElement($comment);
+            }
+        }
+
+        $comments = $element->getCommentsRangeStart();
+        if ($comments !== null) {
+            foreach ($comments->getItems() as $comment) {
+                if ($comment->getEndElement() === null) {
+                    $this->writeCommentRangeEndElement($comment);
+                }
+            }
+        }
+    }
+
+    private function writeCommentRangeEndElement(Comment $comment): void
+    {
+        $this->getXmlWriter()->startElement('office:annotation-end');
+        $this->getXmlWriter()->writeAttribute('office:name', $comment->getElementId());
+        $this->getXmlWriter()->endElement();
+    }
+
     protected function replaceTabs($text, $xmlWriter): void
     {
         if (preg_match('/^ +/', $text, $matches)) {

--- a/src/PhpWord/Writer/ODText/Element/Image.php
+++ b/src/PhpWord/Writer/ODText/Element/Image.php
@@ -51,6 +51,7 @@ class Image extends AbstractElement
             $xmlWriter->writeAttribute('text:style-name', 'IM' . $mediaIndex);
         }
 
+        $this->writeCommentRangeStart();
         $xmlWriter->startElement('draw:frame');
         $xmlWriter->writeAttribute('draw:style-name', 'fr' . $mediaIndex);
         $xmlWriter->writeAttributeIf($this->withoutP, 'draw:text-style-name', 'IM' . $mediaIndex);
@@ -68,6 +69,7 @@ class Image extends AbstractElement
         $xmlWriter->endElement(); // draw:image
 
         $xmlWriter->endElement(); // draw:frame
+        $this->writeCommentRangeEnd();
 
         if (!$this->withoutP) {
             $xmlWriter->endElement(); // text:p

--- a/src/PhpWord/Writer/ODText/Element/Link.php
+++ b/src/PhpWord/Writer/ODText/Element/Link.php
@@ -40,11 +40,13 @@ class Link extends AbstractElement
             $xmlWriter->startElement('text:p'); // text:p
         }
 
+        $this->writeCommentRangeStart();
         $xmlWriter->startElement('text:a');
         $xmlWriter->writeAttribute('xlink:type', 'simple');
         $xmlWriter->writeAttribute('xlink:href', ($element->isInternal() ? '#' : '') . $element->getSource());
         $this->writeText($element->getText());
         $xmlWriter->endElement(); // text:a
+        $this->writeCommentRangeEnd();
 
         if (!$this->withoutP) {
             $xmlWriter->endElement(); // text:p

--- a/src/PhpWord/Writer/ODText/Element/Ruby.php
+++ b/src/PhpWord/Writer/ODText/Element/Ruby.php
@@ -52,10 +52,12 @@ class Ruby extends AbstractElement
             }
         }
 
+        $this->writeCommentRangeStart();
         $this->replaceTabs($element->getBaseTextRun()->getText(), $xmlWriter);
         $this->writeText(' (');
         $this->replaceTabs($element->getRubyTextRun()->getText(), $xmlWriter);
         $this->writeText(')');
+        $this->writeCommentRangeEnd();
 
         if (!$this->withoutP) {
             $xmlWriter->endElement(); // text:p

--- a/src/PhpWord/Writer/ODText/Element/Text.php
+++ b/src/PhpWord/Writer/ODText/Element/Text.php
@@ -53,6 +53,7 @@ class Text extends AbstractElement
         if (!$this->withoutP) {
             $xmlWriter->startElement('text:p'); // text:p
         }
+        $this->writeCommentRangeStart();
         if ($element->getTrackChange() != null && $element->getTrackChange()->getChangeType() == TrackChange::DELETED) {
             $xmlWriter->startElement('text:change');
             $xmlWriter->writeAttribute('text:change-id', $element->getTrackChange()->getElementId());
@@ -84,6 +85,7 @@ class Text extends AbstractElement
                 $xmlWriter->endElement();
             }
         }
+        $this->writeCommentRangeEnd();
         if (!$this->withoutP) {
             $xmlWriter->endElement(); // text:p
         }

--- a/src/PhpWord/Writer/ODText/Element/TextRun.php
+++ b/src/PhpWord/Writer/ODText/Element/TextRun.php
@@ -40,10 +40,12 @@ class TextRun extends Text
             $pStyle = 'Normal';
         }
         $xmlWriter->writeAttribute('text:style-name', $pStyle);
+        $this->writeCommentRangeStart();
 
         $containerWriter = new Container($xmlWriter, $element);
         $containerWriter->write();
 
+        $this->writeCommentRangeEnd();
         $xmlWriter->endElement();
     }
 }

--- a/src/PhpWord/Writer/ODText/Element/Title.php
+++ b/src/PhpWord/Writer/ODText/Element/Title.php
@@ -53,6 +53,7 @@ class Title extends AbstractElement
         } else {
             $xmlWriter->writeAttribute('text:style-name', 'Title');
         }
+        $this->writeCommentRangeStart();
         $text = $element->getText();
         if (is_string($text)) {
             $this->writeText($text);
@@ -61,6 +62,7 @@ class Title extends AbstractElement
             $containerWriter = new Container($xmlWriter, $text);
             $containerWriter->write();
         }
+        $this->writeCommentRangeEnd();
         $xmlWriter->endElement(); // text:span
         $xmlWriter->endElement(); // text:h
     }

--- a/tests/PhpWordTests/Writer/ODText/ElementTest.php
+++ b/tests/PhpWordTests/Writer/ODText/ElementTest.php
@@ -66,7 +66,6 @@ class ElementTest extends \PHPUnit\Framework\TestCase
     // ODT Macro Button not yet implemented
     // ODT Form Field not yet implemented
     // ODT SDT not yet implemented
-    // ODT Comment not yet implemented
     // ODT Track Changes implemented, possibly not correctly
     // ODT List Item not yet implemented
 
@@ -92,6 +91,140 @@ class ElementTest extends \PHPUnit\Framework\TestCase
         $element = "$p2t/text:p[3]/text:a";
         self::assertTrue($doc->elementExists($element));
         self::assertEquals("#$intlink", $doc->getElementAttribute($element, 'xlink:href'));
+    }
+
+    /**
+     * Test comments as native ODF annotations.
+     */
+    public function testCommentElement(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $comment = new \PhpOffice\PhpWord\Element\Comment('Ada', new DateTime('2024-01-02 03:04:05 UTC'), 'AD');
+        $comment->addText('Review this', ['bold' => true]);
+        $phpWord->addComment($comment);
+        $text = $section->addText('This text');
+        $text->setCommentRangeStart($comment);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        $path = '/office:document-content/office:body/office:text/text:section/text:p[2]';
+        $annotation = $path . '/office:annotation';
+
+        self::assertTrue($doc->elementExists($annotation));
+        self::assertSame($comment->getElementId(), $doc->getElementAttribute($annotation, 'office:name'));
+        self::assertSame('Ada', $doc->getElement($annotation . '/dc:creator')->nodeValue);
+        self::assertSame('2024-01-02T03:04:05Z', $doc->getElement($annotation . '/dc:date')->nodeValue);
+        self::assertSame('Review this', $doc->getElement($annotation . '/text:p/text:span')->nodeValue);
+        self::assertTrue($doc->elementExists($path . '/office:annotation-end'));
+        self::assertSame($comment->getElementId(), $doc->getElementAttribute($path . '/office:annotation-end', 'office:name'));
+    }
+
+    /**
+     * Test explicit comment ranges and multiple comments on one element.
+     */
+    public function testCommentRangesAndMultipleComments(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $comment = new \PhpOffice\PhpWord\Element\Comment('Ada');
+        $comment->addText('Across two runs');
+        $secondComment = new \PhpOffice\PhpWord\Element\Comment('Grace');
+        $secondComment->addText('Only the first run');
+        $phpWord->addComment($comment);
+        $phpWord->addComment($secondComment);
+        $run = $section->addTextRun();
+        $first = $run->addText('First');
+        $last = $run->addText(' last');
+        $first->setCommentRangeStart($comment);
+        $first->setCommentRangeStart($secondComment);
+        $last->setCommentRangeEnd($comment);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        $path = '/office:document-content/office:body/office:text/text:section/text:p[2]';
+        $annotations = $path . '/office:annotation';
+        self::assertTrue($doc->elementExists($annotations . '[1]'));
+        self::assertTrue($doc->elementExists($annotations . '[2]'));
+        self::assertSame($comment->getElementId(), $doc->getElementAttribute($annotations . '[1]', 'office:name'));
+        self::assertSame($secondComment->getElementId(), $doc->getElementAttribute($annotations . '[2]', 'office:name'));
+        self::assertSame($secondComment->getElementId(), $doc->getElementAttribute($path . '/office:annotation-end[1]', 'office:name'));
+        self::assertSame($comment->getElementId(), $doc->getElementAttribute($path . '/office:annotation-end[2]', 'office:name'));
+    }
+
+    /**
+     * Test comments on image elements.
+     */
+    public function testCommentOnImageElement(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $comment = new \PhpOffice\PhpWord\Element\Comment('Ada');
+        $phpWord->addComment($comment);
+        $image = $section->addImage(__DIR__ . '/../../_files/images/earth.jpg');
+        $image->setCommentRangeStart($comment);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        $path = '/office:document-content/office:body/office:text/text:section/text:p[2]';
+        self::assertSame($comment->getElementId(), $doc->getElementAttribute($path . '/office:annotation', 'office:name'));
+        self::assertSame($comment->getElementId(), $doc->getElementAttribute($path . '/office:annotation-end', 'office:name'));
+    }
+
+    /**
+     * Test comments on link elements.
+     */
+    public function testCommentOnLinkElement(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $comment = new \PhpOffice\PhpWord\Element\Comment('Ada');
+        $phpWord->addComment($comment);
+        $link = $section->addLink('https://example.com', 'Example');
+        $link->setCommentRangeStart($comment);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        $path = '/office:document-content/office:body/office:text/text:section/text:p[2]';
+        self::assertSame($comment->getElementId(), $doc->getElementAttribute($path . '/office:annotation', 'office:name'));
+        self::assertSame($comment->getElementId(), $doc->getElementAttribute($path . '/office:annotation-end', 'office:name'));
+    }
+
+    /**
+     * Test comments on ruby elements.
+     */
+    public function testCommentOnRubyElement(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $comment = new \PhpOffice\PhpWord\Element\Comment('Ada');
+        $phpWord->addComment($comment);
+        $baseTextRun = new TextRun(null);
+        $baseTextRun->addText('私');
+        $rubyTextRun = new TextRun(null);
+        $rubyTextRun->addText('わたし');
+        $ruby = $section->addRuby($baseTextRun, $rubyTextRun, new RubyProperties());
+        $ruby->setCommentRangeStart($comment);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        $path = '/office:document-content/office:body/office:text/text:section/text:p[2]';
+        self::assertSame($comment->getElementId(), $doc->getElementAttribute($path . '/office:annotation', 'office:name'));
+        self::assertSame($comment->getElementId(), $doc->getElementAttribute($path . '/office:annotation-end', 'office:name'));
+    }
+
+    /**
+     * Test comments on title elements.
+     */
+    public function testCommentOnTitleElement(): void
+    {
+        $phpWord = new PhpWord();
+        $phpWord->addTitleStyle(1, []);
+        $section = $phpWord->addSection();
+        $comment = new \PhpOffice\PhpWord\Element\Comment('Ada');
+        $phpWord->addComment($comment);
+        $title = $section->addTitle('Commented title', 1);
+        $title->setCommentRangeStart($comment);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        $path = '/office:document-content/office:body/office:text/text:section/text:h[1]/text:span';
+        self::assertSame($comment->getElementId(), $doc->getElementAttribute($path . '/office:annotation', 'office:name'));
+        self::assertSame($comment->getElementId(), $doc->getElementAttribute($path . '/office:annotation-end', 'office:name'));
     }
 
     /**


### PR DESCRIPTION
### Description

Serialize PHPWord comments in ODText output as native ODF annotations. Comment authors, dates, rich text, point ranges, explicit ranges, and multiple comments are preserved inline with office:annotation and office:annotation-end elements.

Fixes #2921

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md) to reference this pull request