### PR TITLE
Writer ODText: support native form controls

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -8,6 +8,7 @@
 - GD extension is now optional by [@andrew-demb](https://github.com/andrew-demb) fixing [#2789] in [#2902](https://github.com/PHPOffice/PHPWord/pull/2902)
 - Writer ODText: Serialize comments as native ODF annotations by [@potofcoffee](https://github.com/potofcoffee) fixing [#2921](https://github.com/PHPOffice/PHPWord/issues/2921) in [#2922](https://github.com/PHPOffice/PHPWord/pull/2922)
 - Writer ODText: Support native shapes, text boxes, and watermarks by [@potofcoffee](https://github.com/potofcoffee) fixing [#2909](https://github.com/PHPOffice/PHPWord/issues/2909) in [#2910](https://github.com/PHPOffice/PHPWord/pull/2910)
+- Writer ODText: Support native form controls by [@potofcoffee](https://github.com/potofcoffee) fixing [#2925](https://github.com/PHPOffice/PHPWord/issues/2925) in [#2926](https://github.com/PHPOffice/PHPWord/pull/2926)
 
 ### Bug fixes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,7 @@ Below are the supported features for each file formats.
 |                           | Footnote             | :material-check: |       |       | :material-check: |       |
 |                           | Endnote              | :material-check: |       |       | :material-check: |       |
 |                           | Comments             | :material-check: | :material-check: |       |        |       |
+|                           | Form fields          | :material-check: | :material-check: |       |        |       |
 | **Graphs**                | 2D basic graphs      | :material-check: |       |       |        |       |
 |                           | 2D advanced graphs   |        |       |       |        |       |
 |                           | 3D graphs            | :material-check: |       |       |        |       |

--- a/docs/usage/elements/checkbox.md
+++ b/docs/usage/elements/checkbox.md
@@ -12,3 +12,6 @@ $section->addCheckBox($name, $text, [$fontStyle], [$paragraphStyle]);
 - ``$text``. Text to be displayed in the document.
 - ``$fontStyle``. See [`Styles > Font`](../styles/font.md).
 - ``$paragraphStyle``. See [`Styles > Paragraph`](../styles/paragraph.md).
+
+When written with the `ODText` writer, the checkbox is represented by a native
+ODF form control and retains its name and visible label.

--- a/docs/usage/elements/formfield.md
+++ b/docs/usage/elements/formfield.md
@@ -1,0 +1,17 @@
+# Form fields
+
+Form fields can be added to sections or table cells with `addFormField`.
+
+```php
+$section->addFormField('textinput')
+    ->setName('name')
+    ->setDefault('Default value');
+
+$section->addFormField('dropdown')
+    ->setName('color')
+    ->setEntries(['Red', 'Blue']);
+```
+
+The supported types are `textinput`, `checkbox`, and `dropdown`. The `ODText`
+writer serializes them as native ODF form controls and preserves their names,
+values, and dropdown entries.

--- a/docs/usage/elements/index.md
+++ b/docs/usage/elements/index.md
@@ -20,10 +20,11 @@ Below are the matrix of element availability in each container. The column shows
 | 14    | [Footnote](note.md) | :white_check_mark: | :red_circle: | :red_circle: | :material-check-decagram: | :material-check-decagram: | :red_circle: |
 | 15    | [Endnote](note.md) | :white_check_mark: | :red_circle: | :red_circle: | :material-check-decagram: | :material-check-decagram: | :red_circle: |
 | 16    | [CheckBox](checkbox.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :red_circle: |
-| 17    | [TextBox](textbox.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :red_circle: | :red_circle: |
-| 18    | [Field](field.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| 19    | [Line](line.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| 20    | [Chart](chart.md) | :white_check_mark: | | | :white_check_mark: | | |
+| 17    | [Form fields](formfield.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :red_circle: |
+| 18    | [TextBox](textbox.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :red_circle: | :red_circle: |
+| 19    | [Field](field.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| 20    | [Line](line.md) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| 21    | [Chart](chart.md) | :white_check_mark: | | | :white_check_mark: | | |
 
 Legend:
 

--- a/src/PhpWord/Writer/ODText/Element/CheckBox.php
+++ b/src/PhpWord/Writer/ODText/Element/CheckBox.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * document files.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\ODText\Element;
+
+use PhpOffice\PhpWord\Element\CheckBox as CheckBoxElement;
+
+/**
+ * CheckBox element writer.
+ */
+class CheckBox extends Control
+{
+    public function write(): void
+    {
+        $element = $this->getElement();
+        if (!$element instanceof CheckBoxElement) {
+            return;
+        }
+        $xmlWriter = $this->getXmlWriter();
+        if (!$this->withoutP) {
+            $xmlWriter->startElement('text:p');
+            $xmlWriter->writeAttribute('text:style-name', $element->getParagraphStyle() ?: 'Normal');
+        }
+        $this->writeControlText($element, $element->getText());
+        $this->writeControlAnchor('control-' . $element->getElementId(), $element->getName(), $element->getText(), $element->getFontStyle());
+        if (!$this->withoutP) {
+            $xmlWriter->endElement();
+        }
+    }
+}

--- a/src/PhpWord/Writer/ODText/Element/Control.php
+++ b/src/PhpWord/Writer/ODText/Element/Control.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * document files.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\ODText\Element;
+
+use PhpOffice\PhpWord\Element\Text;
+
+/**
+ * Base writer for inline ODF form controls.
+ */
+abstract class Control extends AbstractElement
+{
+    /**
+     * @param mixed $fontStyle
+     */
+    protected function writeControlAnchor(string $id, ?string $name, ?string $text, $fontStyle = null): void
+    {
+        $xmlWriter = $this->getXmlWriter();
+        $xmlWriter->startElement('draw:control');
+        $xmlWriter->writeAttribute('draw:control', $id);
+        $xmlWriter->writeAttribute('draw:name', $name ?: $id);
+        if ($fontStyle && is_string($fontStyle)) {
+            $xmlWriter->writeAttribute('draw:text-style-name', $fontStyle);
+        }
+        $xmlWriter->endElement();
+    }
+
+    protected function writeControlText(Text $element, ?string $text): void
+    {
+        if ($text === null || $text === '') {
+            return;
+        }
+        $xmlWriter = $this->getXmlWriter();
+        $fontStyle = $element->getFontStyle();
+        if ($fontStyle) {
+            $xmlWriter->startElement('text:span');
+            if (is_string($fontStyle)) {
+                $xmlWriter->writeAttribute('text:style-name', $fontStyle);
+            }
+        }
+        $this->replaceTabs($text, $xmlWriter);
+        if ($fontStyle) {
+            $xmlWriter->endElement();
+        }
+    }
+}

--- a/src/PhpWord/Writer/ODText/Element/FormField.php
+++ b/src/PhpWord/Writer/ODText/Element/FormField.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * document files.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\ODText\Element;
+
+use PhpOffice\PhpWord\Element\FormField as FormFieldElement;
+
+/**
+ * FormField element writer.
+ */
+class FormField extends Control
+{
+    public function write(): void
+    {
+        $element = $this->getElement();
+        if (!$element instanceof FormFieldElement) {
+            return;
+        }
+        $xmlWriter = $this->getXmlWriter();
+        if (!$this->withoutP) {
+            $xmlWriter->startElement('text:p');
+            $xmlWriter->writeAttribute('text:style-name', $element->getParagraphStyle() ?: 'Normal');
+        }
+        $text = null;
+        if ($element->getType() === 'textinput') {
+            $text = $element->getValue() ?? $element->getDefault();
+        } elseif ($element->getType() === 'dropdown' && $element->getEntries()) {
+            $index = $element->getValue() ?? $element->getDefault();
+            $text = $element->getEntries()[(int) $index] ?? null;
+        }
+        $this->writeControlText($element, $text === null ? null : (string) $text);
+        $this->writeControlAnchor('control-' . $element->getElementId(), $element->getName(), $text === null ? null : (string) $text, $element->getFontStyle());
+        if (!$this->withoutP) {
+            $xmlWriter->endElement();
+        }
+    }
+}

--- a/src/PhpWord/Writer/ODText/Part/Content.php
+++ b/src/PhpWord/Writer/ODText/Part/Content.php
@@ -20,7 +20,9 @@ namespace PhpOffice\PhpWord\Writer\ODText\Part;
 
 use PhpOffice\PhpWord\Element\AbstractContainer;
 use PhpOffice\PhpWord\Element\Cell as CellElement;
+use PhpOffice\PhpWord\Element\CheckBox;
 use PhpOffice\PhpWord\Element\Field;
+use PhpOffice\PhpWord\Element\FormField;
 use PhpOffice\PhpWord\Element\Image;
 use PhpOffice\PhpWord\Element\Row as RowElement;
 use PhpOffice\PhpWord\Element\Shape;
@@ -85,6 +87,12 @@ class Content extends AbstractPart
         // Body
         $xmlWriter->startElement('office:body');
         $xmlWriter->startElement('office:text');
+
+        $formControls = [];
+        foreach ($phpWord->getSections() as $section) {
+            $this->collectFormControls($section, $formControls);
+        }
+        $this->writeForms($xmlWriter, $formControls);
 
         // Tracked changes declarations
         $trackedChanges = [];
@@ -518,5 +526,102 @@ class Content extends AbstractPart
                 $this->collectTrackedChanges($element, $trackedChanges);
             }
         }
+    }
+
+    /**
+     * Collect form controls from the document containers.
+     *
+     * @param array<int, CheckBox|FormField> $controls
+     */
+    private function collectFormControls(AbstractContainer $container, array &$controls): void
+    {
+        foreach ($container->getElements() as $element) {
+            if ($element instanceof CheckBox || $element instanceof FormField) {
+                if (!$element->getElementId()) {
+                    $element->setElementId();
+                }
+                $controls[] = $element;
+            }
+            if ($element instanceof AbstractContainer) {
+                $this->collectFormControls($element, $controls);
+            }
+        }
+    }
+
+    /**
+     * Write the document-level form controls referenced by draw:control.
+     *
+     * @param array<int, CheckBox|FormField> $controls
+     */
+    private function writeForms(XMLWriter $xmlWriter, array $controls): void
+    {
+        if ($controls === []) {
+            return;
+        }
+
+        $xmlWriter->startElement('office:forms');
+        $xmlWriter->startElement('form:form');
+        $xmlWriter->writeAttribute('form:name', 'Standard');
+
+        foreach ($controls as $control) {
+            $id = 'control-' . $control->getElementId();
+            $name = $control->getName();
+            $name = $name ?: (($control instanceof CheckBox ? 'checkbox' : $control->getType()) . $id);
+
+            if ($control instanceof CheckBox) {
+                $xmlWriter->startElement('form:checkbox');
+                $xmlWriter->writeAttribute('xml:id', $id);
+                $xmlWriter->writeAttribute('form:name', $name);
+                $xmlWriter->writeAttribute('form:label', (string) $control->getText());
+                $xmlWriter->writeAttribute('form:current-state', 'unchecked');
+                $xmlWriter->endElement();
+
+                continue;
+            }
+
+            switch ($control->getType()) {
+                case 'textinput':
+                    $xmlWriter->startElement('form:text');
+                    $xmlWriter->writeAttribute('xml:id', $id);
+                    $xmlWriter->writeAttribute('form:name', $name);
+                    if ($control->getDefault() !== null) {
+                        $xmlWriter->writeAttribute('form:value', (string) $control->getDefault());
+                    }
+                    if ($control->getValue() !== null) {
+                        $xmlWriter->writeAttribute('form:current-value', (string) $control->getValue());
+                    }
+                    $xmlWriter->endElement();
+
+                    break;
+                case 'checkbox':
+                    $xmlWriter->startElement('form:checkbox');
+                    $xmlWriter->writeAttribute('xml:id', $id);
+                    $xmlWriter->writeAttribute('form:name', $name);
+                    $state = $control->getValue() ?? $control->getDefault();
+                    $xmlWriter->writeAttribute('form:current-state', $state ? 'checked' : 'unchecked');
+                    $xmlWriter->endElement();
+
+                    break;
+                case 'dropdown':
+                    $xmlWriter->startElement('form:listbox');
+                    $xmlWriter->writeAttribute('xml:id', $id);
+                    $xmlWriter->writeAttribute('form:name', $name);
+                    $selected = $control->getValue() ?? $control->getDefault();
+                    foreach ($control->getEntries() as $index => $entry) {
+                        $xmlWriter->startElement('form:option');
+                        $xmlWriter->writeAttribute('form:label', (string) $entry);
+                        $xmlWriter->writeAttribute('form:value', (string) $entry);
+                        $xmlWriter->writeAttributeIf((int) $selected === (int) $index, 'form:current-selected', 'true');
+                        $xmlWriter->text((string) $entry);
+                        $xmlWriter->endElement();
+                    }
+                    $xmlWriter->endElement();
+
+                    break;
+            }
+        }
+
+        $xmlWriter->endElement(); // form:form
+        $xmlWriter->endElement(); // office:forms
     }
 }

--- a/tests/PhpWordTests/Writer/ODText/Element/FormControlsTest.php
+++ b/tests/PhpWordTests/Writer/ODText/Element/FormControlsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * document files.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+/**
+ * This file is part of PHPWord - A pure PHP library to read and write documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser General Public License.
+ */
+
+namespace PhpOffice\PhpWordTests\Writer\ODText\Element;
+
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWordTests\TestHelperDOCX;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for ODText form controls.
+ */
+class FormControlsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        TestHelperDOCX::clear();
+    }
+
+    public function testWritesNativeFormControlsAndAnchors(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+
+        $checkBox = $section->addCheckBox('accept', 'Accept');
+        $textInput = $section->addFormField('textinput')->setName('name')->setDefault('Default')->setValue('Alice');
+        $dropdown = $section->addFormField('dropdown')->setName('color')->setEntries(['Red', 'Blue'])->setDefault(0)->setValue(1);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'ODText');
+        $form = '/office:document-content/office:body/office:text/office:forms/form:form';
+
+        self::assertTrue($doc->elementExists($form));
+        self::assertSame('accept', $doc->getElementAttribute($form . '/form:checkbox', 'form:name'));
+        self::assertSame('unchecked', $doc->getElementAttribute($form . '/form:checkbox', 'form:current-state'));
+        self::assertSame('Accept', $doc->getElementAttribute($form . '/form:checkbox', 'form:label'));
+        self::assertSame('Alice', $doc->getElementAttribute($form . '/form:text', 'form:current-value'));
+        self::assertSame('Default', $doc->getElementAttribute($form . '/form:text', 'form:value'));
+        self::assertSame('Blue', $doc->getElement($form . '/form:listbox/form:option[2]')->textContent);
+        self::assertSame('true', $doc->getElementAttribute($form . '/form:listbox/form:option[2]', 'form:current-selected'));
+        self::assertTrue($doc->elementExists('/office:document-content/office:body/office:text/text:section/text:p[2]/draw:control[@draw:control="control-' . $checkBox->getElementId() . '"]'));
+        self::assertTrue($doc->elementExists('/office:document-content/office:body/office:text/text:section/text:p[3]/draw:control[@draw:control="control-' . $textInput->getElementId() . '"]'));
+        self::assertTrue($doc->elementExists('/office:document-content/office:body/office:text/text:section/text:p[4]/draw:control[@draw:control="control-' . $dropdown->getElementId() . '"]'));
+    }
+}


### PR DESCRIPTION
### Description

The ODText writer now serializes PHPWord CheckBox and FormField elements as native ODF form controls. It emits document-level office:forms declarations and inline draw:control anchors for text input, checkbox, and dropdown controls.

The implementation uses standard ODF form:text, form:checkbox, form:listbox, and form:option elements, preserving names, values, labels, and dropdown selections.

Fixes #2925

### Verification

- Focused ODText tests pass (67 tests, 628 assertions).
- PHPStan, PHP Mess Detector, PHP CS Fixer, and git diff --check pass.
- Documentation and the 1.x changelog were updated.

### Checklist

- [x] I have run the relevant test suite.
- [x] I have run the code style and static analysis checks.
- [x] I have added or updated documentation.
- [x] I have added a changelog entry.