### PR TITLE
Writer WPS: basic support of Microsoft Works documents

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -9,6 +9,7 @@
 - Writer ODText: Serialize comments as native ODF annotations by [@potofcoffee](https://github.com/potofcoffee) fixing [#2921](https://github.com/PHPOffice/PHPWord/issues/2921) in [#2922](https://github.com/PHPOffice/PHPWord/pull/2922)
 - Writer ODText: Support native shapes, text boxes, and watermarks by [@potofcoffee](https://github.com/potofcoffee) fixing [#2909](https://github.com/PHPOffice/PHPWord/issues/2909) in [#2910](https://github.com/PHPOffice/PHPWord/pull/2910)
 - Writer ODText: Support native form controls by [@potofcoffee](https://github.com/potofcoffee) fixing [#2925](https://github.com/PHPOffice/PHPWord/issues/2925) in [#2926](https://github.com/PHPOffice/PHPWord/pull/2926)
+- Writer WPS: Basic support of the Microsoft Works word processor documents by [@businessarshgoyal](https://github.com/businessarshgoyal) fixing [#69](https://github.com/PHPOffice/PHPWord/issues/69)
 
 ### Bug fixes
 

--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -9,7 +9,7 @@
 - Writer ODText: Serialize comments as native ODF annotations by [@potofcoffee](https://github.com/potofcoffee) fixing [#2921](https://github.com/PHPOffice/PHPWord/issues/2921) in [#2922](https://github.com/PHPOffice/PHPWord/pull/2922)
 - Writer ODText: Support native shapes, text boxes, and watermarks by [@potofcoffee](https://github.com/potofcoffee) fixing [#2909](https://github.com/PHPOffice/PHPWord/issues/2909) in [#2910](https://github.com/PHPOffice/PHPWord/pull/2910)
 - Writer ODText: Support native form controls by [@potofcoffee](https://github.com/potofcoffee) fixing [#2925](https://github.com/PHPOffice/PHPWord/issues/2925) in [#2926](https://github.com/PHPOffice/PHPWord/pull/2926)
-- Writer WPS: Basic support of the Microsoft Works word processor documents by [@businessarshgoyal](https://github.com/businessarshgoyal) fixing [#69](https://github.com/PHPOffice/PHPWord/issues/69)
+- Writer WPS: Basic support of the Microsoft Works word processor documents by [@businessarshgoyal](https://github.com/businessarshgoyal) fixing [#69](https://github.com/PHPOffice/PHPWord/issues/69) in [#2929](https://github.com/PHPOffice/PHPWord/pull/2929)
 
 ### Bug fixes
 

--- a/docs/usage/writers.md
+++ b/docs/usage/writers.md
@@ -151,3 +151,22 @@ $writer = IOFactory::createWriter($oPhpWord, 'Word2007');
 $writer->setZipAdapter(new PclZipAdapter());
 $writer->save(__DIR__ . '/sample.docx');
 ```
+
+## WPS
+The name of the writer is `WPS`. It writes documents for the word processor of
+Microsoft Works 7 and 8, ie an OLE compound file whose `CONTENTS` stream holds
+the chunks (`CHNKWKS`) of the document.
+
+``` php
+<?php
+
+$writer = IOFactory::createWriter($oPhpWord, 'WPS');
+$writer->save(__DIR__ . '/sample.wps');
+```
+
+The writer outputs the text of the document, one paragraph per element, and the
+page breaks. The text of the cells of a table is written as consecutive
+paragraphs. The following features are not supported yet: character and
+paragraph styles, tables and lists structure, images, objects, headers,
+footers, footnotes, endnotes, comments, table of contents, document properties
+and form fields. The elements which are not supported are ignored.

--- a/src/PhpWord/IOFactory.php
+++ b/src/PhpWord/IOFactory.php
@@ -36,7 +36,7 @@ abstract class IOFactory
      */
     public static function createWriter(PhpWord $phpWord, $name = 'Word2007')
     {
-        if ($name !== 'WriterInterface' && !in_array($name, ['ODText', 'RTF', 'Word2007', 'HTML', 'PDF', 'EPub3'], true)) {
+        if ($name !== 'WriterInterface' && !in_array($name, ['ODText', 'RTF', 'Word2007', 'HTML', 'PDF', 'EPub3', 'WPS'], true)) {
             throw new Exception("\"{$name}\" is not a valid writer.");
         }
 

--- a/src/PhpWord/Shared/OLEWrite.php
+++ b/src/PhpWord/Shared/OLEWrite.php
@@ -1,0 +1,325 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Shared;
+
+use PhpOffice\PhpWord\Exception\Exception;
+
+/**
+ * OLE compound document writer.
+ *
+ * Builds a version 3 compound file (512 bytes sectors) from a set of named
+ * streams. It is the counterpart of OLERead, used by the writers of the
+ * binary Microsoft formats.
+ *
+ * @see https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cfb
+ * @since 1.5.0
+ */
+class OLEWrite
+{
+    /** Size of a sector, in bytes. */
+    const SECTOR_SIZE = 512;
+
+    /** Size of a mini sector, in bytes. */
+    const MINI_SECTOR_SIZE = 64;
+
+    /** Streams smaller than this size are stored in the mini stream. */
+    const MINI_STREAM_CUTOFF = 4096;
+
+    /** Number of sector numbers stored in a sector of the FAT. */
+    const FAT_ENTRIES_PER_SECTOR = 128;
+
+    /** Number of FAT sector numbers stored in the header. */
+    const HEADER_DIFAT_ENTRIES = 109;
+
+    /** Maximum length of a stream name, in characters. */
+    const MAX_NAME_LENGTH = 31;
+
+    const FREESECT = 0xFFFFFFFF;
+
+    const ENDOFCHAIN = 0xFFFFFFFE;
+
+    const FATSECT = 0xFFFFFFFD;
+
+    const NOSTREAM = 0xFFFFFFFF;
+
+    const TYPE_STREAM = 2;
+
+    const TYPE_ROOT = 5;
+
+    /**
+     * Streams, name => content.
+     *
+     * @var array<string, string>
+     */
+    private $streams = [];
+
+    /**
+     * Add a stream to the document.
+     */
+    public function addStream(string $name, string $content): self
+    {
+        if ($name === '' || strlen($name) > self::MAX_NAME_LENGTH) {
+            throw new Exception("Invalid OLE stream name: {$name}.");
+        }
+        $this->streams[$name] = $content;
+
+        return $this;
+    }
+
+    /**
+     * Get the binary content of the compound document.
+     */
+    public function write(): string
+    {
+        $names = array_keys($this->streams);
+        usort($names, [self::class, 'compareNames']);
+
+        [$miniStream, $miniFat, $miniStarts] = $this->buildMiniStream($names);
+
+        $numDirectorySectors = (int) ceil((count($names) + 1) / 4);
+        $numMiniFatSectors = (int) ceil(count($miniFat) / self::FAT_ENTRIES_PER_SECTOR);
+        $numMiniStreamSectors = (int) ceil(strlen($miniStream) / self::SECTOR_SIZE);
+
+        // Sectors are allocated in writing order: directory, mini FAT, mini
+        // stream, streams stored outside of the mini stream, then the FAT.
+        $sector = $numDirectorySectors + $numMiniFatSectors + $numMiniStreamSectors;
+        $starts = $miniStarts;
+        $lengths = [];
+        foreach ($names as $name) {
+            $length = strlen($this->streams[$name]);
+            $lengths[$name] = $length;
+            if ($length >= self::MINI_STREAM_CUTOFF) {
+                $starts[$name] = $sector;
+                $sector += (int) ceil($length / self::SECTOR_SIZE);
+            }
+        }
+
+        $numFatSectors = 0;
+        while ($numFatSectors * self::FAT_ENTRIES_PER_SECTOR < $sector + $numFatSectors) {
+            ++$numFatSectors;
+        }
+        if ($numFatSectors > self::HEADER_DIFAT_ENTRIES) {
+            throw new Exception('OLE document too large to be written.');
+        }
+
+        $fat = array_fill(0, $numFatSectors * self::FAT_ENTRIES_PER_SECTOR, self::FREESECT);
+        $this->addChain($fat, 0, $numDirectorySectors);
+        $this->addChain($fat, $numDirectorySectors, $numMiniFatSectors);
+        $this->addChain($fat, $numDirectorySectors + $numMiniFatSectors, $numMiniStreamSectors);
+        foreach ($names as $name) {
+            if ($lengths[$name] >= self::MINI_STREAM_CUTOFF) {
+                $this->addChain($fat, $starts[$name], (int) ceil($lengths[$name] / self::SECTOR_SIZE));
+            }
+        }
+        for ($i = 0; $i < $numFatSectors; ++$i) {
+            $fat[$sector + $i] = self::FATSECT;
+        }
+
+        $content = $this->writeHeader($numFatSectors, $numMiniFatSectors, $numDirectorySectors, $sector);
+        $content .= $this->writeDirectory($names, $starts, $lengths, $numDirectorySectors, $numMiniFatSectors, $numMiniStreamSectors, strlen($miniStream));
+        $content .= $this->writeFat($miniFat, $numMiniFatSectors);
+        $content .= $this->pad($miniStream, self::SECTOR_SIZE);
+        foreach ($names as $name) {
+            if ($lengths[$name] >= self::MINI_STREAM_CUTOFF) {
+                $content .= $this->pad($this->streams[$name], self::SECTOR_SIZE);
+            }
+        }
+        $content .= $this->writeFat($fat, $numFatSectors);
+
+        return $content;
+    }
+
+    /**
+     * Compare two stream names, using the compound file ordering.
+     */
+    private static function compareNames(string $nameA, string $nameB): int
+    {
+        if (strlen($nameA) !== strlen($nameB)) {
+            return strlen($nameA) < strlen($nameB) ? -1 : 1;
+        }
+
+        return strcmp(strtoupper($nameA), strtoupper($nameB));
+    }
+
+    /**
+     * Build the mini stream, its allocation table and the start of each stream in it.
+     *
+     * @param string[] $names
+     *
+     * @return array{0: string, 1: int[], 2: array<string, int>}
+     */
+    private function buildMiniStream(array $names): array
+    {
+        $miniStream = '';
+        $miniFat = [];
+        $starts = [];
+        foreach ($names as $name) {
+            $content = $this->streams[$name];
+            if (strlen($content) >= self::MINI_STREAM_CUTOFF) {
+                continue;
+            }
+            if ($content === '') {
+                $starts[$name] = self::ENDOFCHAIN;
+
+                continue;
+            }
+            $starts[$name] = count($miniFat);
+            $miniStream .= $this->pad($content, self::MINI_SECTOR_SIZE);
+            $this->addChain($miniFat, $starts[$name], (int) ceil(strlen($content) / self::MINI_SECTOR_SIZE));
+        }
+
+        return [$miniStream, $miniFat, $starts];
+    }
+
+    /**
+     * Add a chain of consecutive sectors to an allocation table.
+     *
+     * @param int[] $table
+     */
+    private function addChain(array &$table, int $start, int $count): void
+    {
+        for ($i = 0; $i < $count; ++$i) {
+            $table[$start + $i] = ($i === $count - 1) ? self::ENDOFCHAIN : $start + $i + 1;
+        }
+    }
+
+    /**
+     * Write the header of the compound document.
+     */
+    private function writeHeader(int $numFatSectors, int $numMiniFatSectors, int $numDirectorySectors, int $firstFatSector): string
+    {
+        $header = "\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1";
+        $header .= str_repeat("\x00", 16); // CLSID
+        $header .= pack('vvv', 0x3E, 0x03, 0xFFFE); // minor version, major version, byte order
+        $header .= pack('vv', 9, 6); // sector shift, mini sector shift
+        $header .= str_repeat("\x00", 6); // reserved
+        $header .= pack('V', 0); // number of directory sectors, unused in version 3
+        $header .= pack('V', $numFatSectors);
+        $header .= pack('V', 0); // first directory sector
+        $header .= pack('V', 0); // transaction signature
+        $header .= pack('V', self::MINI_STREAM_CUTOFF);
+        $header .= pack('V', $numMiniFatSectors > 0 ? $numDirectorySectors : self::ENDOFCHAIN);
+        $header .= pack('V', $numMiniFatSectors);
+        $header .= pack('V', self::ENDOFCHAIN); // first DIFAT sector
+        $header .= pack('V', 0); // number of DIFAT sectors
+
+        for ($i = 0; $i < self::HEADER_DIFAT_ENTRIES; ++$i) {
+            $header .= pack('V', $i < $numFatSectors ? $firstFatSector + $i : self::FREESECT);
+        }
+
+        return $header;
+    }
+
+    /**
+     * Write the directory sectors.
+     *
+     * @param string[] $names
+     * @param array<string, int> $starts
+     * @param array<string, int> $lengths
+     */
+    private function writeDirectory(array $names, array $starts, array $lengths, int $numDirectorySectors, int $numMiniFatSectors, int $numMiniStreamSectors, int $miniStreamSize): string
+    {
+        $nodes = [];
+        $rootChild = $this->buildTree(0, count($names) - 1, $nodes);
+        // The mini stream is stored right after the mini FAT.
+        $rootStart = $numMiniStreamSectors > 0 ? $numDirectorySectors + $numMiniFatSectors : self::ENDOFCHAIN;
+
+        $directory = $this->writeDirectoryEntry('Root Entry', self::TYPE_ROOT, self::NOSTREAM, self::NOSTREAM, $rootChild, $rootStart, $miniStreamSize);
+        foreach ($names as $index => $name) {
+            $directory .= $this->writeDirectoryEntry(
+                $name,
+                self::TYPE_STREAM,
+                $nodes[$index]['left'],
+                $nodes[$index]['right'],
+                self::NOSTREAM,
+                $starts[$name],
+                $lengths[$name]
+            );
+        }
+
+        return $this->pad($directory, self::SECTOR_SIZE);
+    }
+
+    /**
+     * Write a directory entry.
+     */
+    private function writeDirectoryEntry(string $name, int $type, int $left, int $right, int $child, int $start, int $size): string
+    {
+        $utf16Name = (string) mb_convert_encoding($name, 'UTF-16LE', 'UTF-8');
+
+        $entry = str_pad($utf16Name . "\x00\x00", 64, "\x00");
+        $entry .= pack('v', strlen($utf16Name) + 2);
+        $entry .= pack('CC', $type, 1); // object type, black node
+        $entry .= pack('VVV', $left, $right, $child);
+        $entry .= str_repeat("\x00", 16); // CLSID
+        $entry .= pack('V', 0); // state bits
+        $entry .= str_repeat("\x00", 16); // creation and modification times
+        $entry .= pack('V', $start);
+        $entry .= pack('VV', $size, 0);
+
+        return $entry;
+    }
+
+    /**
+     * Build the tree of the directory entries and return the directory index of its root.
+     *
+     * The entries being sorted, a balanced tree is built by taking the middle
+     * entry of each range as its root.
+     *
+     * @param array<int, array{left: int, right: int}> $nodes
+     */
+    private function buildTree(int $first, int $last, array &$nodes): int
+    {
+        if ($first > $last) {
+            return self::NOSTREAM;
+        }
+
+        $root = intdiv($first + $last, 2);
+        $nodes[$root] = [
+            'left' => $this->buildTree($first, $root - 1, $nodes),
+            'right' => $this->buildTree($root + 1, $last, $nodes),
+        ];
+
+        // Directory entries are numbered after the root entry of the document.
+        return $root + 1;
+    }
+
+    /**
+     * Write an allocation table.
+     *
+     * @param int[] $table
+     */
+    private function writeFat(array $table, int $numSectors): string
+    {
+        $content = '';
+        foreach ($table as $entry) {
+            $content .= pack('V', $entry);
+        }
+
+        return str_pad($content, $numSectors * self::SECTOR_SIZE, "\xff\xff\xff\xff");
+    }
+
+    /**
+     * Pad a content to a multiple of the given size.
+     */
+    private function pad(string $content, int $size): string
+    {
+        return str_pad($content, (int) ceil(strlen($content) / $size) * $size, "\x00");
+    }
+}

--- a/src/PhpWord/Writer/WPS.php
+++ b/src/PhpWord/Writer/WPS.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer;
+
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Shared\OLEWrite;
+
+/**
+ * WPS writer, Microsoft Works word processor.
+ *
+ * The document is an OLE compound file whose CONTENTS stream holds the
+ * chunked (CHNKWKS) representation of the document.
+ *
+ * @since 1.5.0
+ */
+class WPS extends AbstractWriter implements WriterInterface
+{
+    /**
+     * Create new instance.
+     */
+    public function __construct(?PhpWord $phpWord = null)
+    {
+        $this->setPhpWord($phpWord);
+
+        $this->parts = ['Contents'];
+        foreach ($this->parts as $partName) {
+            $partClass = static::class . '\\Part\\' . $partName;
+            if (class_exists($partClass)) {
+                /** @var WPS\Part\AbstractPart $part */
+                $part = new $partClass();
+                $part->setParentWriter($this);
+                $this->writerParts[strtolower($partName)] = $part;
+            }
+        }
+    }
+
+    /**
+     * Save content to file.
+     */
+    public function save(string $filename): void
+    {
+        $ole = new OLEWrite();
+        $ole->addStream('CONTENTS', $this->getWriterPart('Contents')->write());
+
+        $this->writeFile($this->openFile($filename), $ole->write());
+    }
+}

--- a/src/PhpWord/Writer/WPS/Part/AbstractPart.php
+++ b/src/PhpWord/Writer/WPS/Part/AbstractPart.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\WPS\Part;
+
+use PhpOffice\PhpWord\Writer\AbstractWriter;
+use PhpOffice\PhpWord\Writer\WriterPartInterface;
+
+/**
+ * Abstract class for WPS parts.
+ *
+ * @since 1.5.0
+ */
+abstract class AbstractPart implements WriterPartInterface
+{
+    /**
+     * Parent writer.
+     *
+     * @var AbstractWriter
+     */
+    protected $parentWriter;
+
+    /**
+     * Set parent writer.
+     */
+    public function setParentWriter(AbstractWriter $writer): void
+    {
+        $this->parentWriter = $writer;
+    }
+
+    /**
+     * Get parent writer.
+     */
+    public function getParentWriter(): AbstractWriter
+    {
+        return $this->parentWriter;
+    }
+
+    /**
+     * Write part content.
+     */
+    abstract public function write(): string;
+
+    /**
+     * Convert a text to the UTF-16LE encoding used by the WPS format.
+     */
+    protected function encodeText(string $text): string
+    {
+        return (string) mb_convert_encoding($text, 'UTF-16LE', 'UTF-8');
+    }
+}

--- a/src/PhpWord/Writer/WPS/Part/Contents.php
+++ b/src/PhpWord/Writer/WPS/Part/Contents.php
@@ -1,0 +1,220 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWord\Writer\WPS\Part;
+
+use PhpOffice\PhpWord\Element\AbstractContainer;
+use PhpOffice\PhpWord\Element\AbstractElement;
+use PhpOffice\PhpWord\Element\Link;
+use PhpOffice\PhpWord\Element\ListItem;
+use PhpOffice\PhpWord\Element\PageBreak;
+use PhpOffice\PhpWord\Element\Table;
+use PhpOffice\PhpWord\Element\Text;
+use PhpOffice\PhpWord\Element\TextBreak;
+use PhpOffice\PhpWord\Element\Title;
+
+/**
+ * WPS CONTENTS part writer.
+ *
+ * The stream is a list of chunks, each of them described by an entry of the
+ * index which follows the header of the stream.
+ *
+ * @since 1.5.0
+ */
+class Contents extends AbstractPart
+{
+    /** Magic of the Microsoft Works 7/8 word processor documents. */
+    const MAGIC = "CHNKWKS\x00";
+
+    /** Size of the stream header, including the header of the index. */
+    const HEADER_SIZE = 0x20;
+
+    /** Size of an entry of the index. */
+    const ENTRY_SIZE = 0x18;
+
+    /** End of paragraph. */
+    const PARAGRAPH_END = "\x0d";
+
+    /** Page break. */
+    const PAGE_BREAK = "\x0c";
+
+    /**
+     * Write the CONTENTS stream.
+     */
+    public function write(): string
+    {
+        $phpWord = $this->getParentWriter()->getPhpWord();
+
+        $text = '';
+        foreach ($phpWord->getSections() as $section) {
+            $text .= $this->writeContainer($section);
+        }
+
+        return $this->writeChunks([
+            'TEXT' => $this->encodeText($text),
+            'FONT' => $this->writeFontNames([$phpWord->getDefaultFontName()]),
+        ]);
+    }
+
+    /**
+     * Write the header, the index and the data of the chunks.
+     *
+     * @param array<string, string> $chunks Chunk name and content pairs
+     */
+    private function writeChunks(array $chunks): string
+    {
+        $offset = self::HEADER_SIZE + count($chunks) * self::ENTRY_SIZE;
+
+        $index = '';
+        $data = '';
+        $id = 0;
+        foreach ($chunks as $name => $content) {
+            $index .= pack('v', self::ENTRY_SIZE);
+            $index .= $name; // name of the chunk
+            $index .= pack('vvv', $id++, 0, 0);
+            $index .= $name; // type of the chunk
+            $index .= pack('VV', $offset + strlen($data), strlen($content));
+            $data .= $content;
+        }
+
+        $header = self::MAGIC;
+        $header .= pack('vvv', 0, 0, count($chunks)); // unknown, unknown, number of chunks
+        $header .= str_repeat("\x00", 10); // unknown
+        $header .= pack('vv', 0, count($chunks)); // unknown, number of chunks of this index
+        $header .= pack('V', 0xFFFFFFFF); // offset of the next index, none
+
+        return $header . $index . $data;
+    }
+
+    /**
+     * Write the table of the font names.
+     *
+     * @param string[] $fonts
+     */
+    private function writeFontNames(array $fonts): string
+    {
+        $names = '';
+        foreach ($fonts as $font) {
+            $names .= pack('v', mb_strlen($font));
+            $names .= $this->encodeText($font);
+            $names .= str_repeat("\x00", 4); // unknown
+        }
+
+        $offsets = str_repeat(pack('V', 0), count($fonts));
+
+        return pack('V', strlen($offsets) + strlen($names)) // size of the chunk, without this header
+            . pack('V', count($fonts))
+            . str_repeat("\x00", 12) // unknown
+            . $offsets
+            . $names;
+    }
+
+    /**
+     * Write the paragraphs of a container.
+     */
+    private function writeContainer(AbstractContainer $container): string
+    {
+        $text = '';
+        foreach ($container->getElements() as $element) {
+            if ($element instanceof PageBreak) {
+                $text .= self::PAGE_BREAK;
+            } elseif ($element instanceof TextBreak) {
+                $text .= self::PARAGRAPH_END;
+            } elseif ($element instanceof Table) {
+                $text .= $this->writeTable($element);
+            } elseif ($element instanceof AbstractContainer) {
+                $text .= $this->writeParagraph($this->writeInline($element));
+            } else {
+                $text .= $this->writeParagraph($this->getElementText($element));
+            }
+        }
+
+        return $text;
+    }
+
+    /**
+     * Write the paragraphs of the cells of a table.
+     */
+    private function writeTable(Table $table): string
+    {
+        $text = '';
+        foreach ($table->getRows() as $row) {
+            foreach ($row->getCells() as $cell) {
+                $text .= $this->writeContainer($cell);
+            }
+        }
+
+        return $text;
+    }
+
+    /**
+     * Write a paragraph, ie its text followed by an end of paragraph.
+     */
+    private function writeParagraph(string $text): string
+    {
+        if ($text === '') {
+            return '';
+        }
+
+        return $text . self::PARAGRAPH_END;
+    }
+
+    /**
+     * Get the text of the elements of a container, without paragraph separator.
+     */
+    private function writeInline(AbstractContainer $container): string
+    {
+        $text = '';
+        foreach ($container->getElements() as $element) {
+            if ($element instanceof AbstractContainer) {
+                $text .= $this->writeInline($element);
+            } else {
+                $text .= $this->getElementText($element);
+            }
+        }
+
+        return $text;
+    }
+
+    /**
+     * Get the text of an element, empty for the unsupported ones.
+     */
+    private function getElementText(AbstractElement $element): string
+    {
+        if ($element instanceof Text || $element instanceof ListItem) {
+            $text = $element->getText();
+        } elseif ($element instanceof Link) {
+            $text = $element->getText() !== '' ? $element->getText() : $element->getSource();
+        } elseif ($element instanceof Title) {
+            $title = $element->getText();
+            $text = $title instanceof AbstractContainer ? $this->writeInline($title) : $title;
+        } else {
+            $text = '';
+        }
+
+        return $this->sanitizeText((string) $text);
+    }
+
+    /**
+     * Replace the characters which delimit the paragraphs by spaces.
+     */
+    private function sanitizeText(string $text): string
+    {
+        return str_replace(["\r\n", "\r", "\n", self::PAGE_BREAK], ' ', $text);
+    }
+}

--- a/tests/PhpWordTests/Writer/WPSTest.php
+++ b/tests/PhpWordTests/Writer/WPSTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * This file is part of PHPWord - A pure PHP library for reading and writing
+ * word processing documents.
+ *
+ * PHPWord is free software distributed under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software Foundation.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/PHPOffice/PHPWord/contributors.
+ *
+ * @see         https://github.com/PHPOffice/PHPWord
+ *
+ * @license     http://www.gnu.org/licenses/lgpl.txt LGPL version 3
+ */
+
+namespace PhpOffice\PhpWordTests\Writer;
+
+use PhpOffice\PhpWord\Exception\Exception;
+use PhpOffice\PhpWord\IOFactory;
+use PhpOffice\PhpWord\PhpWord;
+use PhpOffice\PhpWord\Shared\OLERead;
+use PhpOffice\PhpWord\Writer\WPS;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for PhpOffice\PhpWord\Writer\WPS.
+ */
+class WPSTest extends TestCase
+{
+    /** @var string */
+    private $file;
+
+    protected function setUp(): void
+    {
+        $this->file = (string) tempnam(sys_get_temp_dir(), 'PhpWord');
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->file)) {
+            unlink($this->file);
+        }
+    }
+
+    public function testConstruct(): void
+    {
+        $object = new WPS(new PhpWord());
+
+        self::assertInstanceOf(PhpWord::class, $object->getPhpWord());
+    }
+
+    public function testConstructWithNull(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No PhpWord assigned.');
+        $object = new WPS();
+        $object->getPhpWord();
+    }
+
+    public function testCreateWriter(): void
+    {
+        self::assertInstanceOf(WPS::class, IOFactory::createWriter(new PhpWord(), 'WPS'));
+    }
+
+    public function testSaveWritesAnOleDocument(): void
+    {
+        $phpWord = new PhpWord();
+        $phpWord->addSection()->addText('Hello');
+
+        (new WPS($phpWord))->save($this->file);
+
+        self::assertStringStartsWith("\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1", (string) file_get_contents($this->file));
+        self::assertStringStartsWith('CHNKWKS', $this->getContentsStream($this->file));
+    }
+
+    public function testSaveWritesTheTextOfTheElements(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $section->addTitle('Title', 1);
+        $section->addText('Text with accents : éàü');
+        $textRun = $section->addTextRun();
+        $textRun->addText('Text ');
+        $textRun->addText('run');
+        $section->addTextBreak();
+        $section->addLink('https://github.com/PHPOffice/PHPWord', 'Link');
+        $section->addListItem('List item');
+        $section->addPageBreak();
+        $table = $section->addTable();
+        $table->addRow();
+        $table->addCell()->addText('Cell');
+
+        (new WPS($phpWord))->save($this->file);
+
+        self::assertSame(
+            "Title\rText with accents : éàü\rText run\r\rLink\rList item\r\x0cCell\r",
+            $this->getText($this->file)
+        );
+    }
+
+    public function testSaveIgnoresTheUnsupportedElements(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $section->addImage(__DIR__ . '/../_files/images/PhpWord.png');
+        $section->addText('Text');
+
+        (new WPS($phpWord))->save($this->file);
+
+        self::assertSame("Text\r", $this->getText($this->file));
+    }
+
+    public function testSaveWritesTheDefaultFontName(): void
+    {
+        $phpWord = new PhpWord();
+        $phpWord->setDefaultFontName('Verdana');
+        $phpWord->addSection()->addText('Text');
+
+        (new WPS($phpWord))->save($this->file);
+
+        self::assertStringContainsString(
+            (string) mb_convert_encoding('Verdana', 'UTF-16LE', 'UTF-8'),
+            $this->getChunk($this->file, 'FONT')
+        );
+    }
+
+    /**
+     * Get the CONTENTS stream of a WPS file.
+     */
+    private function getContentsStream(string $filename): string
+    {
+        $ole = new OLERead();
+        $ole->read($filename);
+
+        foreach ($ole->props as $index => $property) {
+            if ($property['name'] === 'CONTENTS') {
+                return substr((string) $ole->getStream($index), 0, $property['size']);
+            }
+        }
+
+        self::fail('The file does not contain a CONTENTS stream.');
+    }
+
+    /**
+     * Get the content of a chunk of the CONTENTS stream of a WPS file.
+     */
+    private function getChunk(string $filename, string $name): string
+    {
+        $contents = $this->getContentsStream($filename);
+
+        $numChunks = (int) (unpack('v', $contents, 0x0c)[1] ?? 0);
+        for ($index = 0; $index < $numChunks; ++$index) {
+            $entry = 0x20 + $index * 0x18;
+            if (substr($contents, $entry + 2, 4) === $name) {
+                $chunk = (array) unpack('Voffset/Vsize', $contents, $entry + 0x10);
+
+                return substr($contents, (int) $chunk['offset'], (int) $chunk['size']);
+            }
+        }
+
+        self::fail("The CONTENTS stream does not contain a {$name} chunk.");
+    }
+
+    /**
+     * Get the text of a WPS file.
+     */
+    private function getText(string $filename): string
+    {
+        return (string) mb_convert_encoding($this->getChunk($filename, 'TEXT'), 'UTF-8', 'UTF-16LE');
+    }
+}


### PR DESCRIPTION
### Description

Adds a `WPS` writer producing documents for the word processor of Microsoft Works 7 and 8, ie an OLE compound file whose `CONTENTS` stream holds the `CHNKWKS` chunks of the document, as described by the format notes linked in the issue and implemented by [libwps](https://github.com/fosnola/libwps) (`WPS8Parser`).

```php
$writer = IOFactory::createWriter($phpWord, 'WPS');
$writer->save(__DIR__ . '/sample.wps');
```

What is added:

- `Shared\OLEWrite`: a small compound file (CFB v3, 512 bytes sectors) writer, counterpart of the existing `Shared\OLERead`, building the FAT, the mini FAT, the mini stream and the red-black directory from a set of named streams. No new dependency.
- `Writer\WPS` and `Writer\WPS\Part\Contents`, following the structure of the `RTF` writer: the part writes the stream header, the chunk index and the `TEXT` and `FONT` chunks; the text is UTF-16LE, paragraphs are terminated by `\r` and page breaks by `\f`.
- Registration of `WPS` in `IOFactory::createWriter()`.

First iteration scope, as suggested in the issue: text and basic paragraph output. Text, text runs, titles, links, list items, text breaks, page breaks and the text of the cells of a table are written as paragraphs. **Not supported yet** (silently ignored, no error): character and paragraph styles, table and list structure, images, objects, headers, footers, footnotes, endnotes, comments, table of contents, document properties, form fields, and reading `.wps` files.

#### About #2769

I looked at #2769 first and did not build on it: it writes a ZIP package of ODF-like XML parts (`content.xml`, `styles.xml`, `META-INF/manifest.xml`), which is not the Microsoft Works binary format the issue asks for — such a file is not an OLE document and is not recognised by Works or by libwps-based readers (LibreOffice). This PR writes the `CONTENTS`/`CHNKWKS` stream instead, so the two approaches do not share code.

#### Validation

Besides the unit tests, the generated files were checked against the reference implementation, `wps2text` (libwps 0.4.12), which extracts the expected text, and against `olefile`/`file(1)`, which validate the compound file structure.

Fixes #69

/claim #69

### Checklist:

- [x] My CI is :green_circle:
- [x] I have covered by unit tests my new code (check build/coverage for coverage report)
- [x] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [x] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
