### PR TITLE
Fix HTML strikethrough tags and decimal percentage table widths

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -14,6 +14,7 @@
 
 - Set writeAttribute return type by [@radarhere](https://github.com/radarhere) fixing [#2204](https://github.com/PHPOffice/PHPWord/issues/2204) in [#2776](https://github.com/PHPOffice/PHPWord/pull/2776)
 - Fix "Using null as an array offset" deprecation in Style::getStyle() on PHP 8.5 by [@pwsdotru](https://github.com/pwsdotru) & [@slayerfx](https://github.com/slayerfx) fixing [#2863](https://github.com/PHPOffice/PHPWord/issues/2863) in [#2892](https://github.com/PHPOffice/PHPWord/pull/2892)
+- Html: Map `<s>`, `<strike>` and `<del>` tags to strikethrough and fix decimal percentage table/cell widths (e.g. `49.85%`) being truncated by [@aswinkumar863](https://github.com/aswinkumar863) in [#2930](https://github.com/PHPOffice/PHPWord/pull/2930)
 
 ### Miscellaneous
 

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -226,6 +226,9 @@ class Html
             'u' => ['Property',    null,   null,       $styles,    null,   'underline',    'single'],
             'sup' => ['Property',    null,   null,       $styles,    null,   'superScript',  true],
             'sub' => ['Property',    null,   null,       $styles,    null,   'subScript',    true],
+            's' => ['Property',    null,   null,       $styles,    null,   'strikethrough', true],
+            'strike' => ['Property', null,   null,       $styles,    null,   'strikethrough', true],
+            'del' => ['Property',    null,   null,       $styles,    null,   'strikethrough', true],
             'span' => ['Span',        $node,  null,       $styles,    null,   null,           null],
             'font' => ['Span',        $node,  null,       $styles,    null,   null,           null],
             'table' => ['Table',       $node,  $element,   $styles,    null,   null,           null],
@@ -872,8 +875,8 @@ class Html
                     if (preg_match('/([0-9]+[a-z]+)/', $value, $matches)) {
                         $styles['width'] = Converter::cssToTwip($matches[1]);
                         $styles['unit'] = \PhpOffice\PhpWord\SimpleType\TblWidth::TWIP;
-                    } elseif (preg_match('/([0-9]+)%/', $value, $matches)) {
-                        $styles['width'] = $matches[1] * 50;
+                    } elseif (preg_match('/([0-9]*\.?[0-9]+)%/', $value, $matches)) {
+                        $styles['width'] = (int) round((float) $matches[1] * 50);
                         $styles['unit'] = \PhpOffice\PhpWord\SimpleType\TblWidth::PERCENT;
                     } elseif (preg_match('/([0-9]+)/', $value, $matches)) {
                         $styles['width'] = $matches[1];

--- a/tests/PhpWordTests/Shared/HtmlTest.php
+++ b/tests/PhpWordTests/Shared/HtmlTest.php
@@ -234,6 +234,31 @@ class HtmlTest extends AbstractWebServerEmbedded
     }
 
     /**
+     * Test strikethrough tags.
+     *
+     * @dataProvider providerParseStrikethroughTags
+     */
+    public function testParseStrikethroughTags(string $tag): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        Html::addHtml($section, "<{$tag}>test</{$tag}>");
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        self::assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:rPr/w:strike'));
+        self::assertEquals('1', $doc->getElementAttribute('/w:document/w:body/w:p/w:r/w:rPr/w:strike', 'w:val'));
+    }
+
+    public static function providerParseStrikethroughTags(): array
+    {
+        return [
+            ['s'],
+            ['strike'],
+            ['del'],
+        ];
+    }
+
+    /**
      * Test width.
      *
      * @dataProvider providerParseWidth
@@ -250,6 +275,24 @@ class HtmlTest extends AbstractWebServerEmbedded
         self::assertTrue($doc->elementExists($xpath));
         self::assertEquals($docxSize, $doc->getElement($xpath)->getAttribute('w:w'));
         self::assertEquals($docxUnit, $doc->getElement($xpath)->getAttribute('w:type'));
+    }
+
+    /**
+     * The CSS `width` percentage regex had no decimal point, so a value like "49.85%" matched
+     * only the digits immediately before the "%" (here "85"), silently truncating it to 85%.
+     */
+    public function testParseDecimalPercentageWidth(): void
+    {
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        Html::addHtml($section, '<table style="width: 49.85%;"><tr><td>A</td></tr></table>');
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+        $xpath = '/w:document/w:body/w:tbl/w:tblPr/w:tblW';
+        self::assertTrue($doc->elementExists($xpath));
+        // 49.85% = round(49.85 * 50) = 2493 fiftieths-of-a-percent
+        self::assertEquals(2493, $doc->getElement($xpath)->getAttribute('w:w'));
+        self::assertEquals(TblWidth::PERCENT, $doc->getElement($xpath)->getAttribute('w:type'));
     }
 
     /**


### PR DESCRIPTION
## Summary
Two small, unrelated parsing bugs in `Html.php`, bundled together since each is a
one-line fix on its own:

- `<s>`, `<strike>` and `<del>` were not mapped to strikethrough. The parser only
  recognized strikethrough via CSS `text-decoration: line-through`, not any of the
  three semantically-strikethrough tags - so strikethrough text produced by rich
  text editors (e.g. TinyMCE emits `<s>`) silently rendered as plain text.
- The CSS `width` percentage regex `/([0-9]+)%/` had no decimal point, so a value
  like `49.85%` matched only the digits immediately before the `%` (`"85"`),
  silently turning it into 85% instead of ~50%. This affects any table/cell using
  a non-integer percentage width - which is common when widths are computed
  programmatically (e.g. `width.toFixed(2) + '%'`).

## Test plan
- [x] Added `testParseStrikethroughTags` (data provider over `s`/`strike`/`del`)
      and `testParseDecimalPercentageWidth` to `HtmlTest.php`
- [x] `composer test-no-coverage` - full suite passes (1132 tests)
- [x] `composer phpstan` - clean
- [x] `composer phpmd` - clean
- [x] PHP CS Fixer - no violations
- [x] Manually generated a `.docx` exercising both fixes and visually confirmed
      correct rendering in Word